### PR TITLE
UIA optimizations

### DIFF
--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -483,11 +483,10 @@ class UIAWrapper(BaseWrapper):
             err_msg = u"unsupported {0} for item {1}".format(type(item), item)
             raise ValueError(err_msg)
 
-        list_ = self.element_info.children(title = title)
+        list_ = self.children(title = title)
         if item_index < len(list_):
-            elem = list_[item_index].element
-            iface = uia_defs.get_elem_interface(elem, "SelectionItem")
-            iface.Select()
+            wrp = list_[item_index]
+            wrp.iface_selection_item.Select()
         else:
             raise IndexError("item not found")
 

--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -187,8 +187,15 @@ def get_non_text_control_name(ctrl, controls, text_ctrls):
     """
     names = []
 
-    ctrl_index = controls.index(ctrl)
-    ctrl_friendly_class_name =  ctrl.friendly_class_name()
+    # simply look for an instance of the control in the list,
+    # we don't use list.index() method as it invokes __eq__
+    ctrl_index = 0
+    for i, c in enumerate(controls):
+        if c is ctrl:
+            ctrl_index = i
+            print i, len(controls)
+            break
+    ctrl_friendly_class_name = ctrl.friendly_class_name()
 
     if ctrl_index != 0:
         prev_ctrl = controls[ctrl_index-1]

--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -193,7 +193,6 @@ def get_non_text_control_name(ctrl, controls, text_ctrls):
     for i, c in enumerate(controls):
         if c is ctrl:
             ctrl_index = i
-            print i, len(controls)
             break
     ctrl_friendly_class_name = ctrl.friendly_class_name()
 

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -193,6 +193,10 @@ def find_elements(class_name = None,
         if ctrl_index is not None:
             return [elements[ctrl_index], ]
 
+    # early stop
+    if not elements:
+        return elements
+
     if framework_id is not None and elements:
         elements = [elem for elem in elements if elem.framework_id == framework_id]
 
@@ -221,10 +225,6 @@ def find_elements(class_name = None,
                 break
         if not found_active:
             elements = []
-
-    # early stop
-    if not elements:
-        return elements
 
     if class_name is not None:
         elements = [elem for elem in elements if elem.class_name == class_name]
@@ -258,15 +258,13 @@ def find_elements(class_name = None,
 
     if best_match is not None:
         wrapped_elems = []
-        for elem in elements:
-            try:
-                wrapped_elems.append(backend_obj.generic_wrapper_class(elem))
-                #wrapped_elems.append(BaseWrapper(elem))
-            except (controls.InvalidWindowHandle,
-                    controls.InvalidElement):
-                # skip invalid handles - they have dissapeared
-                # since the list of elements was retrieved
-                continue
+        try:
+            wrapped_elems = [backend_obj.generic_wrapper_class(e) for e in elements]
+        except (controls.InvalidWindowHandle,
+                controls.InvalidElement):
+            # skip invalid handles - they have dissapeared
+            # since the list of elements was retrieved
+            pass
         elements = findbestmatch.find_best_control_matches(best_match, wrapped_elems)
 
         # convert found elements back to ElementInfo

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -258,13 +258,14 @@ def find_elements(class_name = None,
 
     if best_match is not None:
         wrapped_elems = []
-        try:
-            wrapped_elems = [backend_obj.generic_wrapper_class(e) for e in elements]
-        except (controls.InvalidWindowHandle,
-                controls.InvalidElement):
-            # skip invalid handles - they have dissapeared
-            # since the list of elements was retrieved
-            pass
+        for elem in elements:
+            try:
+                wrapped_elems.append(backend_obj.generic_wrapper_class(elem))
+            except (controls.InvalidWindowHandle,
+                    controls.InvalidElement):
+                # skip invalid handles - they have dissapeared
+                # since the list of elements was retrieved
+                continue
         elements = findbestmatch.find_best_control_matches(best_match, wrapped_elems)
 
         # convert found elements back to ElementInfo

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -169,7 +169,8 @@ def find_elements(class_name = None,
         element = backend_obj.element_info_class()
         elements = element.children(process = process, 
                                     class_name = class_name, 
-                                    title = title) # root.children == enum_windows()
+                                    title = title,
+                                    cache_enable = True) # root.children == enum_windows()
 
         # if we have been given a parent
         if parent:
@@ -184,7 +185,8 @@ def find_elements(class_name = None,
         # look for ALL children of that parent
         elements = parent.descendants(process = process,
                                       class_name = class_name,
-                                      title = title) # root.children == enum_windows()
+                                      title = title,
+                                      cache_enable = True) # root.children == enum_windows()
 
         # if the ctrl_index has been specified then just return
         # that control
@@ -257,7 +259,6 @@ def find_elements(class_name = None,
     if best_match is not None:
         wrapped_elems = []
         for elem in elements:
-            elem.set_cache_strategy(True)
             try:
                 wrapped_elems.append(backend_obj.generic_wrapper_class(elem))
                 #wrapped_elems.append(BaseWrapper(elem))

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -257,10 +257,14 @@ def find_elements(class_name = None,
         elements = [elem for elem in elements if elem.enabled]
 
     if best_match is not None:
+        # Build a list of wrapped controls.
+        # Speed up the loop by setting up local pointers
         wrapped_elems = []
+        add_to_wrp_elems = wrapped_elems.append
+        wrp_cls = backend_obj.generic_wrapper_class
         for elem in elements:
             try:
-                wrapped_elems.append(backend_obj.generic_wrapper_class(elem))
+                add_to_wrp_elems(wrp_cls(elem))
             except (controls.InvalidWindowHandle,
                     controls.InvalidElement):
                 # skip invalid handles - they have dissapeared

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -143,6 +143,22 @@ class UIAElementInfo(ElementInfo):
             self._cached_visible = self._get_current_visible()
         return self._cached_visible
 
+    def _get_current_rich_text(self):
+        """Return the actual rich_text of the element"""
+        if not self.class_name:
+            return self.name
+        try:
+            pattern = get_elem_interface(self._element, "Text")
+            return pattern.DocumentRange.GetText(-1)
+        except Exception:
+            return self.name # TODO: probably we should raise an exception here
+
+    def _get_cached_rich_text(self):
+        """Return the cached rich_text of the element"""
+        if self._cached_rich_text == False:
+            self._cached_rich_text = self._get_current_rich_text()
+        return self._cached_rich_text
+
     def set_cache_strategy(self, cached = False):
         """Setup a cache strategy for frequently used attributes"""
         self.cache_enable = cached
@@ -155,6 +171,7 @@ class UIAElementInfo(ElementInfo):
             self._cached_control_type = False
             self._cached_name = False
             self._cached_visible = False
+            self._cached_rich_text = False
 
             # Switch to cached attributes
             self._get_class_name = self._get_cached_class_name
@@ -162,6 +179,7 @@ class UIAElementInfo(ElementInfo):
             self._get_control_type = self._get_cached_control_type
             self._get_name = self._get_cached_name
             self._get_visible = self._get_cached_visible
+            self._get_rich_text = self._get_cached_rich_text
         else:
             # Switch to actual (non-cached) attributes 
             self._get_class_name = self._get_current_class_name
@@ -169,6 +187,7 @@ class UIAElementInfo(ElementInfo):
             self._get_control_type = self._get_current_control_type
             self._get_name = self._get_current_name
             self._get_visible = self._get_current_visible
+            self._get_rich_text = self._get_current_rich_text
 
     @property
     def element(self):
@@ -303,13 +322,7 @@ class UIAElementInfo(ElementInfo):
     @property
     def rich_text(self):
         """Return rich_text of the element"""
-        if not self.class_name:
-            return self.name
-        try:
-            pattern = get_elem_interface(self._element, "Text")
-            return pattern.DocumentRange.GetText(-1)
-        except Exception:
-            return self.name # TODO: probably we should raise an exception here
+        return self._get_rich_text()
 
     def __eq__(self, other):
         """Check if 2 UIAElementInfo objects describe 1 actual element"""

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -99,6 +99,8 @@ class UIAElementInfo(ElementInfo):
     
     def _get_cached_class_name(self):
         """Return a cached class name of the element"""
+        if self._cached_class_name == False:
+            self._cached_class_name = self._get_current_class_name()
         return self._cached_class_name
 
     def _get_current_handle(self):
@@ -107,6 +109,8 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_handle(self):
         """Return a cached handle of the element"""
+        if self._cached_handle == False:
+            self._cached_handle = self._get_current_handle()
         return self._cached_handle
 
     def _get_current_control_type(self):
@@ -115,6 +119,8 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_control_type(self):
         """Return a cached control type of the element"""
+        if self._cached_control_type == False:
+            self._cached_control_type = self._get_current_control_type()
         return self._cached_control_type
 
     def _get_current_name(self):
@@ -123,6 +129,8 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_name(self):
         """Return a cached name of the element"""
+        if self._cached_name == False:
+            self._cached_name = self._get_current_name()
         return self._cached_name
 
     def _get_current_visible(self):
@@ -131,6 +139,8 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_visible(self):
         """Return a cached visible property of the element"""
+        if self._cached_visible == False:
+            self._cached_visible = self._get_current_visible()
         return self._cached_visible
 
 
@@ -141,11 +151,11 @@ class UIAElementInfo(ElementInfo):
         self.descendants_list = None
         if cached:
             # Refresh cached attributes
-            self._cached_class_name = self._get_current_class_name()
-            self._cached_handle = self._get_current_handle()
-            self._cached_control_type = self._get_current_control_type()
-            self._cached_name = self._get_current_name()
-            self._cached_visible = self._get_current_visible()
+            self._cached_class_name = False
+            self._cached_handle = False
+            self._cached_control_type = False
+            self._cached_name = False
+            self._cached_visible = False
 
             # Switch to cached attributes
             self._get_class_name = self._get_cached_class_name

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -316,6 +316,13 @@ class UIAElementInfo(ElementInfo):
         """Check if 2 UIAElementInfo objects describe 1 actual element"""
         if not isinstance(other, UIAElementInfo):
             return False;
-        return self.handle == other.handle and self.class_name == other.class_name and self.name == other.name and \
-               self.process_id == other.process_id and self.automation_id == other.automation_id and \
-               self.framework_id == other.framework_id and self.control_type == other.control_type
+        # We put the most frequent attibutes at the top of comparison as
+        # many often the element doesn't have all these attributes.
+        # For example 'handle' exists only for top-level windows.
+        return self.control_type == other.control_type and \
+               self.class_name == other.class_name and \
+               self.process_id == other.process_id and \
+               self.handle == other.handle and \
+               self.name == other.name and \
+               self.automation_id == other.automation_id and \
+               self.framework_id == other.framework_id

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -317,7 +317,7 @@ class UIAElementInfo(ElementInfo):
         if not isinstance(other, UIAElementInfo):
             return False;
         # We put the most frequent attibutes at the top of comparison as
-        # many often the element doesn't have all these attributes.
+        # quite often the element doesn't have all these attributes.
         # For example 'handle' exists only for top-level windows.
         return self.control_type == other.control_type and \
                self.class_name == other.class_name and \

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -99,7 +99,7 @@ class UIAElementInfo(ElementInfo):
     
     def _get_cached_class_name(self):
         """Return a cached class name of the element"""
-        if self._cached_class_name == False:
+        if self._cached_class_name is None:
             self._cached_class_name = self._get_current_class_name()
         return self._cached_class_name
 
@@ -109,7 +109,7 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_handle(self):
         """Return a cached handle of the element"""
-        if self._cached_handle == False:
+        if self._cached_handle is None:
             self._cached_handle = self._get_current_handle()
         return self._cached_handle
 
@@ -119,7 +119,7 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_control_type(self):
         """Return a cached control type of the element"""
-        if self._cached_control_type == False:
+        if self._cached_control_type is None:
             self._cached_control_type = self._get_current_control_type()
         return self._cached_control_type
 
@@ -129,7 +129,7 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_name(self):
         """Return a cached name of the element"""
-        if self._cached_name == False:
+        if self._cached_name is None:
             self._cached_name = self._get_current_name()
         return self._cached_name
 
@@ -139,7 +139,7 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_visible(self):
         """Return a cached visible property of the element"""
-        if self._cached_visible == False:
+        if self._cached_visible is None:
             self._cached_visible = self._get_current_visible()
         return self._cached_visible
 
@@ -155,20 +155,20 @@ class UIAElementInfo(ElementInfo):
 
     def _get_cached_rich_text(self):
         """Return the cached rich_text of the element"""
-        if self._cached_rich_text == False:
+        if self._cached_rich_text is None:
             self._cached_rich_text = self._get_current_rich_text()
         return self._cached_rich_text
 
-    def set_cache_strategy(self, cached = False):
+    def set_cache_strategy(self, cached = None):
         """Setup a cache strategy for frequently used attributes"""
         if cached:
             # Refresh cached attributes
-            self._cached_class_name = False
-            self._cached_handle = False
-            self._cached_control_type = False
-            self._cached_name = False
-            self._cached_visible = False
-            self._cached_rich_text = False
+            self._cached_class_name = None
+            self._cached_handle = None
+            self._cached_control_type = None
+            self._cached_name = None
+            self._cached_visible = None
+            self._cached_rich_text = None
 
             # Switch to cached attributes
             self._get_class_name = self._get_cached_class_name

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -161,9 +161,6 @@ class UIAElementInfo(ElementInfo):
 
     def set_cache_strategy(self, cached = False):
         """Setup a cache strategy for frequently used attributes"""
-        self.cache_enable = cached
-        self.children_list = None
-        self.descendants_list = None
         if cached:
             # Refresh cached attributes
             self._cached_class_name = False
@@ -263,17 +260,9 @@ class UIAElementInfo(ElementInfo):
         * **kwargs** is a criteria to reduce a list by process, 
         class_name and/or title.
         """
