### PR TITLE
UIA: fix ToolbarWpfTests.test_button_access

### DIFF
--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -995,13 +995,13 @@ if UIA_support:
             # Find a tooltip by class name
             tt = self.app.window_(top_level_only=False,
                                   class_name="tooltips_class32").Wait('visible')
-            self.assertEquals(isinstance(tt, uia_ctls.TooltipWrapper), True)
-            self.assertEquals(tt.window_text(), "Large Icons")
+            self.assertEqual(isinstance(tt, uia_ctls.TooltipWrapper), True)
+            self.assertEqual(tt.window_text(), "Large Icons")
 
             # Find a tooltip window by control type
             tt = self.app.top_window_().children(control_type='ToolTip')[0]
-            self.assertEquals(isinstance(tt, uia_ctls.TooltipWrapper), True)
-            self.assertEquals(tt.window_text(), "Large Icons")
+            self.assertEqual(isinstance(tt, uia_ctls.TooltipWrapper), True)
+            self.assertEqual(tt.window_text(), "Large Icons")
 
         def test_button_click(self):
             """Test button click"""

--- a/pywinauto/unittests/test_UIAWrapper.py
+++ b/pywinauto/unittests/test_UIAWrapper.py
@@ -955,7 +955,7 @@ if UIA_support:
             found_txt = tb.button(expect_txt, exact=True).window_text()
             self.assertEqual(found_txt, expect_txt)
 
-            found_txt = tb.button("button ", exact=False).window_text()
+            found_txt = tb.button("b 1", exact=False).window_text()
             self.assertEqual(found_txt, expect_txt)
 
             expect_txt = "button 2"


### PR DESCRIPTION
- This is a small fix for a failing unit test. (Apparently, findbestmatch runs a bit differently on Py3.3 x86)
- Additional small cleanups