### PR TITLE
UIA: documetation fixes

### DIFF
--- a/docs/code/code.txt
+++ b/docs/code/code.txt
@@ -26,6 +26,8 @@ Controls Reference
    pywinauto.controls.HwndWrapper.txt
    pywinauto.controls.menuwrapper.txt
    pywinauto.controls.win32_controls.txt
+   pywinauto.controls.uiawrapper.txt
+   pywinauto.controls.uia_controls.txt
 
 Sendkeys
 ==============================

--- a/docs/code/pywinauto.backend.txt
+++ b/docs/code/pywinauto.backend.txt
@@ -1,0 +1,6 @@
+pywinauto.backend
+-----------------
+ .. automodule:: pywinauto.backend
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.base_wrapper.txt
+++ b/docs/code/pywinauto.base_wrapper.txt
@@ -1,0 +1,6 @@
+pywinauto.base_wrapper
+----------------------
+ .. automodule:: pywinauto.base_wrapper
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.controls.uia_controls.txt
+++ b/docs/code/pywinauto.controls.uia_controls.txt
@@ -1,0 +1,6 @@
+pywinauto.controls.uia_controls
+-------------------------------
+ .. automodule:: pywinauto.controls.uia_controls
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.controls.uiawrapper.txt
+++ b/docs/code/pywinauto.controls.uiawrapper.txt
@@ -1,0 +1,6 @@
+pywinauto.controls.uiawrapper
+-----------------------------
+ .. automodule:: pywinauto.controls.uiawrapper
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.element_info.txt
+++ b/docs/code/pywinauto.element_info.txt
@@ -1,0 +1,6 @@
+pywinauto.element_info
+----------------------
+ .. automodule:: pywinauto.element_info
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.hooks.txt
+++ b/docs/code/pywinauto.hooks.txt
@@ -1,0 +1,6 @@
+pywinauto.hooks
+---------------
+ .. automodule:: pywinauto.hooks
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.keyboard.txt
+++ b/docs/code/pywinauto.keyboard.txt
@@ -1,0 +1,6 @@
+pywinauto.keyboard
+------------------
+ .. automodule:: pywinauto.keyboard
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.mouse.txt
+++ b/docs/code/pywinauto.mouse.txt
@@ -1,0 +1,6 @@
+pywinauto.mouse
+---------------
+ .. automodule:: pywinauto.mouse
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.native_element_info.txt
+++ b/docs/code/pywinauto.native_element_info.txt
@@ -1,0 +1,6 @@
+pywinauto.native_element_info
+-----------------------------
+ .. automodule:: pywinauto.native_element_info
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.six.txt
+++ b/docs/code/pywinauto.six.txt
@@ -1,6 +1,0 @@
-pywinauto.six
--------------
- .. automodule:: pywinauto.six
-    :members:
-    :undoc-members:
-

--- a/docs/code/pywinauto.uia_defines.txt
+++ b/docs/code/pywinauto.uia_defines.txt
@@ -1,0 +1,6 @@
+pywinauto.uia_defines
+---------------------
+ .. automodule:: pywinauto.uia_defines
+    :members:
+    :undoc-members:
+

--- a/docs/code/pywinauto.uia_element_info.txt
+++ b/docs/code/pywinauto.uia_element_info.txt
@@ -1,0 +1,6 @@
+pywinauto.uia_element_info
+--------------------------
+ .. automodule:: pywinauto.uia_element_info
+    :members:
+    :undoc-members:
+

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -47,6 +47,7 @@ if sys.platform.startswith('linux'):
             "win32functions",
             "win32clipboard",
             'win32structures',
+            'comtypes',
             ]:
 
         sys.modules[mod_name] = mock.MagicMock()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ if sys.platform.startswith('linux'):
             "win32clipboard",
             'win32structures',
             'comtypes',
+            'comtypes.client',
             ]:
 
         sys.modules[mod_name] = mock.MagicMock()

--- a/pywinauto/backend.py
+++ b/pywinauto/backend.py
@@ -66,7 +66,7 @@ class BackendsRegistry(object):
 
     @property
     def element_class(self):
-        """ElementInfo's subclass of the active backend"""
+        """Return :py:class:`.element_info.ElementInfo`'s subclass of the active backend"""
         return self.active_backend.element_info_class
 
     @property
@@ -81,7 +81,7 @@ def name():
     return registry.name
 
 def element_class():
-    """Return ElementInfo's subclass of the active backend"""
+    """Return :py:class:`.element_info.ElementInfo`'s subclass of the active backend"""
     return registry.element_class
 
 def wrapper_class():
@@ -90,10 +90,10 @@ def wrapper_class():
 
 def activate(name):
     """
-    Set active back-end by name
+    Set active backend by name
 
-    Possible values of **active_name** are "win32", "uia" or
-    other name registered by the **register** function.
+    Possible values of **name** are "win32", "uia" or
+    other name registered by the :py:func:`register` function.
     """
     if name not in registry.backends:
         raise ValueError('Back-end "{backend}" is not registered!'.format(backend=name))
