### PR TITLE
test_applications: remove global call to Timings.Fast() 

### DIFF
--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -44,7 +44,6 @@ from pywinauto import findwindows, findbestmatch
 from pywinauto.timings import Timings, TimeoutError, WaitUntil
 from pywinauto.sysinfo import is_x64_Python, is_x64_OS
 
-Timings.Fast()
 #application.set_timing(1, .01, 1, .01, .05, 0, 0, .1, 0, .01)
 
 # About dialog may take some time to load


### PR DESCRIPTION
Now the tests will run with mostly default timings.