### PR TITLE
Add mouse position hook to hooks.py

### DIFF
--- a/pywinauto/hooks.py
+++ b/pywinauto/hooks.py
@@ -297,7 +297,7 @@ if __name__ == "__main__":
 
         if isinstance(args, MouseEvent):
             if args.current_key == 'RButton' and args.event_type == 'key down':
-                print("Right button pressed at ({}, {})".format(args.mouse_x,args.mouse_y))
+                print("Right button pressed at ({0}, {1})".format(args.mouse_x,args.mouse_y))
 
             if args.current_key == 'WheelButton' and args.event_type == 'key down':
                 print("Wheel button pressed")

--- a/pywinauto/hooks.py
+++ b/pywinauto/hooks.py
@@ -28,9 +28,11 @@ class KeyboardEvent(object):
 
 class MouseEvent(object):
     """Is created when mouse event catch"""
-    def __init__(self, current_key=None, event_type=None):
+    def __init__(self, current_key=None, event_type=None, mouse_x=0, mouse_y=0):
         self.current_key = current_key
         self.event_type = event_type
+        self.mouse_x = mouse_x
+        self.mouse_y = mouse_y
 
 
 class Hook(object):
@@ -226,7 +228,8 @@ class Hook(object):
                     current_key = self.MOUSE_ID_TO_KEY[event_code]
                     if current_key != 'Move':
                         event_type = self.MOUSE_ID_TO_EVENT_TYPE[event_code]
-                        event = MouseEvent(current_key, event_type)
+                        #the first two members of kb_data_ptr hold the mouse position, x and y
+                        event = MouseEvent(current_key, event_type, kb_data_ptr[0], kb_data_ptr[1])
 
                         if self.handler != 0:
                             self.handler(event)
@@ -294,7 +297,7 @@ if __name__ == "__main__":
 
         if isinstance(args, MouseEvent):
             if args.current_key == 'RButton' and args.event_type == 'key down':
-                print("Right button pressed")
+                print("Right button pressed at ({}, {})".format(args.mouse_x,args.mouse_y))
 
             if args.current_key == 'WheelButton' and args.event_type == 'key down':
                 print("Wheel button pressed")


### PR DESCRIPTION
First off, great work by @MaxSamokhvalov on the hooks.py file. I know the example I gave was pretty bad (I wrote it as one of my first projects when I was just learning to program), this is so much better. I may even ~~steal~~ use it in my module if that is okay with you all (just as a stand alone module, for those who don't need all of pywinauto).

In this PR I just added the mouse position information, as I had that in my original code, and found it useful. It was easy enough to add so take it if you want the addition. This would allow for checks if the mouse is in a bounding box or if it clicks in said box, etc.

I also added a little to the example in the file.

Oh, and you might want to mention that one _cannot_ exit this with ctrl+c (before and after this PR). When I first wrote this code I was somewhat surprised that it wouldn't quit the loop, as I expect that to kill python when I run things from the console.