@@ -101,5 +101,5 @@ def activate(name):
     registry.active_backend = registry.backends[name]
 
 def register(name, element_info_class, generic_wrapper_class):
-    """Register new back-end"""
+    """Register a new backend"""
     registry.backends[name] = BackEnd(name, element_info_class, generic_wrapper_class)

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -109,7 +109,7 @@ class HwndMeta(BaseMeta):
     def __init__(cls, name, bases, attrs):
         """
         Register the class names
-        
+
         Both the regular expression or the classes directly are registered.
         """
         BaseMeta.__init__(cls, name, bases, attrs)
@@ -172,16 +172,16 @@ class HwndWrapper(BaseWrapper):
 
     handle = None
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def __new__(cls, element):
         """Construct the control wrapper"""
         return super(HwndWrapper, cls)._create_wrapper(cls, element, HwndWrapper)
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def __init__(self, element_info):
         """
         Initialize the control
-        
+
         * **element_info** is either a valid NativeElementInfo or it can be an
           instance or subclass of HwndWrapper.
         If the handle is not valid then an InvalidWindowHandle error
@@ -216,7 +216,7 @@ class HwndWrapper(BaseWrapper):
                       ])
         return props
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def style(self):
         """
         Returns the style of window
@@ -231,7 +231,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Style = style
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def exstyle(self):
         """
         Returns the Extended style of window
@@ -246,7 +246,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     ExStyle = exstyle
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def user_data(self):
         """
         Extra data associted with the window
@@ -259,21 +259,21 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     UserData = user_data
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def context_help_id(self):
         """Return the Context Help ID of the window"""
         return handleprops.contexthelpid(self)
     # Non PEP-8 alias
     ContextHelpID = context_help_id
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_active(self):
         """Whether the window is active or not"""
         return self.top_level_parent() == self.get_active()
     # Non PEP-8 alias
     IsActive = is_active
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_unicode(self):
         """
         Whether the window is unicode or not
@@ -285,7 +285,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     IsUnicode = is_unicode
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def client_rect(self):
         """
         Returns the client rectangle of window
@@ -303,7 +303,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     ClientRect = client_rect
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     #def client_to_screen(self, client_point):
     #    """Maps point from client to screen coordinates"""
     #    point = win32structures.POINT()
@@ -319,7 +319,7 @@ class HwndWrapper(BaseWrapper):
     #    # coords param is always expected to be tuple
     #    return point.x, point.y
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def font(self):
         """
         Return the font of the window
@@ -334,21 +334,21 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Font = font
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def has_style(self, style):
         """Return True if the control has the specified style"""
         return handleprops.has_style(self, style)
     # Non PEP-8 alias
     HasStyle = has_style
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def has_exstyle(self, exstyle):
         """Return True if the control has the specified extended style"""
         return handleprops.has_exstyle(self, exstyle)
     # Non PEP-8 alias
     HasExStyle = has_exstyle
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_dialog(self):
         """Return true if the control is a top level window"""
         if not ("isdialog" in self._cache.keys()):
@@ -356,7 +356,7 @@ class HwndWrapper(BaseWrapper):
 
         return self._cache['isdialog']
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def client_rects(self):
         """
         Return the client rect for each item in this control
@@ -376,7 +376,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     ClientRects = client_rects
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def fonts(self):
         """
         Return the font for each item in this control
@@ -395,19 +395,19 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Fonts = fonts
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def send_command(self, commandID):
         return self.send_message(win32defines.WM_COMMAND, commandID)
     # Non PEP-8 alias
     SendCommand = send_command
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def post_command(self, commandID):
         return self.post_message(win32defines.WM_COMMAND, commandID)
     # Non PEP-8 alias
     PostCommand = post_command
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     #def notify(self, code):
     #    "Send a notification to the parent (not tested yet)"
 
@@ -434,7 +434,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     #Notify = notify
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def send_message(self, message, wparam = 0, lparam = 0):
         """Send a message to the control and wait for it to return"""
         #return win32functions.SendMessage(self, message, wparam, lparam)
@@ -510,7 +510,7 @@ class HwndWrapper(BaseWrapper):
 
             # time.sleep(Timings.after_sendkeys_key_wait)
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def send_message_timeout(
         self,
         message,
@@ -551,7 +551,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     SendMessageTimeout = send_message_timeout
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def post_message(self, message, wparam = 0, lparam = 0):
         """Post a message to the control message queue and return"""
         return win32functions.PostMessage(self, message, wparam, lparam)
@@ -559,7 +559,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     PostMessage = post_message
 
-#    #-----------------------------------------------------------
+#    # -----------------------------------------------------------
 #    def notify_menu_select(self, menu_id):
 #        """Notify the dialog that one of it's menu items was selected
 #
