### PR TITLE
Don't enforce warnings.simplefilter('always')

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -88,6 +88,11 @@ class AppNotConnected(Exception):
     pass    #pragma: no cover
 
 
+# Display User and Deprecation warnings every time
+for warning in (UserWarning, PendingDeprecationWarning):
+    warnings.simplefilter('always', warning)
+
+
 #wait_method_deprecation = "Wait* functions are just simple wrappers around " \
 #    "Wait() or WaitNot(), so they may be removed in the future!"
 
@@ -789,7 +794,6 @@ class Application(object):
         the .connect().
         Should be also removed in 0.6.X.
         """
-        warnings.simplefilter('always', PendingDeprecationWarning)
         warnings.warn(
             "connect_()/Connect_() methods are deprecated, "
             "please switch to instance method connect(). "
@@ -848,7 +852,6 @@ class Application(object):
         calling the .start().
         Should be also removed in 0.6.X.
         """
-        warnings.simplefilter('always', PendingDeprecationWarning)
         warnings.warn(
             "start_()/Start_() methods are deprecated, "
             "please switch to instance method start(). "
@@ -937,12 +940,10 @@ class Application(object):
     def __warn_incorrect_bitness(self):
         if self.is64bit() != is_x64_Python():
             if is_x64_Python():
-                warnings.simplefilter('always', UserWarning) # warn each time
                 warnings.warn(
                     "32-bit application should be automated using 32-bit Python (you use 64-bit Python)",
                     UserWarning)
             else:
-                warnings.simplefilter('always', UserWarning) # warn each time
                 warnings.warn(
                     "64-bit application should be automated using 64-bit Python (you use 32-bit Python)",
                     UserWarning)
@@ -1232,7 +1233,6 @@ def _warn_incorrect_binary_bitness(exe_name):
     "warn if executable is of incorrect bitness"
     if os.path.isabs(exe_name) and os.path.isfile(exe_name):
         if handleprops.is64bitbinary(exe_name) and not is_x64_Python():
-            warnings.simplefilter('always', UserWarning) # warn for every 32-bit binary
             warnings.warn(
                 "64-bit binary from 32-bit Python may work incorrectly (please use 64-bit Python instead)",
                 UserWarning, stacklevel=2)

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -63,6 +63,12 @@ class ApplicationWarningTestCases(unittest.TestCase):
     def setUp(self):
         """Set some data and ensure the application
         is in the state we want it."""
+
+        # Force Display User and Deprecation warnings every time
+        # Python 3.3+nose/unittest trys really hard to suppress them
+        for warning in (UserWarning, PendingDeprecationWarning):
+            warnings.simplefilter('always', warning)
+
         mfc_samples_folder = os.path.join(os.path.dirname(__file__),
                                           r"..\..\apps\MFC_samples")
         if is_x64_Python():


### PR DESCRIPTION
Prevents turning warnings into exceptions and makes suppressing harder if it's necessary.

Setting the filter within this method is unnecessary and makes overriding it awkward, even if you want to turn warnings into exceptions.

My use-case for suppressing warnings:
I have an application which creates several processes, and I want to find and connect a pywinauto.Application instance to one of those processes. They are easy to find based on window title for which I'm using pywinauto.findwindow.find_windows, but occasionally another application (cmd) will show up as a false match.
This is exacerbated by my having to try in a loop for the window to appear, resulting in many repetitions of the UserWarning being printed.
Of course I can easily check the process name once I've attached the Application, but the warning is already emitted at that point, even though I won't actually try to automate the 64bit cmd.

(I could flip my logic around and attempt to find a matching window belonging to each matching process, but this way looks neater and requires significantly fewer find_windows calls).