### PR TITLE
Doc strings fixes

### DIFF
--- a/doc_src/HISTORY.TXT
+++ b/doc_src/HISTORY.TXT
@@ -3,7 +3,7 @@ Change Log
 ==========
 
 0.5.3 Better Unicode support for SetEditText/TypeKeys and menu items
-------------------------------------------------------------------
+--------------------------------------------------------------------
 25-September-2015
  * Better backward compatibility with pywinauto 0.4.2:
 

--- a/doc_src/code/pywinauto.application.txt
+++ b/doc_src/code/pywinauto.application.txt
@@ -1,27 +1,7 @@
-pywinauto.application
----------------------
+pywinauto.application module
+----------------------------
 
- .. automodule:: pywinauto.application
-
-    .. autoclass:: pywinauto.application.Application
-        :undoc-members:
-        :show-inheritance:
-        :members: __getattr__, __getitem__, active_, connect_, kill_, start_, top_window_, window_, windows_, is64bit, CPUUsage, WaitCPUUsageLower 
-
-    .. autoclass:: pywinauto.application.WindowSpecification
-        :members: ChildWindow, Exists, PrintControlIdentifiers, Wait, WaitNot, WrapperObject
-
-        .. automethod:: pywinauto.application.WindowSpecification.__getitem__
-        .. automethod:: pywinauto.application.WindowSpecification.__getattr__
-
-    .. autofunction:: pywinauto.application.process_from_module
-
-    .. autofunction:: pywinauto.application.process_module
-
-    Exceptions
-    ==========
-    .. autoclass:: pywinauto.application.AppNotConnected
-    .. autoclass:: pywinauto.application.AppStartError
-    .. autoclass:: pywinauto.application.AssertValidProcess
-    .. autoclass:: pywinauto.application.ProcessNotFoundError
-
+.. automodule:: pywinauto.application
+    :members:
+    :undoc-members:
+    :show-inheritance:

--- a/doc_src/code/pywinauto.controls.common_controls.txt
+++ b/doc_src/code/pywinauto.controls.common_controls.txt
@@ -1,12 +1,7 @@
 pywinauto.controls.common_controls
 ----------------------------------
+
  .. automodule:: pywinauto.controls.common_controls
     :members:
+    :undoc-members:
     :show-inheritance:
-
- .. autoclass:: pywinauto.controls.common_controls._treeview_element
-    :members:
-
- .. autoclass:: pywinauto.controls.common_controls._toolbar_button
-    :members:
-

--- a/doc_src/conf.py
+++ b/doc_src/conf.py
@@ -210,3 +210,19 @@ latex_documents = [
 
 # parameter to autodoc to make it take the doc from the __init__ methods also
 autoclass_content = 'both'
+
+# This value contains a list of modules to be mocked up. 
+# This is useful when some external dependencies are not met at build time 
+# and break the building process.
+autodoc_mock_imports = [
+        'win32api',
+        'win32con',
+        'win32process', 
+        'win32gui',
+        'win32event',
+        'win32com',
+        'win32com.Client',
+        'multiprocessing',
+        'pywintypes',
+        ]
+

--- a/doc_src/controls_overview.txt
+++ b/doc_src/controls_overview.txt
@@ -2,7 +2,7 @@
 Methods available to each different control type
 ============================================================
 
-Windows has many controls, buttons, lists, etc
+Windows have many controls, buttons, lists, etc
 
 
 All Controls

--- a/doc_src/controls_overview.txt
+++ b/doc_src/controls_overview.txt
@@ -426,7 +426,7 @@ TreeView
 .. _TreeViewElement.Next: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._treeview_element.Next
 .. _TreeViewElement.Rectangle: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._treeview_element.Rectangle
 .. _TreeViewElement.State: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._treeview_element.State
-.. _TreeViewElement.SubElements: code/pywinauto.controlscommon_controls.html#pywinauto.controls.common_controls._treeview_element.SubElements
+.. _TreeViewElement.SubElements: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._treeview_element.SubElements
 .. _TreeViewElement.Text: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._treeview_element.Text
 
 

--- a/doc_src/index.txt
+++ b/doc_src/index.txt
@@ -30,7 +30,7 @@ Installation
 - Run ``python.exe setup.py install``
 
 Installation in silent mode
-------------
+---------------------------
 (Python 2.7, 3.1, 3.2, 3.3, 3.4, 3.5)
 
 - Just run ``pip install pywinauto``

--- a/doc_src/wait_long_operations.txt
+++ b/doc_src/wait_long_operations.txt
@@ -9,7 +9,7 @@ timeout). There are few methods/functions that could help you to make
 your code easier and more reliable.
 
 Application methods
