### PR TITLE
UIA: more methods for ListViewWrapper

### DIFF
--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -546,12 +546,12 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
 
     #-----------------------------------------------------------
     def is_checked(self):
-        """Return True if the ListItem is checked"""
-        # Only items supporting Toggle pattern should answer
-        try:
-            res = (self.iface_toggle.ToggleState_On == toggle_state_on)
-        except NoPatternInterfaceError:
-            res = False
+        """Return True if the ListItem is checked
+        
+        Only items supporting Toggle pattern should answer.
+        Raise NoPatternInterfaceError if the pattern is not supported
+        """
+        res = (self.iface_toggle.ToggleState_On == toggle_state_on)
         return res
 
 

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -661,7 +661,8 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
         """Return the bounding rectangle of the list view item
         
         The interface is kept mostly for a backward compatibility
-        with the native ListViewWrapper interface"""
+        with the native ListViewWrapper interface
+        """
         itm = self.get_item(item_index)
         return itm.rectangle()
 

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -628,3 +628,16 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
 
     item = get_item  # this is an alias to be consistent with other content elements
 
+    #-----------------------------------------------------------
+    def get_selected_count(self):
+        """Return the number of selected items"""
+        # The call can be quite expensieve as we retrieve all 
+        # the selected items in order to count them
+        selection = self.get_selection()
+        if selection:
+            return len(selection)
+        else:
+            return 0
+
+
+

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -641,14 +641,22 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
           with the text of a cell in the row you want returned.
         """
         # Verify arguments
-        if isinstance(row, six.text_type):
+        # In py27 six.text_type is unicode so we check for str as well
+        if isinstance(row, six.text_type) or isinstance(row, str):
             # Look for a cell with the text, return the first found item
-            itm = self.descendants(title = row)[0].parent()
+            itm = self.descendants(title = row)[0]
+            
         elif isinstance(row, six.integer_types):
             # Get the item by a row index of its first cell
-            itm = self.cell(row, 0).parent()
+            itm = self.cell(row, 0)
         else:
             raise ValueError
+
+        # Applications like explorer.exe usually return ListItem
+        # directly while other apps can return only a cell.
+        # In this case we need to take its parent - the whole row.
+        if not isinstance(itm, ListItemWrapper):
+            itm = itm.parent()
 
         # Give to the item a pointer on its container
         itm.container = self

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -592,6 +592,23 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
             hdr = None
 
         return hdr
+
+    #-----------------------------------------------------------
+    def get_column(self, col_index):
+        """Get the information for a column of the ListView"""
+        col = None
+        try:
+            col = self.columns()[col_index]
+        except comtypes.COMError:
+            raise IndexError
+        return col
+
+    #-----------------------------------------------------------
+    def columns(self):
+        """Get the information on the columns of the ListView"""
+        arr = self.iface_table.GetCurrentColumnHeaders()
+        cols = uia_element_info.elements_from_uia_array(arr)
+        return [uiawrapper.UIAWrapper(e) for e in cols]
    
     #-----------------------------------------------------------
     def cell(self, row, column):
@@ -666,7 +683,7 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
         props = super(ListViewWrapper, self).writable_props
         props.extend(['column_count',
                       'item_count',
-                      #'columns',
+                      'columns',
                       #'items',
                       ])
         return props

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -360,7 +360,7 @@ class EditWrapper(uiawrapper.UIAWrapper):
 
         # return this control so that actions can be chained.
         return self
-    # set SetText as an alias to set_edit_text
+    # set set_text as an alias to set_edit_text
     set_text = set_edit_text
 
     #-----------------------------------------------------------
@@ -640,6 +640,15 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
     item = get_item  # this is an alias to be consistent with other content elements
 
     #-----------------------------------------------------------
+    def get_item_rect(self, item_index):
+        """Return the bounding rectangle of the list view item
+        
+        The interface is kept mostly for a backward compatibility
+        with the native ListViewWrapper interface"""
+        itm = self.get_item(item_index)
+        return itm.rectangle()
+
+    #-----------------------------------------------------------
     def get_selected_count(self):
         """Return the number of selected items"""
         # The call can be quite expensieve as we retrieve all 