@@ -581,7 +581,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     #NotifyMenuSelect = notify_menu_select
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def notify_parent(self, message, controlID = None):
         """Send the notification message to parent of this control"""
         if controlID is None:
@@ -594,12 +594,12 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     NotifyParent = notify_parent
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def __hash__(self):
         """Returns the hash value of the handle"""
         return hash(self.handle)
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def click(
         self, button = "left", pressed = "", coords = (0, 0), double = False, absolute = False):
         """
@@ -619,7 +619,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Click = click
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def close_click(
         self, button = "left", pressed = "", coords = (0, 0), double = False):
         """
@@ -659,7 +659,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     CloseClick = close_click
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def close_alt_f4(self):
         """Close the window by pressing Alt+F4 keys."""
 
@@ -671,7 +671,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     CloseAltF4 = close_alt_f4
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def double_click(
         self, button = "left", pressed = "", coords = (0, 0)):
         "Perform a double click action"
@@ -680,7 +680,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     DoubleClick = double_click
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def right_click(
         self, pressed = "", coords = (0, 0)):
         "Perform a right click action"
@@ -692,7 +692,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     RightClick = right_click
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def press_mouse(self, button ="left", coords = (0, 0), pressed =""):
         "Press the mouse button"
         #flags, click_point = _calc_flags_and_coords(pressed, coords)
@@ -702,7 +702,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     PressMouse = press_mouse
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def release_mouse(self, button ="left", coords = (0, 0), pressed =""):
         "Release the mouse button"
         #flags, click_point = _calc_flags_and_coords(pressed, coords)
@@ -711,7 +711,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     ReleaseMouse = release_mouse
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def move_mouse(self, coords = (0, 0), pressed ="", absolute = False):
         "Move the mouse by WM_MOUSEMOVE"
 