-------------
+-------------------
 
   * WaitCPUUsageLower_ (new in pywinauto 0.5.2)
 
@@ -25,7 +25,8 @@ Example: ::
 
 
 WindowSpecification methods
-------------
+---------------------------
+
 These methods are available to all controls.
 
   * Wait_
@@ -39,7 +40,8 @@ It's just a description namely a couple of criteria to search the window. The ``
 can guarantee that the target control exists or even visible, enabled and/or active.
 
 Functions in ``timings`` module
-------------
+-------------------------------
+
 There are also low-level methods useful for any Python code.
 
   * WaitUntil_
@@ -54,7 +56,8 @@ There are also low-level methods useful for any Python code.
 
 
 Identify controls
-------------
+-----------------
+
 The methods to help you to find a needed control.
 
   * PrintControlIdentifiers_

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -20,7 +20,7 @@
 #    Suite 330,
 #    Boston, MA 02111-1307 USA
 
-"""The application module is the main one that users will user first.
+"""The application module is the main one that users will use first.
 
 When starting to automate an application you must initialize an instance
 of the Application class. Then you must :func:`Application.Start` that

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -50,7 +50,7 @@ in almost exactly the same ways. ::
 .. seealso::
 
   :func:`pywinauto.findwindows.find_windows` for the keyword arguments that
-  can be passed to both :func:`Application.Window` and
+  can be passed to both: :func:`Application.Window_` and
   :func:`WindowSpecification.Window`
 
 """
@@ -98,7 +98,11 @@ class WindowSpecification(object):
     """A specificiation for finding a window or control
 
     Windows are resolved when used.
-    You can also wait for existance or non existance of a window
+    You can also wait for existance or non existance of a window 
+ 
+    .. implicitly document some private functions
+    .. automethod:: __getattr__
+    .. automethod:: __getitem__
     """
 
     WAIT_CRITERIA_MAP = {'exists': ('Exists',),
@@ -758,7 +762,13 @@ def _resolve_control(criteria, timeout = None, retry_interval = None):
 
 #=========================================================================
 class Application(object):
-    "Represents an application"
+    """
+    Represents an application
+ 
+    .. implicitly document some private functions
+    .. automethod:: __getattr__
+    .. automethod:: __getitem__
+    """
 
     def __init__(self, datafilename = None):
         "Set the attributes"

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -19,8 +19,24 @@
 #    59 Temple Place,
 #    Suite 330,
 #    Boston, MA 02111-1307 USA
+"""
+Classes that wrap the Windows Common controls
 
-"Classes that wrap the Windows Common controls"
+.. implicitly document some private classes
+.. autoclass:: _toolbar_button
+   :members:
+   :show-inheritance:
+
+.. autoclass:: _treeview_element
+   :members:
+   :show-inheritance:
+
+.. autoclass:: _listview_item
+   :members:
+   :show-inheritance:
+"""
+
+
 from __future__ import absolute_import
 from __future__ import print_function
 
@@ -1869,7 +1885,9 @@ class TabControlWrapper(HwndWrapper.HwndWrapper):
 
 #====================================================================
 class _toolbar_button(object):
-    "Wrapper around Toolbar button (TBBUTTONINFO) items"
+    """
+    Wrapper around Toolbar button (TBBUTTONINFO) items
+    """
     #----------------------------------------------------------------
     def __init__(self, index_, tb_handle):
         "Initialize the item"


### PR DESCRIPTION
1. Fix small typos and warnings about short header underlining
2. Move customization directives to docstrings. The class listings now are in alphabetical order as I didn't find how to customize the listing sorting per file yet.
3. Exprerimental fix for conf.py in ada98c0. Maybe it can help us to generate the docs with RTD.