@@ -649,6 +658,18 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
             return len(selection)
         else:
             return 0
+
+    #-----------------------------------------------------------
+    @property
+    def writable_props(self):
+        """Extend default properties list."""
+        props = super(ListViewWrapper, self).writable_props
+        props.extend(['column_count',
+                      'item_count',
+                      #'columns',
+                      #'items',
+                      ])
+        return props
 
 
 

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -40,6 +40,7 @@ from .. import uia_element_info
 from . import uiawrapper
 from ..uia_defines import IUIA
 from ..uia_defines import NoPatternInterfaceError
+from ..uia_defines import toggle_state_on
 
 
 #====================================================================
@@ -531,7 +532,7 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
         # It must be set by a container wrapper producing the item.
         # Notice that the self.parent property isn't the same 
         # because it results in a different instance of a wrapper.
-        self.container = None
+        self.container = container
 
     #-----------------------------------------------------------
     def select(self):
@@ -542,6 +543,16 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
     def is_selected(self):
         """Return True if the ListItem is selected"""
         return self.iface_selection_item.CurrentIsSelected
+
+    #-----------------------------------------------------------
+    def is_checked(self):
+        """Return True if the ListItem is checked"""
+        # Only items supporting Toggle pattern should answer
+        try:
+            res = (self.iface_toggle.ToggleState_On == toggle_state_on)
+        except NoPatternInterfaceError:
+            res = False
+        return res
 
 
 #====================================================================

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -57,11 +57,6 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         ".*Button",
         r"WindowsForms\d*\.BUTTON\..*",
         ".*CheckBox", ]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_ButtonControlTypeId,
-            IUIA().UIA_dll.UIA_CheckBoxControlTypeId,
-            IUIA().UIA_dll.UIA_RadioButtonControlTypeId]
     can_be_label = True
 
     #-----------------------------------------------------------
@@ -275,9 +270,6 @@ class ComboBoxWrapper(hwndwrapper.HwndWrapper):
         "ComboBox",
         "WindowsForms\d*\.COMBOBOX\..*",
         ".*ComboBox", ]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_ComboBoxControlTypeId]
     has_title = False
 
     #-----------------------------------------------------------
@@ -447,9 +439,6 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
         "ListBox",
         r"WindowsForms\d*\.LISTBOX\..*",
         ".*ListBox", ]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_ListControlTypeId]
     has_title = False
 
     #-----------------------------------------------------------
@@ -667,9 +656,6 @@ class EditWrapper(hwndwrapper.HwndWrapper):
         "ThunderTextBox",
         "ThunderRT6TextBox",
         ]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_EditControlTypeId]
     has_title = False
 
     #-----------------------------------------------------------
@@ -878,10 +864,6 @@ class StaticWrapper(hwndwrapper.HwndWrapper):
         r"WindowsForms\d*\.STATIC\..*",
         "TPanel",
         ".*StaticText"]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_ImageControlTypeId,
-            IUIA().UIA_dll.UIA_TextControlTypeId]
     can_be_label = True
 
     def __init__(self, hwnd):
@@ -916,9 +898,6 @@ class DialogWrapper(hwndwrapper.HwndWrapper):
 
     friendlyclassname = "Dialog"
     #windowclasses = ["#32770", ]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_WindowControlTypeId]
     can_be_label = True
 
     #-----------------------------------------------------------
@@ -1092,9 +1071,6 @@ class PopupMenuWrapper(hwndwrapper.HwndWrapper):
 
     friendlyclassname = "PopupMenu"
     windowclasses = ["#32768", ]
-    if sysinfo.UIA_support:
-        controltypes = [
-            IUIA().UIA_dll.UIA_MenuControlTypeId]
     has_title = False
 
     #-----------------------------------------------------------

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -44,9 +44,6 @@ from .. import controlproperties
 
 from ..timings import Timings
 
