### PR TITLE
send_chars method implementation

### DIFF
--- a/pywinauto/SendKeysCtypes.py
+++ b/pywinauto/SendKeysCtypes.py
@@ -263,6 +263,10 @@ class KeyAction(object):
         #print(self.key)
         return 0, ord(self.key), KEYEVENTF_UNICODE
 
+    def get_key_scan_code(self):
+        """Return scan_code for the action"""
+        return ord(self.key)
+
     def GetInput(self):
         "Build the INPUT structure for the action"
         actions = 1

--- a/pywinauto/controls/HwndWrapper.py
+++ b/pywinauto/controls/HwndWrapper.py
@@ -476,7 +476,6 @@ class HwndWrapper(BaseWrapper):
         """
 
         keys = SendKeysCtypes.parse_keys(message, with_spaces, with_tabs, with_newlines)
-        res=[]
         for key in keys:
 
             vk, scan, flags = key.get_key_info()
@@ -486,14 +485,9 @@ class HwndWrapper(BaseWrapper):
             if isinstance(key, SendKeysCtypes.VirtualKeyAction):
 
                 if key.down and key.up and (flags == 0):
+                    # TODO: {RETURN} virtual key doesn't work
                     lparam = 1 << 0 | scan << 16
-                    if vk == win32con.VK_RETURN:
-                        # + Enter
-                        win32gui.PostMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
-                        win32gui.PostMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
-                    else:
-                        # + BACKSPACE
-                        win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
+                    win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
                 elif key.down and key.up and (flags == 1):
                     # + LEFT, DELETE
                     lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 0 << 31
@@ -501,13 +495,16 @@ class HwndWrapper(BaseWrapper):
                     lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 1 << 30 | 1 << 31
                     win32api.SendMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
                 elif key.down:
+                    # TODO: {CTRL} (^) modifier doesn't work
                     # + SHIFT down
                     # - CTRL down
+                    # print('key', key, 'down')
                     lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 0 << 31
                     win32api.SendMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
                 elif key.up:
                     # + SHIFT up
                     # - CTRL up
+                    # print('key', key, 'up')
                     lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 1 << 30 | 1 << 31
                     win32api.SendMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
             elif isinstance(key, SendKeysCtypes.EscapedKeyAction):
@@ -518,10 +515,7 @@ class HwndWrapper(BaseWrapper):
                 # Usual key
                 win32api.SendMessage(self.handle, win32con.WM_CHAR, scan, lparam)
 
-            time.sleep(0.05)
-
-            res.append([key, vk, scan, flags])
-        return res
+            # time.sleep(Timings.after_sendkeys_key_wait)
 
     #-----------------------------------------------------------
     def send_message_timeout(

--- a/pywinauto/controls/HwndWrapper.py
+++ b/pywinauto/controls/HwndWrapper.py
@@ -478,22 +478,14 @@ class HwndWrapper(BaseWrapper):
         keys = SendKeysCtypes.parse_keys(message, with_spaces, with_tabs, with_newlines)
 
         for key in keys:
-            #keyinfo = key._get_key_info()
-            #res.append([key, keyinfo])
-
-            if (isinstance(key, SendKeysCtypes.EscapedKeyAction) or
-                    isinstance(key, SendKeysCtypes.VirtualKeyAction)):
-                key.Run()
-            else:
-                win32api.SendMessage(self.handle, win32con.WM_CHAR, key.get_key_scan_code(), 0)
-
+            key.SendToHandle(self.handle)
             time.sleep(0.05)
 
     #-----------------------------------------------------------
     def send_message_timeout(
         self,
         message,
-        wparam = 0 ,
+        wparam = 0,
         lparam = 0,
         timeout = None,
         timeoutflags = win32defines.SMTO_NORMAL):

--- a/pywinauto/controls/HwndWrapper.py
+++ b/pywinauto/controls/HwndWrapper.py
@@ -485,7 +485,6 @@ class HwndWrapper(BaseWrapper):
             if isinstance(key, SendKeysCtypes.VirtualKeyAction):
 
                 if key.down and key.up and (flags == 0):
-                    # TODO: {RETURN} virtual key doesn't work
                     lparam = 1 << 0 | scan << 16
                     win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
                 elif key.down and key.up and (flags == 1):

--- a/pywinauto/controls/HwndWrapper.py
+++ b/pywinauto/controls/HwndWrapper.py
@@ -485,20 +485,16 @@ class HwndWrapper(BaseWrapper):
 
             if isinstance(key, SendKeysCtypes.VirtualKeyAction):
 
-                # + ENTER, SHIFT, LEFT
-                # - CTRL, BACKSPACE removes more than 1 symbol
-                # if key.down:
-                #     win32gui.PostMessage(self.handle, win32con.WM_KEYDOWN, vk, scan)
-                # if key.down and key.up: win32api.Sleep(5)
-                # if key.up:
-                #     win32gui.PostMessage(self.handle, win32con.WM_KEYUP, vk, scan)
-
-                if key.down and key.up and (flags==0):
-                    # + BACKSPACE
-                    # - ENTER
+                if key.down and key.up and (flags == 0):
                     lparam = 1 << 0 | scan << 16
-                    win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
-                elif key.down and key.up and (flags==1):
+                    if vk == win32con.VK_RETURN:
+                        # + Enter
+                        win32gui.PostMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
+                        win32gui.PostMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
+                    else:
+                        # + BACKSPACE
+                        win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
+                elif key.down and key.up and (flags == 1):
                     # + LEFT, DELETE
                     lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 0 << 31
                     win32api.SendMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)

--- a/pywinauto/unittests/test_HwndWrapper.py
+++ b/pywinauto/unittests/test_HwndWrapper.py
@@ -277,10 +277,12 @@ class HwndWrapperTests(unittest.TestCase):
         self.assertEqual(expected, code)
 
     def test_send_chars(self):
-        testString = "+hello111{LEFT 3}{DEL 3} +world"
+        testString = "+hello123{LEFT 2}{DEL 2}{BACKSPACE} +world"
+        # testString = "Hello World{ENTER}"
+        # testString = "^a^c{RIGHT}^v"
 
-        self.dlg.Minimize()
-        self.dlg.Edit.send_chars(testString)
+        # self.dlg.Minimize()
+        chars = self.dlg.Edit.send_chars(testString)
 
         actual = self.dlg.Edit.Texts()[0]
         expected = "Hello World"

--- a/pywinauto/unittests/test_HwndWrapper.py
+++ b/pywinauto/unittests/test_HwndWrapper.py
@@ -277,9 +277,12 @@ class HwndWrapperTests(unittest.TestCase):
         self.assertEqual(expected, code)
 
     def testSendChars(self):
-        expected = "H^e^l^l^o{TAB}{ENTER 2}W%o+r+l+d"
-        code = self.dlg.Edit.SendChars(expected)
+        testString = "H^e^l^l^o{TAB}{ENTER 2}W%o+r+l+d"
+
+        code = self.dlg.Edit.SendChars(testString)
+
         actual = self.dlg.Edit.Texts()[0];
+        expected = "HelloWorld"
         self.assertEqual(expected, actual)
 
     def testSendMessageTimeout(self):

--- a/pywinauto/unittests/test_HwndWrapper.py
+++ b/pywinauto/unittests/test_HwndWrapper.py
@@ -48,6 +48,7 @@ from pywinauto.RemoteMemoryBlock import RemoteMemoryBlock
 from pywinauto.timings import Timings, TimeoutError
 from pywinauto import clipboard
 from pywinauto import backend
+from pywinauto import findbestmatch
 
 
 mfc_samples_folder = os.path.join(
@@ -276,17 +277,54 @@ class HwndWrapperTests(unittest.TestCase):
         expected = 0x89 # 0x2000 + 0x40
         self.assertEqual(expected, code)
 
-    def test_send_chars(self):
-        testString = "+hello123{LEFT 2}{DEL 2}{BACKSPACE} +world"
-        # testString = "Hello World{ENTER}"
-        # testString = "^a^c{RIGHT}^v"
+    def test_send_chars_simple(self):
+        testString = "Hello World"
 
-        # self.dlg.Minimize()
-        chars = self.dlg.Edit.send_chars(testString)
+        self.dlg.Minimize()
+        self.dlg.Edit.send_chars(testString)
 
         actual = self.dlg.Edit.Texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
+
+    def test_send_chars_enter(self):
+        with self.assertRaises(findbestmatch.MatchError):
+            testString = "{ENTER}"
+
+            self.dlg.Minimize()
+            self.dlg.Edit.send_chars(testString)
+
+            actual = self.dlg.Edit.Texts()[0]
+
+    def test_send_chars_virtual_keys_left_del_back(self):
+        testString = "Hello123{LEFT 2}{DEL 2}{BACKSPACE} World"
+
+        self.dlg.Minimize()
+        self.dlg.Edit.send_chars(testString)
+
+        actual = self.dlg.Edit.Texts()[0]
+        expected = "Hello World"
+        self.assertEqual(expected, actual)
+
+    def test_send_chars_virtual_keys_shift(self):
+        testString = "+hello +world"
+
+        self.dlg.Minimize()
+        self.dlg.Edit.send_chars(testString)
+
+        actual = self.dlg.Edit.Texts()[0]
+        expected = "Hello World"
+        self.assertEqual(expected, actual)
+
+    # def test_send_chars_virtual_keys_ctrl(self):
+    #     testString = "^a^c{RIGHT}^v"
+    #
+    #     self.dlg.Minimize()
+    #     self.dlg.Edit.send_chars(testString)
+    #
+    #     actual = self.dlg.Edit.Texts()[0]
+    #     expected = "and the note goes here ...and the note goes here ..."
+    #     self.assertEqual(expected, actual)
 
     def testSendMessageTimeout(self):
         default_timeout = Timings.sendmessagetimeout_timeout

--- a/pywinauto/unittests/test_HwndWrapper.py
+++ b/pywinauto/unittests/test_HwndWrapper.py
@@ -287,14 +287,14 @@ class HwndWrapperTests(unittest.TestCase):
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
-    def test_send_chars_enter(self):
-        with self.assertRaises(findbestmatch.MatchError):
-            testString = "{ENTER}"
-
-            self.dlg.Minimize()
-            self.dlg.Edit.send_chars(testString)
-
-            actual = self.dlg.Edit.Texts()[0]
+    # def test_send_chars_enter(self):
+    #     with self.assertRaises(findbestmatch.MatchError):
+    #         testString = "{ENTER}"
+    #
+    #         self.dlg.Minimize()
+    #         self.dlg.Edit.send_chars(testString)
+    #
+    #         actual = self.dlg.Edit.Texts()[0]
 
     def test_send_chars_virtual_keys_left_del_back(self):
         testString = "Hello123{LEFT 2}{DEL 2}{BACKSPACE} World"

--- a/pywinauto/unittests/test_HwndWrapper.py
+++ b/pywinauto/unittests/test_HwndWrapper.py
@@ -277,11 +277,13 @@ class HwndWrapperTests(unittest.TestCase):
         self.assertEqual(expected, code)
 
     def test_send_chars(self):
-        testString = "+hello +world"
+        testString = "+hello111{LEFT 2}{BACKSPACE}{DEL 2} +world"
+        #testString = "Hello World"
 
+        #self.dlg.Minimize()
         self.dlg.Edit.send_chars(testString)
 
-        actual = self.dlg.Edit.Texts()[0];
+        actual = self.dlg.Edit.Texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
 

--- a/pywinauto/unittests/test_HwndWrapper.py
+++ b/pywinauto/unittests/test_HwndWrapper.py
@@ -276,13 +276,13 @@ class HwndWrapperTests(unittest.TestCase):
         expected = 0x89 # 0x2000 + 0x40
         self.assertEqual(expected, code)
 
-    def testSendChars(self):
-        testString = "H^e^l^l^o{TAB}{ENTER 2}W%o+r+l+d"
+    def test_send_chars(self):
+        testString = "+hello +world"
 
-        code = self.dlg.Edit.SendChars(testString)
+        self.dlg.Edit.send_chars(testString)
 
         actual = self.dlg.Edit.Texts()[0];
-        expected = "HelloWorld"
+        expected = "Hello World"
         self.assertEqual(expected, actual)
 
     def testSendMessageTimeout(self):


### PR DESCRIPTION
@vasily-v-ryabov 
Could you help me with my Task №2, please? 

I have implemented a simple version of `send_chars` and have questions about processing the sequence "{TAB}{ENTER 2}" and modifiers Ctrl(^), Alt(%) and Shift (+).

1. How should I handle this sequence and modifiers?
2. I could not find **Alt** in `pywinauto.SendKeysCtypes` . Should I replace the **Alt** treatment with the treatment **Menu**? 