### PR TITLE
Using preferred encoding to decode multibyte text in ListView.

### DIFF
--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -27,6 +27,7 @@ from __future__ import print_function
 import time
 import ctypes
 import warnings
+import locale
 
 from .. import six
 from .. import win32functions
@@ -468,7 +469,7 @@ class ListViewWrapper(HwndWrapper.HwndWrapper):
             self.LVITEM         = win32structures.LVITEMW
             self.LVM_GETCOLUMN  = win32defines.LVM_GETCOLUMNA
             self.LVM_GETITEM    = win32defines.LVM_GETITEMA            
-            self.text_decode    = lambda v: v.decode('utf-8')
+            self.text_decode    = lambda v: v.decode(locale.getpreferredencoding())
 
     #-----------------------------------------------------------
     def ColumnCount(self):


### PR DESCRIPTION
This patch fix text encoding in ListView in multibyte applications.
locale.getpreferredencoding() method return encoding which correspond to the settings "Language for non-unicode programs" in Windows Control Panel.
It seems that there are other places where 'utf-8' endoding is hardcoded and should be fixed.