-if sysinfo.UIA_support:
-    from ..uia_defines import IUIA
-
 #====================================================================
 class ButtonWrapper(hwndwrapper.HwndWrapper):
     "Wrap a windows Button control"

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -679,6 +679,8 @@ if UIA_support:
             self.assertEqual(i.is_selected(), True)
             cnt = self.ctrl.get_selected_count()
             self.assertEqual(cnt, 1)
+            rect = self.ctrl.get_item_rect(row)
+            self.assertEqual(rect, i.rectangle())
             
             # Select by text
             row = '3'

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -666,20 +666,24 @@ if UIA_support:
 
         def test_select(self):
             """Test selecting an item of the ListView control"""
+            # Verify get_selected_count
+            cnt = self.ctrl.get_selected_count()
+            self.assertEqual(cnt, 0)
+
             # Select by an index
             row = 1
             i = self.ctrl.get_item(row)
             self.assertEqual(i.is_selected(), False)
             i.select()
             self.assertEqual(i.is_selected(), True)
-            i.select()  # de-select it back
+            cnt = self.ctrl.get_selected_count()
+            self.assertEqual(cnt, 1)
             
             # Select by text
             row = '3'
             i = self.ctrl.get_item(row)
             i.select()
             self.assertEqual(i.is_selected(), True)
-            i.select()  # de-select it back
             row = 'White'
             i = self.ctrl.get_item(row)
             i.select()

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -660,7 +660,7 @@ if UIA_support:
             num_cols = self.ctrl.column_count()
             self.assertEqual(num_cols, len(self.texts[0]))
             col = self.ctrl.get_column(1)
-            col.texts()[0] == u'Name'
+            self.assertEqual(col.texts()[0], u'Name')
             self.assertRaises(IndexError, self.ctrl.get_column, num_cols + 1)
 
         def test_get_header_control(self):
@@ -671,14 +671,13 @@ if UIA_support:
         def test_select(self):
             """Test selecting an item of the ListView control"""
             # Verify get_selected_count
-            cnt = self.ctrl.get_selected_count()
-            self.assertEqual(cnt, 0)
+            self.assertEqual(self.ctrl.get_selected_count(), 0)
 
             # Select by an index
             row = 1
             i = self.ctrl.get_item(row)
             self.assertEqual(i.is_selected(), False)
-            self.assertEqual(i.is_checked(), False)
+            self.assertRaises(uia_defs.NoPatternInterfaceError, i.is_checked)
             i.select()
             self.assertEqual(i.is_selected(), True)
             cnt = self.ctrl.get_selected_count()

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -566,7 +566,7 @@ if UIA_support:
             self.app = app
             self.dlg = app.WPFSampleApplication
 
-            self.slider = self.dlg.window_(class_name="Slider").WrapperObject()
+            self.slider = self.dlg.child_window(class_name="Slider").WrapperObject()
 
         def tearDown(self):
             """Close the application after tests"""

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -674,6 +674,7 @@ if UIA_support:
             row = 1
             i = self.ctrl.get_item(row)
             self.assertEqual(i.is_selected(), False)
+            self.assertEqual(i.is_checked(), False)
             i.select()
             self.assertEqual(i.is_selected(), True)
             cnt = self.ctrl.get_selected_count()

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -657,7 +657,11 @@ if UIA_support:
 
         def test_column_count(self):
             """Test the columns count in the ListView control"""
-            self.assertEqual(self.ctrl.column_count(), len(self.texts[0]))
+            num_cols = self.ctrl.column_count()
+            self.assertEqual(num_cols, len(self.texts[0]))
+            col = self.ctrl.get_column(1)
+            col.texts()[0] == u'Name'
+            self.assertRaises(IndexError, self.ctrl.get_column, num_cols + 1)
 
         def test_get_header_control(self):
             """Test getting a Header control of the ListView control"""


### PR DESCRIPTION
More methods for ListViewWrapper: get_selected_count/get_item_rect/is_checked/columns/get_column
Remove UIA control types from win32 control wrappers