@@ -725,7 +725,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     MoveMouse = move_mouse
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def drag_mouse(self, button ="left",
                    press_coords = (0, 0),
                    release_coords = (0, 0),
@@ -754,7 +754,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     DragMouse = drag_mouse
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def set_window_text(self, text, append = False):
         "Set the text of the window"
 
@@ -772,7 +772,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     SetWindowText = set_window_text
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def debug_message(self, text):
         "Write some debug text over the window"
 
@@ -804,7 +804,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     DebugMessage = debug_message
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def set_transparency(self, alpha = 120):
         "Set the window transparency from 0 to 255 by alpha attribute"
         if not (0 <= alpha <= 255):
@@ -815,7 +815,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     SetTransparency = set_transparency
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def popup_window(self):
         """Return owned enabled Popup window wrapper if shown.
 
@@ -831,7 +831,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     PopupWindow = popup_window
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def owner(self):
         """Return the owner window for the window if it exists
 
@@ -844,7 +844,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Owner = owner
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
 #    def context_menu_select(self, path, x = None, y = None):
 #        "TODO context_menu_select Not Implemented"
 #        pass
@@ -853,7 +853,7 @@ class HwndWrapper(BaseWrapper):
 #    # Non PEP-8 alias
 #    ContextMenuSelect = context_menu_select
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def _menu_handle(self):
         "Simple Overridable method to get the menu handle"
         #return win32functions.GetMenu(self) # vvryabov: it doesn't work in 64-bit Python for x64 applications
@@ -864,7 +864,7 @@ class HwndWrapper(BaseWrapper):
             is_main_menu = False
         return (hMenu, is_main_menu) #win32gui.GetMenu(self.handle)
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def menu(self):
         "Return the menu of the control"
         hMenu, is_main_menu = self._menu_handle()
@@ -874,7 +874,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Menu = menu
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def menu_item(self, path, exact = False):
         """Return the menu item specified by path
 
@@ -902,7 +902,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     MenuItem = menu_item
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def menu_items(self):
         """Return the menu items for the dialog
 
@@ -920,7 +920,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     MenuItems = menu_items
 
-#    #-----------------------------------------------------------
+#    # -----------------------------------------------------------
 #    def menu_click(self, path):
 #        "Select the MenuItem specifed in path"
 #
@@ -943,9 +943,13 @@ class HwndWrapper(BaseWrapper):
 #    # Non PEP-8 alias
 #    MenuClick = menu_click
 
-    #-----------------------------------------------------------
-    def menu_select(self, path, exact = False, ):
-        "Select the menuitem specified in path"
+    # -----------------------------------------------------------
+    def menu_select(self, path, exact=False, ):
+        """Find a menu item specified by the path
+
+        The full path syntax is specified in:
+        :py:meth:`pywinauto.menuwrapper.Menu.get_menu_path`
+        """
 
         self.verify_actionable()
 
@@ -953,7 +957,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     MenuSelect = menu_select
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def move_window(
         self,
         x = None,
@@ -1014,7 +1018,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     MoveWindow = move_window
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def close(self, wait_time = 0):
         """Close the window
 
@@ -1051,7 +1055,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Close = close
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def maximize(self):
         """Maximize the window"""
         win32functions.ShowWindow(self, win32defines.SW_MAXIMIZE)
@@ -1059,7 +1063,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Maximize = maximize
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def minimize(self):
         """Minimize the window"""
         win32functions.ShowWindow(self, win32defines.SW_MINIMIZE)
@@ -1067,7 +1071,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Minimize = minimize
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def restore(self):
         """Restore the window"""
 
@@ -1080,7 +1084,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Restore = restore
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def get_show_state(self):
         """Get the show state and Maximized/minimzed/restored state
 
@@ -1106,7 +1110,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     GetShowState = get_show_state
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def get_active(self):
         """
         Return a handle to the active window within the process
@@ -1129,7 +1133,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     GetActive = get_active
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def get_focus(self):
         """Return the control in the process of this window that has the Focus
         """
@@ -1148,7 +1152,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     GetFocus = get_focus
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def set_focus(self):
         """
         Set the focus to this control.
@@ -1234,7 +1238,7 @@ class HwndWrapper(BaseWrapper):
 
         return self
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def set_application_data(self, appdata):
         """Application data is data from a previous run of the software
 
@@ -1268,7 +1272,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     SetApplicationData = set_application_data
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def scroll(self, direction, amount, count = 1, retry_interval = None):
         """Ask the control to scroll itself
 
@@ -1299,7 +1303,7 @@ class HwndWrapper(BaseWrapper):
     # Non PEP-8 alias
     Scroll = scroll
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def get_toolbar(self):
         """Get the first child toolbar if it exists"""
 
@@ -1310,7 +1314,7 @@ class HwndWrapper(BaseWrapper):
         return None
     # Non PEP-8 alias
     GetToolbar = get_toolbar
-    
+
     # Non PEP-8 aliases for BaseWrapper methods
     # We keep them for the backward compatibility in legacy scripts
     ClickInput = BaseWrapper.click_input

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -948,7 +948,7 @@ class HwndWrapper(BaseWrapper):
         """Find a menu item specified by the path
 
         The full path syntax is specified in:
-        :py:meth:`pywinauto.menuwrapper.Menu.get_menu_path`
+        :py:meth:`.controls.menuwrapper.Menu.get_menu_path`
         """
 
         self.verify_actionable()

--- a/pywinauto/controls/menuwrapper.py
+++ b/pywinauto/controls/menuwrapper.py
@@ -45,6 +45,7 @@ import win32gui_struct
 import locale
 import six
 
+from functools import wraps
 from .. import win32structures
 from .. import win32functions
 from .. import win32defines
@@ -87,7 +88,7 @@ class MenuInaccessible(RuntimeError):
 
 def ensure_accessible(method):
     """Decorator for Menu instance methods"""
-
+    @wraps(method)
     def check(instance, *args, **kwargs):
         """Check if the instance is accessible"""
 
@@ -505,19 +506,22 @@ class Menu(object):
     @ensure_accessible
     def get_menu_path(self, path, path_items=None, appdata=None, exact=False):
         """
-        Walk the items in this menu to find the item specified by path
+        Walk the items in this menu to find the item specified by a path
 
-        The path is specified by a list of items separated by '->' each Item
-        can be either a string (can include spaces) e.g. "Save As" or the zero
-        based index of the item to return prefaced by # e.g. #1.
+        The path is specified by a list of items separated by '->'. Each item
+        can be either a string (can include spaces) e.g. "Save As" or a zero
+        based index of the item to return prefaced by # e.g. #1 or an ID of
+        the item prefaced by $ specifier.
 
-        These can be mixed as necessary. For Example:
-            "#0 -> Save As",
-            "$23453 -> Save As",
-            "Tools -> #0 -> Configure"
+        These can be mixed as necessary. For example:
+            - "#0 -> Save As",
+            - "$23453 -> Save As",
+            - "Tools -> #0 -> Configure"
 
         Text matching is done using a 'best match' fuzzy algorithm, so you don't
         have to add all punctuation, ellipses, etc.
+        ID matching is performed against wID field of MENUITEMINFO structure
+        (https://msdn.microsoft.com/en-us/library/windows/desktop/ms647578(v=vs.85).aspx)
         """
 
         if path_items is None:

--- a/pywinauto/controls/menuwrapper.py
+++ b/pywinauto/controls/menuwrapper.py
@@ -503,7 +503,7 @@ class Menu(object):
     GetProperties = get_properties
 
     @ensure_accessible
-    def get_menu_path(self, path, path_items = None, appdata = None, exact=False):
+    def get_menu_path(self, path, path_items=None, appdata=None, exact=False):
         """
         Walk the items in this menu to find the item specified by path
 
@@ -524,7 +524,7 @@ class Menu(object):
             path_items = []
 
         # get the first part (and remainder)
-        parts = path.split("->", 1)
+        parts = [p.strip() for p in path.split("->", 1)]
         current_part = parts[0]
 
         if current_part.startswith("#"):
@@ -559,7 +559,6 @@ class Menu(object):
                     self.items())
 
         path_items.append(best_item)
-
 
         # if there are more parts - then get the next level
         if parts[1:]:

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -226,9 +226,9 @@ class EditWrapper(uiawrapper.UIAWrapper):
     has_title = False
 
     # -----------------------------------------------------------
-    def __init__(self, elem_or_handle):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(EditWrapper, self).__init__(elem_or_handle)
+        super(EditWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     @property
@@ -440,9 +440,9 @@ class SliderWrapper(uiawrapper.UIAWrapper):
     has_title = False
 
     # -----------------------------------------------------------
-    def __init__(self, elem_or_handle):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(SliderWrapper, self).__init__(elem_or_handle)
+        super(SliderWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     def min_value(self):

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -817,6 +817,7 @@ class MenuWrapper(uiawrapper.UIAWrapper):
 
         The full path syntax is specified in:
         :py:meth:`pywinauto.menuwrapper.Menu.get_menu_path`
+        Note: $ - specifier is not supported
         """
         # Get the path parts
         part0, parts = path.split("->", 1)

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -48,16 +48,16 @@ class ButtonWrapper(uiawrapper.UIAWrapper):
 
     """Wrap a UIA-compatible Button, CheckBox or RadioButton control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_ButtonControlTypeId,
         IUIA().UIA_dll.UIA_CheckBoxControlTypeId,
         IUIA().UIA_dll.UIA_RadioButtonControlTypeId
-        ]
+    ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(ButtonWrapper, self).__init__(hwnd)
+        super(ButtonWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     def toggle(self):
@@ -139,14 +139,14 @@ class ComboBoxWrapper(uiawrapper.UIAWrapper):
 
     """Wrap a UIA CoboBox control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_ComboBoxControlTypeId
-        ]
+    ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(ComboBoxWrapper, self).__init__(hwnd)
+        super(ComboBoxWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     def texts(self):
@@ -220,7 +220,7 @@ class EditWrapper(uiawrapper.UIAWrapper):
     # TODO: this class supports only 1-line textboxes so there is no point
     # TODO: in methods such as line_count(), line_length(), get_line(), etc
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_EditControlTypeId,
     ]
     has_title = False
@@ -398,14 +398,14 @@ class TabControlWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Tab control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_TabControlTypeId,
     ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(TabControlWrapper, self).__init__(hwnd)
+        super(TabControlWrapper, self).__init__(elem)
 
     # ----------------------------------------------------------------
     def get_selected_tab(self):
@@ -434,7 +434,7 @@ class SliderWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Slider control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_SliderControlTypeId,
     ]
     has_title = False
