### PR TITLE
Cache UIA attributes during the best match look up

### DIFF
--- a/pywinauto/ElementInfo.py
+++ b/pywinauto/ElementInfo.py
@@ -31,6 +31,11 @@
 
 class ElementInfo(object):
     "Wrapper for element"
+
+    def set_cache_strategy(self, cached):
+        """Set a cache strategy for frequently used attributes of the element"""
+        raise NotImplementedError()
+
     @property
     def handle(self):
         "Return the handle of the element"

--- a/pywinauto/NativeElementInfo.py
+++ b/pywinauto/NativeElementInfo.py
@@ -51,6 +51,10 @@ class NativeElementInfo(ElementInfo):
 
         self._as_parameter_ = self._handle
 
+    def set_cache_strategy(self, cached):
+        """Set a cache strategy for frequently used attributes of the element"""
+        pass  # TODO: implement a cache strategy for native elements
+
     @property
     def handle(self):
         """Return the handle of the window"""

--- a/pywinauto/UIAElementInfo.py
+++ b/pywinauto/UIAElementInfo.py
@@ -96,6 +96,35 @@ class UIAElementInfo(ElementInfo):
         else:
             self._element = IUIA().root
 
+        self.set_cache_strategy(False)
+
+    def _get_current_class_name(self):
+        """Return an actual class name of the element"""
+        return self._element.CurrentClassName
+    
+    def _get_cached_class_name(self):
+        """Return a cached class name of the element"""
+        return self._cached_class_name
+
+    def _get_current_handle(self):
+        """Return an actual handle of the element"""
+        return self._element.CurrentNativeWindowHandle
+
+    def _get_cached_handle(self):
+        """Return a cached handle of the element"""
+        return self._cached_handle
+
+    def set_cache_strategy(self, cached = False):
+        """Setup a cache strategy for frequently used attributes"""
+        if cached:
+            self._cached_class_name = self._get_current_class_name()
+            self._cached_handle = self._get_current_handle()
+            self._get_class_name = self._get_cached_class_name
+            self._get_handle = self._get_cached_handle
+        else:
+            self._get_class_name = self._get_current_class_name
+            self._get_handle = self._get_current_handle
+
     @property
     def element(self):
         """Return AutomationElement's instance"""
@@ -137,7 +166,7 @@ class UIAElementInfo(ElementInfo):
     @property
     def class_name(self):
         """Return class name of the element"""
-        return self._element.CurrentClassName
+        return self._get_class_name()
 
     @property
     def control_type(self):
@@ -147,7 +176,7 @@ class UIAElementInfo(ElementInfo):
     @property
     def handle(self):
         """Return handle of the element"""
-        return self._element.CurrentNativeWindowHandle
+        return self._get_handle()
 
     @property
     def parent(self):

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -31,7 +31,7 @@
 """
 Wrap various UIA windows controls
 """
-import pywinauto.uia_defines as uia_defs
+from .. import uia_defines as uia_defs
 from . import UIAWrapper
 from ..uia_defines import IUIA
 

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -233,6 +233,7 @@ def find_elements(class_name = None,
     if best_match is not None:
         wrapped_elems = []
         for elem in elements:
+            elem.set_cache_strategy(True)
             try:
                 # TODO: can't skip invalid handles because UIA element can have no handle
                 # TODO: use className check for this ?
@@ -251,6 +252,7 @@ def find_elements(class_name = None,
         elements = []
         for elem in backup_elements:
             if hasattr(elem, "element_info"):
+                elem.element_info.set_cache_strategy(False)
                 elements.append(elem.element_info)
             else:
                 elements.append(backend_obj.element_info_class(elem.handle))


### PR DESCRIPTION
Add set_cache_strategy method for ElemenInfo and its descendants.
Cache UIAElementIfo.class_name and UIAElementInfo.handle attributes during the best match search.
Use only relative imports in uia_controls.py