-        def _children():
-            cache_enable = kwargs.pop('cache_enable', False)
-            cond = IUIA().build_condition(**kwargs)
-            return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
-
-        if self.cache_enable:
-            if not self.children_list:
-                self.children_list = _children()
-            return self.children_list
-        else:
-            return _children()
+        cache_enable = kwargs.pop('cache_enable', False)
+        cond = IUIA().build_condition(**kwargs)
+        return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
 
     def descendants(self, **kwargs):
         """
@@ -282,17 +271,9 @@ class UIAElementInfo(ElementInfo):
         * **kwargs** is a criteria to reduce a list by process, 
         class_name and/or title.
         """
-        def _descendants():
-            cache_enable = kwargs.pop('cache_enable', False)
-            cond = IUIA().build_condition(**kwargs)
-            return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
-
-        if self.cache_enable:
-            if not self.descendants_list:
-                self.descendants_list = _descendants()
-            return self.descendants_list
-        else:
-            return _descendants()
+        cache_enable = kwargs.pop('cache_enable', False)
+        cond = IUIA().build_condition(**kwargs)
+        return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
 
     @property
     def visible(self):

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -64,20 +64,15 @@ CurrentOrientation
 CurrentProviderDescription
 """
 
-def elements_from_uia_array(ptrs_array):
+def elements_from_uia_array(ptrs, cache_enable = False):
     """Build a list of UIAElementInfo elements from IUIAutomationElementArray"""
-    elements = []
-    for num in range(ptrs_array.Length):
-        child = ptrs_array.GetElement(num)
-        elements.append(UIAElementInfo(child))
-
-    return elements
+    return [UIAElementInfo(ptrs.GetElement(n), cache_enable) for n in range(ptrs.Length)]
 
 
 class UIAElementInfo(ElementInfo):
     """UI element wrapper for IUIAutomation API"""
 
-    def __init__(self, handle_or_elem = None):
+    def __init__(self, handle_or_elem = None, cache_enable = False):
         """
         Create an instance of UIAElementInfo from a handle (int or long)
         or from an IUIAutomationElement.