@@ -504,14 +504,14 @@ class HeaderWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Header control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_HeaderControlTypeId,
     ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(HeaderWrapper, self).__init__(hwnd)
+        super(HeaderWrapper, self).__init__(elem)
 
 
 # ====================================================================
@@ -519,15 +519,15 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible ListViewItem control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_DataItemControlTypeId,
         IUIA().UIA_dll.UIA_ListItemControlTypeId,
     ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd, container=None):
+    def __init__(self, elem, container=None):
         """Initialize the control"""
-        super(ListItemWrapper, self).__init__(hwnd)
+        super(ListItemWrapper, self).__init__(elem)
 
         # Init a pointer to the item's container wrapper.
         # It must be set by a container wrapper producing the item.
@@ -561,15 +561,15 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible ListView control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_DataGridControlTypeId,
         IUIA().UIA_dll.UIA_ListControlTypeId,
     ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(ListViewWrapper, self).__init__(hwnd)
+        super(ListViewWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     def item_count(self):
@@ -715,14 +715,14 @@ class MenuItemWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible MenuItem control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_MenuItemControlTypeId,
     ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(MenuItemWrapper, self).__init__(hwnd)
+        super(MenuItemWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     def items(self):
@@ -746,15 +746,15 @@ class MenuWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible MenuBar or Menu control"""
 
-    control_types = [
+    _control_types = [
         IUIA().UIA_dll.UIA_MenuBarControlTypeId,
         IUIA().UIA_dll.UIA_MenuControlTypeId
     ]
 
     # -----------------------------------------------------------
-    def __init__(self, hwnd):
+    def __init__(self, elem):
         """Initialize the control"""
-        super(MenuWrapper, self).__init__(hwnd)
+        super(MenuWrapper, self).__init__(elem)
 
     # -----------------------------------------------------------
     def items(self):

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -816,7 +816,8 @@ class MenuWrapper(uiawrapper.UIAWrapper):
         """Find a menu item specified by the path
 
         The full path syntax is specified in:
-        :py:meth:`pywinauto.menuwrapper.Menu.get_menu_path`
+        :py:meth:`.controls.menuwrapper.Menu.get_menu_path`
+
         Note: $ - specifier is not supported
         """
         # Get the path parts

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -71,12 +71,12 @@ VirtualizedItemPattern = IUIA().ui_automation_client.IUIAutomationVirtualizedIte
 WindowPattern = IUIA().ui_automation_client.IUIAutomationWindowPattern
 # endregion
 
-#=========================================================================
+# =========================================================================
 _friendly_classes = {
     'Custom': None,
     'DataGrid': 'ListView',
     'DataItem': 'ListViewItem',
-    'Document': None, # TODO: this is RichTextBox
+    'Document': None,  # TODO: this is RichTextBox
     'Group': 'GroupBox',
     'Header': None,
     'HeaderItem': None,
@@ -103,9 +103,10 @@ _friendly_classes = {
     'ToolTip': 'ToolTips',
     'Tree': None,
     'Window': 'Dialog',
-    }
+}
 
-#=========================================================================
+
+# =========================================================================
 class LazyProperty(object):
 
     """
@@ -129,7 +130,8 @@ class LazyProperty(object):
         return value
 lazy_property = LazyProperty
 
-#=========================================================================
+
+# =========================================================================
 class UiaMeta(BaseMeta):
     """Metaclass for UiaWrapper objects"""
     control_type_to_cls = {}
@@ -139,7 +141,7 @@ class UiaMeta(BaseMeta):
 
         BaseMeta.__init__(cls, name, bases, attrs)
 
-        for t in cls.control_types:
+        for t in cls._control_types:
             UiaMeta.control_type_to_cls[t] = cls
 
     @staticmethod
@@ -154,7 +156,8 @@ class UiaMeta(BaseMeta):
 
         return wrapper_match
 
-#=========================================================================
+
+# =========================================================================
 @six.add_metaclass(UiaMeta)
 class UIAWrapper(BaseWrapper):
 
@@ -170,14 +173,14 @@ class UIAWrapper(BaseWrapper):
     you can click() on any element.
     """
 
-    control_types = []
+    _control_types = []
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     def __new__(cls, element_info):
         """Construct the control wrapper"""
         return super(UIAWrapper, cls)._create_wrapper(cls, element_info, UIAWrapper)
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def __init__(self, element_info):
         """
         Initialize the control
@@ -189,103 +192,103 @@ class UIAWrapper(BaseWrapper):
         """
         BaseWrapper.__init__(self, element_info, backend.registry.backends['uia'])
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     def __hash__(self):
         """Return a unique hash value based on the element's Runtime ID"""
         return hash(self.element_info.runtime_id)
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_expand_collapse(self):
         """Get the element's ExpandCollapse interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "ExpandCollapse")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_selection(self):
         """Get the element's Selection interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Selection")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_selection_item(self):
         """Get the element's SelectionItem interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "SelectionItem")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_invoke(self):
         """Get the element's Invoke interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Invoke")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_toggle(self):
         """Get the element's Toggle interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Toggle")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_text(self):
         """Get the element's Text interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Text")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_value(self):
         """Get the element's Value interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Value")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_range_value(self):
         """Get the element's RangeValue interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "RangeValue")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_grid(self):
         """Get the element's Grid interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Grid")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_grid_item(self):
         """Get the element's GridItem interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "GridItem")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_table(self):
         """Get the element's Table interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Table")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_table_item(self):
         """Get the element's TableItem interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "TableItem")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @lazy_property
     def iface_window(self):
         """Get the element's Window interface pattern"""
         elem = self.element_info.element
         return uia_defs.get_elem_interface(elem, "Window")
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     @property
     def writable_props(self):
         """Extend default properties list."""
@@ -295,7 +298,7 @@ class UIAWrapper(BaseWrapper):
                       ])
         return props
 
