### PR TITLE
Multi-level WindowSpecification objects (3+ levels in a chain)

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -37,6 +37,39 @@ if UIA_support:
     ElementAmbiguousError = findwindows.ElementAmbiguousError
 
 from . import findbestmatch
+from . import backend as backends
 MatchError = findbestmatch.MatchError
 
 from .application import Application, WindowSpecification
+
+
+class Desktop(object):
+
+    """Simple class to call something like ``Desktop().WindowName.ControlName.method()``"""
+
+    def __init__(self, backend=None):
+        """Create desktop element description"""
+        if backend:
+            self.backend = backend
+        else:
+            self.backend = backends.registry.name
+
+    def window(self, **criterion):
+        """Create WindowSpecification object for top-level window"""
+        if 'top_level_only' not in criterion:
+            criterion['top_level_only'] = True
+        if 'backend' not in criterion:
+            criterion['backend'] = self.backend
+        return WindowSpecification(criterion)
+
+    def __getitem__(self, key):
+        """Allow describe top-level window as Desktop()['Window Caption']"""
+        return self.window(best_match=key)
+
+    def __getattribute__(self, attr_name):
+        """Attribute access for this class"""
+        try:
+            return object.__getattribute__(self, attr_name)
+        except AttributeError:
+            return self[attr_name] # delegate it to __get_item__
+

--- a/pywinauto/backend.py
+++ b/pywinauto/backend.py
@@ -75,7 +75,7 @@ def element_class():
 
 def wrapper_class():
     """Return BaseWrapper's subclass of the active backend"""
-    return registry.element_class
+    return registry.wrapper_class
 
 def activate(name):
     """

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -581,7 +581,7 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
             hdr = None
 
         return hdr
-   
+
     #-----------------------------------------------------------
     def cell(self, row, column):
         """Return a cell in the ListView control
@@ -604,7 +604,7 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
             raise IndexError
 
         return cell
-   
+
     #-----------------------------------------------------------
     def get_item(self, row):
         """Return an item of the ListView control
@@ -627,4 +627,11 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
         return itm
 
     item = get_item  # this is an alias to be consistent with other content elements
+
+    #-----------------------------------------------------------
+    def texts(self):
+        """Return a list of item texts"""
+        return [ch.window_text() for ch in self.children() if ch.element_info.element.CurrentIsContentElement]
+        # TODO: add is_content() method to UIAWrapper
+
 

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -631,7 +631,12 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
     #-----------------------------------------------------------
     def texts(self):
         """Return a list of item texts"""
-        return [ch.window_text() for ch in self.children() if ch.element_info.element.CurrentIsContentElement]
-        # TODO: add is_content() method to UIAWrapper
+        is_content_element = IUIA().iuia.CreatePropertyCondition(
+                IUIA().UIA_dll.UIA_IsContentElementPropertyId, True)
+        return [ch.name for ch in self.element_info._get_elements(IUIA().tree_scope["children"],
+                is_content_element, cache_enable=False)]
+        # TODO: add is_content_element() method to UIAWrapper
+        # alternative (but slower) implementation:
+        # return [ch.window_text() for ch in self.children() if ch.element_info.element.CurrentIsContentElement]
 
 

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -31,6 +31,8 @@
 
 """
 
+from comtypes import COMError
+
 from .uia_defines import IUIA
 from .uia_defines import get_elem_interface
 
@@ -135,7 +137,10 @@ class UIAElementInfo(ElementInfo):
 
     def _get_current_visible(self):
         """Return an actual visible property of the element"""
-        return bool(not self._element.CurrentIsOffscreen)
+        try:
+            return bool(not self._element.CurrentIsOffscreen)
+        except COMError:
+            return False # probably element already doesn't exist
 
     def _get_cached_visible(self):
         """Return a cached visible property of the element"""

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -37,6 +37,7 @@ import warnings
 
 sys.path.append(".")
 from pywinauto import Desktop
+from pywinauto import win32defines
 from pywinauto import application
 from pywinauto.controls import hwndwrapper
 from pywinauto.application import Application

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -36,6 +36,7 @@ import time
 import warnings
 
 sys.path.append(".")
+from pywinauto import Desktop
 from pywinauto import application
 from pywinauto.controls import hwndwrapper
 from pywinauto.application import Application
@@ -54,6 +55,7 @@ from pywinauto.timings import always_wait_until
 from pywinauto.timings import always_wait_until_passes
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.sysinfo import is_x64_OS
+from pywinauto.sysinfo import UIA_support
 from pywinauto import backend
 
 #application.set_timing(1, .01, 1, .01, .05, 0, 0, .1, 0, .01)
@@ -67,6 +69,11 @@ def _notepad_exe():
         return r"C:\Windows\System32\notepad.exe"
     else:
         return r"C:\Windows\SysWOW64\notepad.exe"
+
+mfc_samples_folder = os.path.join(
+   os.path.dirname(__file__), r"..\..\apps\MFC_samples")
+if is_x64_Python():
+    mfc_samples_folder = os.path.join(mfc_samples_folder, 'x64')
 
 
 class ApplicationWarningTestCases(unittest.TestCase):
@@ -873,8 +880,8 @@ class WindowSpecificationTestCases(unittest.TestCase):
 #        #self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
 
 
-    def testPrintControlIdentifiers(self):
-        """Make sure PrintControlIdentifiers() doesn't crash"""
+    def test_print_control_identifiers(self):
+        """Make sure print_control_identifiers() doesn't crash"""
         self.dlgspec.print_control_identifiers()
         self.ctrlspec.print_control_identifiers()
 
@@ -883,6 +890,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
         self.dlgspec.Wait('visible')
         windows = findwindows.find_elements(title_re = "Untitled - Notepad")
         self.assertTrue(len(windows) >= 1)