@@ -96,7 +91,7 @@ class UIAElementInfo(ElementInfo):
         else:
             self._element = IUIA().root
 
-        self.set_cache_strategy(False)
+        self.set_cache_strategy(cache_enable)
 
     def _get_current_class_name(self):
         """Return an actual class name of the element"""
@@ -225,10 +220,10 @@ class UIAElementInfo(ElementInfo):
         else:
             return None
 
-    def _get_elements(self, tree_scope, cond = IUIA().true_condition):
+    def _get_elements(self, tree_scope, cond = IUIA().true_condition, cache_enable = False):
         """Find all elements according to the given tree scope and conditions"""
         ptrs_array = self._element.FindAll(tree_scope, cond)
-        return elements_from_uia_array(ptrs_array)
+        return elements_from_uia_array(ptrs_array, cache_enable)
 
     def children(self, **kwargs):
         """
@@ -237,8 +232,9 @@ class UIAElementInfo(ElementInfo):
         * **kwargs** is a criteria to reduce a list by process, 
         class_name and/or title.
         """
+        cache_enable = kwargs.pop('cache_enable', False)
         cond = IUIA().build_condition(**kwargs)
-        return self._get_elements(IUIA().tree_scope["children"], cond)
+        return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
 
     def descendants(self, **kwargs):
         """
@@ -247,8 +243,9 @@ class UIAElementInfo(ElementInfo):
         * **kwargs** is a criteria to reduce a list by process, 
         class_name and/or title.
         """