-    #------------------------------------------------------------
+    # ------------------------------------------------------------
     def friendly_class_name(self):
         """
         Return the friendly class name for the control
@@ -319,17 +322,17 @@ class UIAWrapper(BaseWrapper):
                     self.friendlyclassname = _friendly_classes[ctrl_type]
         return self.friendlyclassname
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_keyboard_focusable(self):
         """Return True if the element can be focused with keyboard"""
         return self.element_info.element.CurrentIsKeyboardFocusable == 1
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def has_keyboard_focus(self):
         """Return True if the element is focused with keyboard"""
         return self.element_info.element.CurrentHasKeyboardFocus == 1
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def set_focus(self):
         """Set the focus to this element"""
         if self.is_keyboard_focusable() and not self.has_keyboard_focus():
@@ -354,7 +357,7 @@ class UIAWrapper(BaseWrapper):
         except(uia_defs.NoPatternInterfaceError):
             self.type_keys("{ESC}")
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def minimize(self):
         """
         Minimize the window
@@ -366,7 +369,7 @@ class UIAWrapper(BaseWrapper):
             iface.SetWindowVisualState(uia_defs.window_visual_state_minimized)
         return self
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def maximize(self):
         """
         Maximize the window
@@ -378,7 +381,7 @@ class UIAWrapper(BaseWrapper):
             iface.SetWindowVisualState(uia_defs.window_visual_state_maximized)
         return self
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def invoke(self):
         """An interface to the Invoke method of the Invoke control pattern"""
         self.iface_invoke.Invoke()
@@ -386,7 +389,7 @@ class UIAWrapper(BaseWrapper):
         # Return itself to allow action chaining
         return self
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def expand(self):
         """
         Displays all child nodes, controls, or content of the control