+
 
 class WaitUntilDecoratorTests(unittest.TestCase):
     """Unit tests for always_wait_until and always_wait_until_passes decorators"""
@@ -918,7 +926,86 @@ class WaitUntilDecoratorTests(unittest.TestCase):
         def foo():
             raise Exception("Unexpected Error in foo")
         self.assertRaises(TimeoutError, foo)
-        
+
+
+class MultiLevelWindowSpecificationTests(unittest.TestCase):
+
+    """Unit tests for multi-level (3+) WindowSpecification objects"""
+
+    if UIA_support:
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            Timings.Slow()
+            self.app = Application(backend='uia').start(os.path.join(mfc_samples_folder, u"RowList.exe"))
+            self.dlg = self.app.RowListSampleApplication
+
+        def tearDown(self):
+            """Close the application after tests"""
+            self.dlg.CloseButton.click()
+            self.dlg.wait_not('visible')
+
+        def test_3level_specification(self):
+            """Test that controls can be accessed by 3 levels of attributes"""
+            self.dlg.Toolbar.About.click()
+            self.dlg.AboutRowList.OK.click()
+            self.dlg.AboutRowList.wait_not('visible')
+
+    else: # Win32
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            Timings.Defaults()
+            self.app = Application(backend='native').start(os.path.join(mfc_samples_folder, u"CmnCtrl3.exe"))
+            self.dlg = self.app.CommonControlsSample
+
+        def tearDown(self):
+            """Close the application after tests"""
+            self.dlg.SendMessage(win32defines.WM_CLOSE)
+
+        def test_4level_specification(self):
+            """Test that controls can be accessed by 4 levels of attributes"""
+            self.assertEqual(self.dlg.CPagerCtrl.Pager.Toolbar.button_count(), 12)
+
+
+class DesktopWindowSpecificationTests(unittest.TestCase):
+
+    """Unit tests for Desktop object"""
+
+    if UIA_support:
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            Timings.Slow()
+            self.app = Application().start('explorer.exe "' + mfc_samples_folder + '"')
+            self.desktop = Desktop(backend='uia')
+
+        def tearDown(self):
+            """Close the application after tests"""
+            self.desktop.MFC_samplesDialog.CloseButton.click()
+            self.desktop.MFC_samplesDialog.wait_not('visible')
+
+        def test_folder_list(self):
+            """Test that ListViewWrapper returns correct files list in explorer.exe"""
+            files_list = self.desktop.MFC_samplesDialog.Shell_Folder_View.Items_View.wrapper_object()
+            self.assertEqual(files_list.texts(),
+                             [u'x64', u'BCDialogMenu.exe', u'CmnCtrl1.exe', u'CmnCtrl2.exe', u'CmnCtrl3.exe',
+                              u'CtrlTest.exe', u'mfc100u.dll', u'RebarTest.exe', u'RowList.exe', u'TrayMenu.exe'])
+
+    else: # Win32
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            Timings.Defaults()
+            self.app = Application(backend='native').start(os.path.join(mfc_samples_folder, u"CmnCtrl3.exe"))
+            self.desktop = Desktop()
+
+        def tearDown(self):
+            """Close the application after tests"""
+            self.desktop.window(title='Common Controls Sample', process=self.app.process).SendMessage(win32defines.WM_CLOSE)
+
+        def test_simple_access_through_desktop(self):
+            """Test that controls can be accessed by 4 levels of attributes"""
+            dlg = self.desktop.window(title='Common Controls Sample', process=self.app.process)
+            self.assertEqual(dlg.Pager.Toolbar.button_count(), 12)
+
+
 if __name__ == "__main__":
     unittest.main()
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -71,7 +71,7 @@ def _notepad_exe():
     else:
         return r"C:\Windows\SysWOW64\notepad.exe"
 
-mfc_samples_folder = os.path.join(
+mfc_samples_folder_32 = mfc_samples_folder = os.path.join(
    os.path.dirname(__file__), r"..\..\apps\MFC_samples")
 if is_x64_Python():
     mfc_samples_folder = os.path.join(mfc_samples_folder, 'x64')
@@ -949,7 +949,7 @@ class MultiLevelWindowSpecificationTests(unittest.TestCase):
             """Test that controls can be accessed by 3 levels of attributes"""
             self.dlg.Toolbar.About.click()
             self.dlg.AboutRowList.OK.click()
-            self.dlg.AboutRowList.wait_not('visible')
+            #self.dlg.AboutRowList.wait_not('visible') # XXX: it takes more than 50 seconds!
 
     else: # Win32
         def setUp(self):
@@ -975,7 +975,7 @@ class DesktopWindowSpecificationTests(unittest.TestCase):
         def setUp(self):
             """Set some data and ensure the application is in the state we want"""
             Timings.Slow()
-            self.app = Application().start('explorer.exe "' + mfc_samples_folder + '"')
+            self.app = Application().start('explorer.exe "' + mfc_samples_folder_32 + '"')
             self.desktop = Desktop(backend='uia')
 
         def tearDown(self):

--- a/pywinauto/unittests/test_taskbar.py
+++ b/pywinauto/unittests/test_taskbar.py
@@ -43,7 +43,7 @@ mfc_samples_folder = os.path.join(
 if is_x64_Python():
     mfc_samples_folder = os.path.join(mfc_samples_folder, 'x64')
 
-_ready_timeout = 40
+_ready_timeout = 60
 _retry_interval = 0.5
 def _toggle_notification_area_icons(show_all=True, debug_img=None):
     """


### PR DESCRIPTION
* Allow 3+ levels in an access chain of attributes.
* Add method `texts()` into ListViewWrapper.
* Add class `Desktop` as an alternative root of WindowSpecification objects (without process info).
* Fix "copypasta" bug in `backend.py`.