+        cache_enable = kwargs.pop('cache_enable', False)
         cond = IUIA().build_condition(**kwargs)
-        return self._get_elements(IUIA().tree_scope["descendants"], cond)
+        return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
 
     @property
     def visible(self):

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -270,7 +270,7 @@ class UIAElementInfo(ElementInfo):
 
         if self.cache_enable:
             if not self.descendants_list:
-                self.descendants_list = _children()
+                self.descendants_list = _descendants()
             return self.descendants_list
         else:
             return _descendants()

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -90,7 +90,7 @@ class UIAElementInfo(ElementInfo):
                     "with integer or IUIAutomationElement instance only!")
         else:
             self._element = IUIA().root
-
+ 
         self.set_cache_strategy(cache_enable)
 
     def _get_current_class_name(self):
@@ -136,6 +136,9 @@ class UIAElementInfo(ElementInfo):
 
     def set_cache_strategy(self, cached = False):
         """Setup a cache strategy for frequently used attributes"""
+        self.cache_enable = cached
+        self.children_list = None
+        self.descendants_list = None
         if cached:
             # Refresh cached attributes
             self._cached_class_name = self._get_current_class_name()
@@ -232,9 +235,17 @@ class UIAElementInfo(ElementInfo):
         * **kwargs** is a criteria to reduce a list by process, 
         class_name and/or title.
         """
-        cache_enable = kwargs.pop('cache_enable', False)
-        cond = IUIA().build_condition(**kwargs)
-        return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
+        def _children():
+            cache_enable = kwargs.pop('cache_enable', False)
+            cond = IUIA().build_condition(**kwargs)
+            return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
+
+        if self.cache_enable:
+            if not self.children:
+                self.children_list = _children()
+            return self.children_list
+        else:
+            return _children()
 
     def descendants(self, **kwargs):
         """