@@ -398,7 +401,7 @@ class UIAWrapper(BaseWrapper):
         # Return itself to allow action chaining
         return self
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def collapse(self):
         """
         Displays all child nodes, controls, or content of the control
@@ -410,7 +413,7 @@ class UIAWrapper(BaseWrapper):
         # Return itself to allow action chaining
         return self
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def get_expand_state(self):
         """
         Indicates the state of the control: expanded or collapsed.
@@ -424,19 +427,19 @@ class UIAWrapper(BaseWrapper):
         """
         return self.iface_expand_collapse.CurrentExpandCollapseState
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_expanded(self):
         """Test if the control is expanded"""
         state = self.get_expand_state()
         return state == uia_defs.expand_state_expanded
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_collapsed(self):
         """Test if the control is collapsed"""
         state = self.get_expand_state()
         return state == uia_defs.expand_state_collapsed
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def get_selection(self):
         """
         An interface to GetSelection of the SelectionProvider pattern
@@ -448,7 +451,7 @@ class UIAWrapper(BaseWrapper):
         ptrs_array = self.iface_selection.GetCurrentSelection()
         return elements_from_uia_array(ptrs_array)
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def selected_item_index(self):
         """Return the index of a selected item"""
         # Go through all children and look for an index
@@ -461,12 +464,12 @@ class UIAWrapper(BaseWrapper):
                     return i
         return None
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def children_texts(self):
         """Get texts of the control's children"""
         return [c.window_text() for c in self.children()]
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def can_select_multiple(self):
         """
         An interface to CanSelectMultiple of the SelectionProvider pattern
@@ -476,7 +479,7 @@ class UIAWrapper(BaseWrapper):
         """
         return self.iface_selection.CurrentCanSelectMultiple
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_selection_required(self):
         """
         An interface to IsSelectionRequired property of the SelectionProvider pattern.
@@ -489,8 +492,8 @@ class UIAWrapper(BaseWrapper):
         """
         return self.iface_selection.CurrentIsSelectionRequired
 
-    #-----------------------------------------------------------
-    def _select(self, item = None):
+    # -----------------------------------------------------------
+    def _select(self, item=None):
         """
         Find a child item by the name or index and select
 
@@ -507,21 +510,21 @@ class UIAWrapper(BaseWrapper):
             err_msg = u"unsupported {0} for item {1}".format(type(item), item)
             raise ValueError(err_msg)
 
-        list_ = self.children(title = title)
+        list_ = self.children(title=title)
         if item_index < len(list_):
             wrp = list_[item_index]
             wrp.iface_selection_item.Select()
         else:
             raise IndexError("item not found")
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def is_active(self):
         """Whether the window is active or not"""
         ae = IUIA().get_focused_element()
         focused_wrap = UIAWrapper(UIAElementInfo(ae))
         return (focused_wrap.top_level_parent() == self.top_level_parent())
 
-    #-----------------------------------------------------------
+    # -----------------------------------------------------------
     def menu_select(self, path, exact=False, ):
         """Select a menu item specified in the path
 

--- a/pywinauto/unittests/test_menuwrapper.py
+++ b/pywinauto/unittests/test_menuwrapper.py
@@ -31,7 +31,8 @@
 
 """Tests for Menu"""
 
-import sys, os
+import sys
+import os
 import unittest
 sys.path.append(".")
 from pywinauto.application import Application
@@ -62,27 +63,25 @@ class MenuWrapperTests(unittest.TestCase):
         "Close the application after tests"
         self.app.kill_()
 
-
     def testInvalidHandle(self):
         "Test that an exception is raised with an invalid menu handle"
-        #self.assertRaises(InvalidWindowHandle, HwndWrapper, -1)
+        # self.assertRaises(InvalidWindowHandle, HwndWrapper, -1)
         pass
 
-
     def testItemCount(self):
-        self.assertEquals(5, self.dlg.Menu().ItemCount())
+        self.assertEqual(5, self.dlg.Menu().ItemCount())
 
     def testItem(self):
