### PR TITLE
Redesigned print_control_identifiers() function

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -550,11 +550,11 @@ class WindowSpecification(object):
         Prints identifiers for the control and for its descendants to
         a depth of **depth**.
 
-        .. note:: The identifiers printed by this method have not been made
-               unique. So if you have 2 edit boxes, they will both have "Edit"
-               listed in their identifiers. In reality though the first one
-               can be refered to as "Edit", "Edit0", "Edit1" and the 2nd
-               should be refered to as "Edit2".
+        .. note:: The identifiers printed by this method have been made
+               unique. So if you have 2 edit boxes, they won't both have "Edit"
+               listed in their identifiers. In fact the first one can be
+               referred to as "Edit", "Edit0", "Edit1" and the 2nd should be
+               referred to as "Edit2".
         """
         # Wrap this control
         this_ctrl = self.__resolve_control(self.criteria)[-1]
@@ -572,9 +572,11 @@ class WindowSpecification(object):
 
         print("Control Identifiers:")
 
-        # Recursive function that prints identifiers for ctrls and theirs
-        # descendants in a tree-like format
         def print_identifiers(ctrls, current_depth = 1):
+            """
+            Recursive function that prints identifiers for ctrls and
+            theirs descendants in a tree-like format
+            """
             if len(ctrls) == 0 or current_depth > depth:
                 return
 

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -53,8 +53,8 @@ from . import HwndWrapper
 
 from ..timings import Timings
 from ..timings import WaitUntil
-from pywinauto.handleprops import is64bitprocess
-from pywinauto.sysinfo import is_x64_Python
+from ..handleprops import is64bitprocess
+from ..sysinfo import is_x64_Python
 
 if sysinfo.UIA_support:
     from ..uia_defines import IUIA

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -182,8 +182,8 @@ def find_elements(class_name = None,
             parent = backend_obj.element_info_class()
 
         # look for ALL children of that parent
-        elements = parent.descendants(process = process, 
-                                      class_name = class_name, 
+        elements = parent.descendants(process = process,
+                                      class_name = class_name,
                                       title = title) # root.children == enum_windows()
 
         # if the ctrl_index has been specified then just return


### PR DESCRIPTION
New output of `print_control_identifiers(depth = 2)` looks like this
```txt
Control Identifiers:

Dialog - 'Untitled - Notepad'    (L337, T103, R1520, B782)  
['Untitled - NotepadDialog', 'Untitled - Notepad', 'Dialog']
     | 
     | Edit - ''    (L345, T154, R1512, B774)   
     | ['', 'Edit0', '1', 'Edit1', '0', 'Edit']
     | 
     | TitleBar - 'None'    (L361, T106, R1512, B134)   
     | ['TitleBar', '2']
     | 
     | MenuBar - 'Application'    (L345, T134, R1512, B153) 
     | ['MenuBar2', 'ApplicationMenuBar', 'Application']
```