@@ -243,9 +254,17 @@ class UIAElementInfo(ElementInfo):
         * **kwargs** is a criteria to reduce a list by process, 
         class_name and/or title.
         """
-        cache_enable = kwargs.pop('cache_enable', False)
-        cond = IUIA().build_condition(**kwargs)
-        return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
+        def _descendants():
+            cache_enable = kwargs.pop('cache_enable', False)
+            cond = IUIA().build_condition(**kwargs)
+            return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
+
+        if self.cache_enable:
+            if not self.descendants_list:
+                self.descendants_list = _children()
+            return self.descendants_list
+        else:
+            return _descendants()
 
     @property
     def visible(self):

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -143,7 +143,6 @@ class UIAElementInfo(ElementInfo):
             self._cached_visible = self._get_current_visible()
         return self._cached_visible
 
-
     def set_cache_strategy(self, cached = False):
         """Setup a cache strategy for frequently used attributes"""
         self.cache_enable = cached
@@ -251,7 +250,7 @@ class UIAElementInfo(ElementInfo):
             return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
 
         if self.cache_enable:
-            if not self.children:
+            if not self.children_list:
                 self.children_list = _children()
             return self.children_list
         else:

--- a/pywinauto/unittests/test_Calendar.py
+++ b/pywinauto/unittests/test_Calendar.py
@@ -134,8 +134,8 @@ class CalendarWrapperTests(unittest.TestCase):
         self.assertEquals(win32defines.MCHT_CALENDARBK, res)
 
     def test_can_determine_date_is_hit(self):
-        x = int(self.width / 1.14)
-        y = int(self.height / 1.33)
+        x = int(self.width / 1.13)
+        y = int(self.height / 1.62)
 
         res = self.calendar.hit_test(x, y)
 

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -671,6 +671,9 @@ if UIA_support:
             i.select()
             i = self.ctrl.get_item(3)  # re-get the item by a row index
             self.assertEqual(i.is_selected(), True)
+            
+            row = None
+            self.assertRaises(ValueError, self.ctrl.get_item, row)
 
         def test_cell(self):
             """Test getting a cell of the ListView control"""

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -615,9 +615,8 @@ if UIA_support:
             dlg = app.WPFSampleApplication
 
             self.app = app
-            self.dlg = dlg
-            dlg.TabControl.select(u'Views')
-            self.ctrl = dlg.ListView.WrapperObject()
+            tab_item_wrp = dlg.Views.set_focus()
+            self.ctrl = tab_item_wrp.children(class_name="ListView")[0]
 
             self.texts = [
                 (u"1", u"Tomatoe", u"Red",),

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -921,3 +921,4 @@ class WaitUntilDecoratorTests(unittest.TestCase):
         
 if __name__ == "__main__":
     unittest.main()
+


### PR DESCRIPTION
1. Add to cache UIAElementInfo.rich_text as it's extensievely used during the control name resolution.
2. Do not pre-cache UIAElementInfo properties untill implicit call to the property
3. Small optimizations find_elements and get_non_text_control_name
4. Fix UIAWrapper._select to work with own methods instead of direct access to lower level element_info functions
5. Fix EOL in test_application.py