-        self.assertEquals(u'&File', self.dlg.Menu().Item(0).Text())
-        self.assertEquals(u'&File', self.dlg.Menu().Item(u'File').Text())
-        self.assertEquals(u'&File', self.dlg.Menu().Item(u'&File', exact=True).Text())
+        self.assertEqual(u'&File', self.dlg.Menu().Item(0).Text())
+        self.assertEqual(u'&File', self.dlg.Menu().Item(u'File').Text())
+        self.assertEqual(u'&File', self.dlg.Menu().Item(u'&File', exact=True).Text())
 
     def testItems(self):
-        self.assertEquals([u'&File', u'&Edit', u'F&ormat', u'&View', u'&Help'],
+        self.assertEqual([u'&File', u'&Edit', u'F&ormat', u'&View', u'&Help'],
                           [item.Text() for item in self.dlg.Menu().Items()])
 
     def testFriendlyClassName(self):
-        self.assertEquals('MenuItem', self.dlg.Menu().Item(0).friendly_class_name())
+        self.assertEqual('MenuItem', self.dlg.Menu().Item(0).friendly_class_name())
 
     def testMenuItemNotEnabled(self):
         self.assertRaises(MenuItemNotEnabled, self.dlg.MenuSelect, 'Edit->Find Next')
@@ -90,16 +89,19 @@ class MenuWrapperTests(unittest.TestCase):
         self.assertRaises(MenuItemNotEnabled, self.dlg.MenuItem('Edit->Find Next').click_input)
 
     def testGetProperties(self):
-        self.assertEquals({u'menu_items': [{u'index': 0, u'state': 0, u'item_type': 0, u'item_id': 64, u'text': u'View &Help'},
-                                           {u'index': 1, u'state': 3, u'item_type': 2048, u'item_id': 0, u'text': u''},
-                                           {u'index': 2, u'state': 0, u'item_type': 0, u'item_id': 65, u'text': u'&About Notepad'}]},
-                          self.dlg.Menu().GetMenuPath('Help')[0].SubMenu().GetProperties())
+        self.assertEqual(
+            {u'menu_items':
+                [{u'index': 0, u'state': 0, u'item_type': 0, u'item_id': 64, u'text': u'View &Help'},
+                 {u'index': 1, u'state': 3, u'item_type': 2048, u'item_id': 0, u'text': u''},
+                 {u'index': 2, u'state': 0, u'item_type': 0, u'item_id': 65, u'text': u'&About Notepad'}]},
+            self.dlg.Menu().GetMenuPath('Help')[0].SubMenu().GetProperties())
 
     def testGetMenuPath(self):
-        #print('id = ' + str(self.dlg.Menu().GetMenuPath('Help->#3')[0].id()))
-        self.assertEquals(u'&About Notepad', self.dlg.Menu().GetMenuPath('Help->#2')[-1].Text())
-        self.assertEquals(u'&About Notepad', self.dlg.Menu().GetMenuPath('Help->$65')[-1].Text())
-        self.assertEquals(u'&About Notepad', self.dlg.Menu().GetMenuPath('&Help->&About Notepad', exact=True)[-1].Text())
+        # print('id = ' + str(self.dlg.Menu().GetMenuPath('Help->#3')[0].id()))
+        self.assertEqual(u'&About Notepad', self.dlg.Menu().GetMenuPath(' Help -> #2 ')[-1].Text())
+        self.assertEqual(u'&About Notepad', self.dlg.Menu().GetMenuPath('Help->$65')[-1].Text())
+        self.assertEqual(u'&About Notepad',
+                          self.dlg.Menu().GetMenuPath('&Help->&About Notepad', exact=True)[-1].Text())
         self.assertRaises(IndexError, self.dlg.Menu().GetMenuPath, '&Help->About what?', exact=True)
 
     def test__repr__(self):
@@ -137,10 +139,9 @@ class OwnerDrawnMenuTests(unittest.TestCase):
         self.app.kill_()
 
     def testCorrectText(self):
-        self.assertEquals(u'&New', self.dlg.Menu().GetMenuPath('&File->#0')[-1].Text()[:4])
-        self.assertEquals(u'&Open...', self.dlg.Menu().GetMenuPath('&File->#1')[-1].Text()[:8])
+        self.assertEqual(u'&New', self.dlg.Menu().GetMenuPath('&File->#0')[-1].Text()[:4])
+        self.assertEqual(u'&Open...', self.dlg.Menu().GetMenuPath('&File->#1')[-1].Text()[:8])
 
 
 if __name__ == "__main__":
     unittest.main()
-


### PR DESCRIPTION
- Add UIA related modules to the doc index
- Fix sphinx build of UIA related modules on Linux
- Remove pywinauto.six module from the doc as it's removed from the project
- Make UIAWrapper._control_types to be private so the it won't be rendered in sphinx generated docs.
- Fix #130 - allow spaces in menu path for HwndWrapper.menu_select
- PEP8 typos and code refactoring: bracket indentation, consistent names, strip trailing spaces