### PR TITLE
Improve the docs and more

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,6 +2,21 @@
 Change Log
 ==========
 
+0.6.0 Introduce MS UI Automation support and many more improvements
+--------------------------------------------------------------------
+30-October-2016
+ * This big release introduces MS UI Automation (UIA) support:
+
+   - Just start from `app = Application(backend='uia').start('your_app.exe')`.
+
+   - Supported controls: Menu, Button/CheckBox/RadioButton, ComboBox, Edit,
+     Tab control, List (ListView), DataGrid, Tree, Toolbar, Tooltip, Slider.
+
+ * New multi-backend architecture makes new platforms support easier in the future.
+
+ * Code style is much closer to PEP8.
+
+
 0.5.4 Bug fixes and partial MFC Menu Bar support
 --------------------------------------------------------------------
 30-October-2015

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -7,14 +7,32 @@ Change Log
 30-October-2016
  * This big release introduces MS UI Automation (UIA) support:
 
-   - Just start from `app = Application(backend='uia').start('your_app.exe')`.
+   - Just start from ``app = Application(backend='uia').start('your_app.exe')``.
 
    - Supported controls: Menu, Button/CheckBox/RadioButton, ComboBox, Edit,
      Tab control, List (ListView), DataGrid, Tree, Toolbar, Tooltip, Slider.
 
- * New multi-backend architecture makes new platforms support easier in the future.
+ * Documentation is built continuously now on ReadTheDocs. See also improved
+   `Getting Started Guide`_.
 
- * Code style is much closer to PEP8.
+   .. _`Getting Started Guide`: getting_started.html
+
+ * New multi-backend architecture makes implementation of new platforms support
+   easier in the future. The minimal set for new backend includes its name and
+   two classes inherited from :py:class:`.element_info.ElementInfo` and from
+   :py:class:`pywinauto.base_wrapper.BaseWrapper`. New backend must be
+   registered by function :func:`pywinauto.backend.register()`.
+
+ * Code style is much closer to PEP8: i.e. ``click_input`` should be used
+   instead of ``ClickInput``.
+
+ * Initial implementation of the ``hooks`` module. Keyboard and mouse event
+   handlers can be registered in the system. It was inspired by pyHook, pyhk,
+   pyhooked and similar modules, but re-written from scratch. Thanks for
+   Max Samokhvalov! The fork of the ``hooks`` module is used in pyhooked 0.8
+   by Ethan Smith.
+
+ * A lot of small improvements are not counted here.
 
 
 0.5.4 Bug fixes and partial MFC Menu Bar support

--- a/docs/HowTo.txt
+++ b/docs/HowTo.txt
@@ -52,24 +52,20 @@ one of the following:
 
   ::
 
-          app = Application.connect(path=r"c:\windows\system32\notepad.exe")
+          app = Application().connect(path=r"c:\windows\system32\notepad.exe")
 
 
 or any combination of the parameters that specify a window, these get
-passed to the :func:`pywinauto.findwindows.find_windows()` function.  e.g.
+passed to the :func:`pywinauto.findwindows.find_elements()` function.  e.g.
 
   ::
 
           app = Application.connect(title_re=".*Notepad", class_name="Notepad")
 
 
-**Note**: I have since added static methods Application.start() and
-Application.connect() these can be used the same as above - except that
-you no longer need to instantiate an Application object first.
-
-**Note2**: The application has to be ready before you can use connect*().
+**Note**: The application has to be ready before you can use connect*().
 There is no timeout or retries like there is when finding the application
-after start*(). So if you start the application outside of pywinauto you
+after start(). So if you start the application outside of pywinauto you
 need to either sleep or program a wait loop to wait until the application
 has fully started.
 
@@ -148,7 +144,7 @@ There are a number of ways to specify a control, the simplest are
 
 
 The 2nd is better for non English OS's where you need to pass unicode
-strings e.g. app[u'your dlg title'][u'your ctrl title']
+strings e.g. ``app[u'your dlg title'][u'your ctrl title']``
 
 The code builds up multiple identifiers for each control from the following:
 

--- a/docs/code/pywinauto.application.txt
+++ b/docs/code/pywinauto.application.txt
@@ -3,5 +3,6 @@ pywinauto.application module
 
 .. automodule:: pywinauto.application
     :members:
+    :exclude-members: Kill_, kill_, Window_
     :undoc-members:
     :show-inheritance:

--- a/docs/code/pywinauto.controls.common_controls.txt
+++ b/docs/code/pywinauto.controls.common_controls.txt
@@ -1,7 +1,8 @@
 pywinauto.controls.common_controls
 ----------------------------------
-
- .. automodule:: pywinauto.controls.common_controls
+.. automodule:: pywinauto.controls.common_controls
     :members:
+    :exclude-members: Click, ClickInput, HasStyle, IsCheckable, IsChecked,
+        IsEnabled, IsPressable, IsPressed, Rectangle, State, Style, Text
     :undoc-members:
     :show-inheritance:

--- a/docs/code/pywinauto.controls.hwndwrapper.txt
+++ b/docs/code/pywinauto.controls.hwndwrapper.txt
@@ -2,5 +2,20 @@ pywinauto.controls.hwndwrapper
 ------------------------------
  .. automodule:: pywinauto.controls.hwndwrapper
     :members:
+    :exclude-members: re_wrappers, str_wrappers, CaptureAsImage, Children,
+        Class, Click, ClickInput, ClientRect, ClientRects, ClientToScreen,
+        Close, CloseAltF4, CloseClick, ContextHelpID, ControlID, DebugMessage,
+        DoubleClick, DoubleClickInput, DragMouse, DragMouseInput, DrawOutline,
+        ExStyle, Font, Fonts, FriendlyClassName, GetActive, GetFocus,
+        GetProperties, GetShowState, GetToolbar, HasExStyle, HasStyle,
+        IsActive, IsChild, IsDialog, IsEnabled, IsUnicode, IsVisible,
+        Maximize, Menu, MenuItem, MenuItems, MenuSelect, Minimize, MoveMouse,
+        MoveMouseInput, MoveWindow, NotifyParent, Owner, Parent, PopupWindow,
+        PostCommand, PostMessage, PressMouse, PressMouseInput, ProcessID,
+        Rectangle, ReleaseMouse, ReleaseMouseInput, Restore, RightClick,
+        RightClickInput, Scroll, SendCommand, SendMessage, SendMessageTimeout,
+        SetApplicationData, SetFocus, SetTransparency, SetWindowText, Style,
+        Texts, TopLevelParent, TypeKeys, UserData, VerifyActionable,
+        VerifyEnabled, VerifyVisible, WheelMouseInput, WindowText
     :undoc-members:
     :show-inheritance:

--- a/docs/code/pywinauto.controls.menuwrapper.txt
+++ b/docs/code/pywinauto.controls.menuwrapper.txt
@@ -2,6 +2,9 @@ pywinauto.controls.menuwrapper
 ------------------------------
  .. automodule:: pywinauto.controls.menuwrapper
     :members:
+    :exclude-members: GetMenuPath, GetProperties, Item, ItemCount, Items,
+        Click, ClickInput, FriendlyClassName, GetProperties, ID, Index,
+        IsChecked, IsEnabled, Rectangle, Select, State, SubMenu, Text, Type
     :undoc-members:
     :show-inheritance:
 

--- a/docs/code/pywinauto.controls.uiawrapper.txt
+++ b/docs/code/pywinauto.controls.uiawrapper.txt
@@ -2,6 +2,7 @@ pywinauto.controls.uiawrapper
 -----------------------------
  .. automodule:: pywinauto.controls.uiawrapper
     :members:
+    :exclude-members: control_type_to_cls
     :undoc-members:
     :show-inheritance:
 

--- a/docs/controls_overview.txt
+++ b/docs/controls_overview.txt
@@ -9,38 +9,37 @@ All Controls
 ------------
 These functions are aviailable to all controls.
 
-  * CaptureAsImage_
-  * Click_
-  * ClickInput_
-  * Close_
-  * CloseClick_
-  * DebugMessage_
-  * DoubleClick_
-  * DoubleClickInput_
-  * DragMouse_
+  * capture_as_image_
+  * click_
+  * click_input_
+  * close_
+  * close_click_
+  * debug_message_
+  * double_click_
+  * double_click_input_
+  * drag_mouse_
   * draw_outline_
-  * GetFocus_
-  * GetShowState_
-  * Maximize_
-  * MenuSelect_
-  * Minimize_
-  * MoveMouse_
-  * MoveWindow_
-  * NotifyMenuSelect_
-  * NotifyParent_
-  * PressMouse_
-  * PressMouseInput_
-  * ReleaseMouse_
-  * ReleaseMouseInput_
-  * Restore_
-  * RightClick_
-  * RightClickInput_
-  * RightClickInput_
-  * SendMessage_
-  * SendMessageTimeout_
-  * SetFocus_
-  * SetWindowText_
-  * TypeKeys_
+  * get_focus_
+  * get_show_state_
+  * maximize_
+  * menu_select_
+  * minimize_
+  * move_mouse_
+  * move_window_
+  * notify_menu_select_
+  * notify_parent_
+  * press_mouse_
+  * press_mouse_input_
+  * release_mouse_
+  * release_mouse_input_
+  * restore_
+  * right_click_
+  * right_click_input_
+  * send_message_
+  * send_message_timeout_
+  * set_focus_
+  * set_window_text_
+  * type_keys_
 
   * Children_
   * Class_
@@ -78,38 +77,37 @@ These functions are aviailable to all controls.
   * WindowText_
 
 
-.. _CaptureAsImage: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.CaptureAsImage
-.. _Click: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Click
-.. _ClickInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.ClickInput
-.. _CloseClick: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.CloseClick
-.. _DebugMessage: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DebugMessage
-.. _DoubleClick: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DoubleClick
-.. _DoubleClickInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DoubleClickInput
-.. _DragMouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DragMouse
+.. _capture_as_image: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.capture_as_image
+.. _click: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.click
+.. _click_input: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.click_input
+.. _close_click: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.close_click
+.. _debug_message: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.debug_message
+.. _double_click: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.double_click
+.. _double_click_input: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.double_click_input
+.. _drag_mouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.drag_mouse
 .. _draw_outline: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.draw_outline
-.. _GetFocus: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.GetFocus
-.. _MenuSelect: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.MenuSelect
-.. _MoveMouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.MoveMouse
-.. _MoveWindow: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.MoveWindow
-.. _NotifyMenuSelect: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.NotifyMenuSelect
-.. _NotifyParent: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.NotifyParent
-.. _PressMouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.PressMouse
-.. _PressMouseInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.PressMouseInput
-.. _ReleaseMouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.ReleaseMouse
-.. _ReleaseMouseInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.ReleaseMouseInput
-.. _RightClick: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.RightClick
-.. _RightClickInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.RightClickInput
-.. _RightClickInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.RightClickInput
-.. _SendMessage: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.SendMessage
-.. _SendMessageTimeout: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.SendMessageTimeout
-.. _SetFocus: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.SetFocus
-.. _SetWindowText: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.SetWindowText
-.. _TypeKeys: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.TypeKeys
-.. _Close: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Close
-.. _Restore: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Restore
-.. _GetShowState: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.GetShowState
-.. _Maximize: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Maximize
-.. _Minimize: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Minimize
+.. _get_focus: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.get_focus
+.. _menu_select: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.menu_select
+.. _move_mouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.move_mouse
+.. _move_window: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.move_window
+.. _notify_menu_select: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.notify_menu_select
+.. _notify_parent: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.notify_parent
+.. _press_mouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.press_mouse
+.. _press_mouse_input: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.press_mouse_input
+.. _release_mouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.release_mouse
+.. _release_mouse_input: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.release_mouse_input
+.. _right_click: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.right_click
+.. _right_click_input: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.right_click_input
+.. _send_message: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.send_message
+.. _send_message_timeout: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.send_message_timeout
+.. _set_focus: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.set_focus
+.. _set_window_text: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.set_window_text
+.. _type_keys: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.type_keys
+.. _close: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.close
+.. _restore: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.restore
+.. _get_show_state: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.get_show_state
+.. _maximize: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.maximize
+.. _minimize: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.minimize
 
 .. _Children: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Children
 .. _Class: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.Class
@@ -200,7 +198,7 @@ Edit
   * EditWrapper.Select_
   * EditWrapper.SelectionIndices_
   * EditWrapper.SetEditText_
-  * EditWrapper.SetWindowText_
+  * EditWrapper.set_window_text_
   * EditWrapper.TextBlock_
 
 .. _EditWrapper.GetLine: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.GetLine
@@ -209,7 +207,7 @@ Edit
 .. _EditWrapper.Select: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.Select
 .. _EditWrapper.SelectionIndices: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.SelectionIndices
 .. _EditWrapper.SetEditText: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.SetEditText
-.. _EditWrapper.SetWindowText: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.SetWindowText
+.. _EditWrapper.set_window_text: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.set_window_text
 .. _EditWrapper.TextBlock: code/pywinauto.controls.win32_controls.html#pywinauto.controls.win32_controls.EditWrapper.TextBlock
 
 Header
@@ -357,7 +355,7 @@ Toolbar
 
       * ToolbarButton.Rectangle_
       * ToolbarButton.Style_
-      * ToolbarButton.ClickInput_
+      * ToolbarButton.click_input_
       * ToolbarButton.Click_
       * ToolbarButton.IsCheckable_
       * ToolbarButton.IsChecked_
@@ -368,7 +366,7 @@ Toolbar
 
 .. _ToolbarButton.Rectangle: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.Rectangle
 .. _ToolbarButton.Style: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.Style
-.. _ToolbarButton.ClickInput: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.ClickInput
+.. _ToolbarButton.click_input: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.click_input
 .. _ToolbarButton.Click: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.Click
 .. _ToolbarButton.IsCheckable: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.IsCheckable
 .. _ToolbarButton.IsChecked: code/pywinauto.controls.common_controls.html#pywinauto.controls.common_controls._toolbar_button.IsChecked

--- a/docs/controls_overview.txt
+++ b/docs/controls_overview.txt
@@ -18,7 +18,7 @@ These functions are aviailable to all controls.
   * DoubleClick_
   * DoubleClickInput_
   * DragMouse_
-  * DrawOutline_
+  * draw_outline_
   * GetFocus_
   * GetShowState_
   * Maximize_
@@ -86,7 +86,7 @@ These functions are aviailable to all controls.
 .. _DoubleClick: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DoubleClick
 .. _DoubleClickInput: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DoubleClickInput
 .. _DragMouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DragMouse
-.. _DrawOutline: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.DrawOutline
+.. _draw_outline: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.draw_outline
 .. _GetFocus: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.GetFocus
 .. _MenuSelect: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.MenuSelect
 .. _MoveMouse: code/pywinauto.controls.hwndwrapper.html#pywinauto.controls.hwndwrapper.HwndWrapper.MoveMouse

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -58,10 +58,10 @@ Entry Points for Automation
 So you have an application, you know it supports one of the mentioned 
 accessibility technologies. What's the next?
 
-First you should start your application or connect to the existing app
+First you should start your application or connect to an existing app
 instance. It can be done with an ``Application`` object. This is not just
 a clone of ``subprocess.Popen``, but an entry point for further automation
-limiting all the scope by a process boundaries. It's useful to control
+limiting all the scope by process boundaries. It's useful to control
 potentially few instances of an application (you work with one instance
 not bothering another ones).
 
@@ -71,9 +71,9 @@ not bothering another ones).
     app = Application(backend="uia").start('notepad.exe')
     
     # describe the window inside Notepad.exe process
-    dlg = app.UntitledNotepad
-    # wait till the window is open
-    dlg.wait('visible')
+    dlg_spec = app.UntitledNotepad
+    # wait till the window is really open
+    actionable_dlg = dlg_spec.wait('visible')
 
 If you want to navigate across process boundaries (say Win10 Calculator
 surprisingly draws its widgets in more than one process) your entry point
@@ -97,10 +97,10 @@ Window Specification
 
 It's a core concept for the high level pywinauto API. You are able to describe
 any window or control approximately or in more details even if it doesn't exist
-yet or already closed. Window specification also keeps an information about
-matching/search algorithm that will be used to get real window/control.
+yet or already closed. Window specification also keeps information about
+matching/search algorithm that will be used to get a real window or control.
 
-Let's create detailed window specification for the window:
+Let's create a detailed window specification:
 
  ::
 
@@ -112,7 +112,7 @@ Let's create detailed window specification for the window:
     >>> dlg_spec.wrapper_object()
     <pywinauto.controls.win32_controls.DialogWrapper object at 0x05639B70>
 
-Actual window lookup is done by ``wrapper_object()`` method. It returns some
+Actual window lookup is performed by ``wrapper_object()`` method. It returns some
 wrapper for the real existing window/control or raises ``ElementNotFound``
 exception. This wrapper can deal with the window/control sending actions or
 retrieving data.

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -58,9 +58,96 @@ Entry Points for Automation
 So you have an application, you know it supports one of the mentioned 
 accessibility technologies. What's the next?
 
-**Application** and **Desktop** objects are backend-specific.
+First you should start your application or connect to the existing app
+instance. It can be done with an ``Application`` object. This is not just
+a clone of ``subprocess.Popen``, but an entry point for further automation
+limiting all the scope by a process boundaries. It's useful to control
+potentially few instances of an application (you work with one instance
+not bothering another ones).
 
-TODO: continue telling about window specifications and other basic things.
+ ::
+
+    from pywinauto.application import Application
+    app = Application(backend="uia").start('notepad.exe')
+    
+    # describe the window inside Notepad.exe process
+    dlg = app.UntitledNotepad
+    # wait till the window is open
+    dlg.wait('visible')
+
+If you want to navigate across process boundaries (say Win10 Calculator
+surprisingly draws its widgets in more than one process) your entry point
+is a ``Desktop`` object.
+
+ ::
+
+    from subprocess import Popen
+    from pywinauto import Desktop
+    
+    Popen('calc.exe', shell=True)
+    dlg = Desktop(backend="uia").Calculator
+    dlg.wait('visible')
+
+**Application** and **Desktop** objects are both backend-specific. So no need
+to use backend name in further actions explicitly.
+
+
+Window Specification
+--------------------
+
+It's a core concept for the high level pywinauto API. You are able to describe
+any window or control approximately or in more details even if it doesn't exist
+yet or already closed. Window specification also keeps an information about
+matching/search algorithm that will be used to get real window/control.
+
+Let's create detailed window specification for the window:
+
+ ::
+
+    >>> dlg_spec = app.window(title='Untitled - Notepad')
+    
+    >>> dlg_spec
+    <pywinauto.application.WindowSpecification object at 0x0568B790>
+    
+    >>> dlg_spec.wrapper_object()
+    <pywinauto.controls.win32_controls.DialogWrapper object at 0x05639B70>
+
+Actual window lookup is done by ``wrapper_object()`` method. It returns some
+wrapper for the real existing window/control or raises ``ElementNotFound``
+exception. This wrapper can deal with the window/control sending actions or
+retrieving data.
+
+But Python can hide this ``wrapper_object()`` call so that you have more
+compact code in production. The following statements do absolutely the same:
+
+ ::
+
+    dlg_spec.wrapper_object().minimize() # while debugging
+    dlg_spec.minimize() # in production
+
+There are many possible criteria for creating window specifications. These
+are just a few examples.
+
+ ::
+
+    # can be multi-level
+    app.window(title_re='.* - Notepad$').window(class_name='Edit')
+    
+    # can combine criteria
+    dlg = Desktop(backend="uia").Calculator
+    dlg.window(auto_id='num8Button', control_type='Button')
+
+The list of possible criteria can be found in the
+:func:`pywinauto.findwindows.find_elements()` function.
+
+
+Attribute Resolution Magic
+--------------------------
+
+To be done.
+
+Best match algorithm.
+Attribute and dict-like access.
 
 
 Look at the examples

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -366,8 +366,8 @@ Please find below a sample run ::
 	(2)   >>> app = application.Application()
 	(3)   >>> app.start("Notepad.exe")
 	      <pywinauto.application.Application object at 0x00AE0990>
-	(4)   >>> app.Notepad.draw_outline()
-	(5)   >>> app.Notepad.menu_select("Edit -> Replace")
+	(4)   >>> app.UntitledNotepad.draw_outline()
+	(5)   >>> app.UntitledNotepad.menu_select("Edit -> Replace")
 	(6)   >>> app.Replace.print_control_identifiers()
 	      Control Identifiers:
 	      Static - 'Fi&nd what:'   (L1018, T159, R1090, B172)
@@ -389,9 +389,9 @@ Please find below a sample run ::
 	      Button - 'Cancel'   (L1273, T233, R1348, B256)
 	              'Button4' 'Cancel' 'CancelButton'
 	(7)   >>> app.Replace.Cancel.click()
-	(8)   >>> app.Notepad.Edit.type_keys("Hi from Python interactive prompt %s" % str(dir()), with_spaces = True)
+	(8)   >>> app.UntitledNotepad.Edit.type_keys("Hi from Python interactive prompt %s" % str(dir()), with_spaces = True)
 	      <pywinauto.controls.win32_controls.EditWrapper object at 0x00DDC2D0>
-	(9)   >>> app.Notepad.menu_select("File -> Exit")
+	(9)   >>> app.UntitledNotepad.menu_select("File -> Exit")
 	(10)  >>> app.Notepad.No.click()
 	      >>>
 

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -172,11 +172,12 @@ There are several principles how "best match" gold names are attached
 to the controls. So if a window specification is close to one of these names
 you will have a successful name matching.
 
- 1. By title (window text, name): ``app.Properties.OK.click()``
- 2. By title and control type: ``app.Properties.OKButton.click()``
- 3. By control type and number: ``app.Properties.Button3.click()``
- 4. By top-left label and control type: ``app.OpenDialog.FileNameEdit.set_text("")``
- 5. By control type and item text: ``app.Properties.TabControlSharing.select("General")``
+1. By title (window text, name): ``app.Properties.OK.click()``
+2. By title and control type: ``app.Properties.OKButton.click()``
+3. By control type and number: ``app.Properties.Button3.click()``
+   (*Note*: Button0 and Button1 match the same button, Button2 is the next etc.)
+4. By top-left label and control type: ``app.OpenDialog.FileNameEdit.set_text("")``
+5. By control type and item text: ``app.Properties.TabControlSharing.select("General")``
 
 Often not all of these matching names are available simultaneously. To check
 these names for specified dialog you can use ``print_control_identifiers()``

--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -113,9 +113,8 @@ Let's create a detailed window specification:
     <pywinauto.controls.win32_controls.DialogWrapper object at 0x05639B70>
 
 Actual window lookup is performed by ``wrapper_object()`` method. It returns some
-wrapper for the real existing window/control or raises ``ElementNotFound``
-exception. This wrapper can deal with the window/control sending actions or
-retrieving data.
+wrapper for the real existing window/control or raises ``ElementNotFoundError``.
+This wrapper can deal with the window/control by sending actions or retrieving data.
 
 But Python can hide this ``wrapper_object()`` call so that you have more
 compact code in production. The following statements do absolutely the same:
@@ -144,10 +143,192 @@ The list of possible criteria can be found in the
 Attribute Resolution Magic
 --------------------------
 
-To be done.
+Python simplifies creating window specification by resolving object attributes
+dynamically. But an attibute name has the same limitations as any variable name:
+no spaces, commas and other special symbols. But fortunately pywinauto uses
+"best match" algorithm to make a lookup resistant to typos and small variations.
 
-Best match algorithm.
-Attribute and dict-like access.
+ ::
+
+    app.UntitledNotepad
+    # is equivalent to
+    app.window(best_match='UntitledNotepad')
+
+
+Unicode characters and special symbols usage is possible through an item access
+in a dictionary like manner.
+
+ ::
+
+    app['Untitled - Notepad']
+    # is the same as
+    app.window(best_match='Untitled - Notepad')
+
+
+How to know magic attribute names
+---------------------------------
+
+There are several principles how "best match" gold names are attached
+to the controls. So if a window specification is close to one of these names
+you will have a successful name matching.
+
+ 1. By title (window text, name): ``app.Properties.OK.click()``
+ 2. By title and control type: ``app.Properties.OKButton.click()``
+ 3. By control type and number: ``app.Properties.Button3.click()``
+ 4. By top-left label and control type: ``app.OpenDialog.FileNameEdit.set_text("")``
+ 5. By control type and item text: ``app.Properties.TabControlSharing.select("General")``
+
+Often not all of these matching names are available simultaneously. To check
+these names for specified dialog you can use ``print_control_identifiers()``
+method. Possible "best_match" names are displayed as a Python list for every
+control in a tree. More detailed window specification can also be just copied
+from the method output. Say
+``app.Properties.child_window(title="Contains:", auto_id="13087", control_type="Edit")``.
+
+ ::
+
+    >>> app.Properties.print_control_identifiers()
+    
+    Control Identifiers:
+
+    Dialog - 'Windows NT Properties'    (L688, T518, R1065, B1006)
+    [u'Windows NT PropertiesDialog', u'Dialog', u'Windows NT Properties']
+    child_window(title="Windows NT Properties", control_type="Window")
+       | 
+       | Image - ''    (L717, T589, R749, B622)
+       | [u'', u'0', u'Image1', u'Image0', 'Image', u'1']
+       | child_window(auto_id="13057", control_type="Image")
+       | 
+       | Image - ''    (L717, T630, R1035, B632)
+       | ['Image2', u'2']
+       | child_window(auto_id="13095", control_type="Image")
+       | 
+       | Edit - 'Folder name:'    (L790, T596, R1036, B619)
+       | [u'3', 'Edit', u'Edit1', u'Edit0']
+       | child_window(title="Folder name:", auto_id="13156", control_type="Edit")
+       | 
+       | Static - 'Type:'    (L717, T643, R780, B658)
+       | [u'Type:Static', u'Static', u'Static1', u'Static0', u'Type:']
+       | child_window(title="Type:", auto_id="13080", control_type="Text")
+       | 
+       | Edit - 'Type:'    (L790, T643, R1036, B666)
+       | [u'4', 'Edit2', u'Type:Edit']
+       | child_window(title="Type:", auto_id="13059", control_type="Edit")
+       | 
+       | Static - 'Location:'    (L717, T669, R780, B684)
+       | [u'Location:Static', u'Location:', u'Static2']
+       | child_window(title="Location:", auto_id="13089", control_type="Text")
+       | 
+       | Edit - 'Location:'    (L790, T669, R1036, B692)
+       | ['Edit3', u'Location:Edit', u'5']
+       | child_window(title="Location:", auto_id="13065", control_type="Edit")
+       | 
+       | Static - 'Size:'    (L717, T695, R780, B710)
+       | [u'Size:Static', u'Size:', u'Static3']
+       | child_window(title="Size:", auto_id="13081", control_type="Text")
+       | 
+       | Edit - 'Size:'    (L790, T695, R1036, B718)
+       | ['Edit4', u'6', u'Size:Edit']
+       | child_window(title="Size:", auto_id="13064", control_type="Edit")
+       | 
+       | Static - 'Size on disk:'    (L717, T721, R780, B736)
+       | [u'Size on disk:', u'Size on disk:Static', u'Static4']
+       | child_window(title="Size on disk:", auto_id="13107", control_type="Text")
+       | 
+       | Edit - 'Size on disk:'    (L790, T721, R1036, B744)
+       | ['Edit5', u'7', u'Size on disk:Edit']
+       | child_window(title="Size on disk:", auto_id="13106", control_type="Edit")
+       | 
+       | Static - 'Contains:'    (L717, T747, R780, B762)
+       | [u'Contains:1', u'Contains:0', u'Contains:Static', u'Static5', u'Contains:']
+       | child_window(title="Contains:", auto_id="13088", control_type="Text")
+       | 
+       | Edit - 'Contains:'    (L790, T747, R1036, B770)
+       | [u'8', 'Edit6', u'Contains:Edit']
+       | child_window(title="Contains:", auto_id="13087", control_type="Edit")
+       | 
+       | Image - 'Contains:'    (L717, T773, R1035, B775)
+       | [u'Contains:Image', 'Image3', u'Contains:2']
+       | child_window(title="Contains:", auto_id="13096", control_type="Image")
+       | 
+       | Static - 'Created:'    (L717, T786, R780, B801)
+       | [u'Created:', u'Created:Static', u'Static6', u'Created:1', u'Created:0']
+       | child_window(title="Created:", auto_id="13092", control_type="Text")
+       | 
+       | Edit - 'Created:'    (L790, T786, R1036, B809)
+       | [u'Created:Edit', 'Edit7', u'9']
+       | child_window(title="Created:", auto_id="13072", control_type="Edit")
+       | 
+       | Image - 'Created:'    (L717, T812, R1035, B814)
+       | [u'Created:Image', 'Image4', u'Created:2']
+       | child_window(title="Created:", auto_id="13097", control_type="Image")
+       | 
+       | Static - 'Attributes:'    (L717, T825, R780, B840)
+       | [u'Attributes:Static', u'Static7', u'Attributes:']
+       | child_window(title="Attributes:", auto_id="13091", control_type="Text")
+       | 
+       | CheckBox - 'Read-only (Only applies to files in folder)'    (L790, T825, R1035, B841)
+       | [u'CheckBox0', u'CheckBox1', 'CheckBox', u'Read-only (Only applies to files in folder)CheckBox', u'Read-only (Only applies to files in folder)']
+       | child_window(title="Read-only (Only applies to files in folder)", auto_id="13075", control_type="CheckBox")
+       | 
+       | CheckBox - 'Hidden'    (L790, T848, R865, B864)
+       | ['CheckBox2', u'HiddenCheckBox', u'Hidden']
+       | child_window(title="Hidden", auto_id="13076", control_type="CheckBox")
+       | 
+       | Button - 'Advanced...'    (L930, T845, R1035, B868)
+       | [u'Advanced...', u'Advanced...Button', 'Button', u'Button1', u'Button0']
+       | child_window(title="Advanced...", auto_id="13154", control_type="Button")
+       | 
+       | Button - 'OK'    (L814, T968, R889, B991)
+       | ['Button2', u'OK', u'OKButton']
+       | child_window(title="OK", auto_id="1", control_type="Button")
+       | 
+       | Button - 'Cancel'    (L895, T968, R970, B991)
+       | ['Button3', u'CancelButton', u'Cancel']
+       | child_window(title="Cancel", auto_id="2", control_type="Button")
+       | 
+       | Button - 'Apply'    (L976, T968, R1051, B991)
+       | ['Button4', u'ApplyButton', u'Apply']
+       | child_window(title="Apply", auto_id="12321", control_type="Button")
+       | 
+       | TabControl - ''    (L702, T556, R1051, B962)
+       | [u'10', u'TabControlSharing', u'TabControlPrevious Versions', u'TabControlSecurity', u'TabControl', u'TabControlCustomize']
+       | child_window(auto_id="12320", control_type="Tab")
+       |    | 
+       |    | TabItem - 'General'    (L704, T558, R753, B576)
+       |    | [u'GeneralTabItem', 'TabItem', u'General', u'TabItem0', u'TabItem1']
+       |    | child_window(title="General", control_type="TabItem")
+       |    | 
+       |    | TabItem - 'Sharing'    (L753, T558, R801, B576)
+       |    | [u'Sharing', u'SharingTabItem', 'TabItem2']
+       |    | child_window(title="Sharing", control_type="TabItem")
+       |    | 
+       |    | TabItem - 'Security'    (L801, T558, R851, B576)
+       |    | [u'Security', 'TabItem3', u'SecurityTabItem']
+       |    | child_window(title="Security", control_type="TabItem")
+       |    | 
+       |    | TabItem - 'Previous Versions'    (L851, T558, R947, B576)
+       |    | [u'Previous VersionsTabItem', u'Previous Versions', 'TabItem4']
+       |    | child_window(title="Previous Versions", control_type="TabItem")
+       |    | 
+       |    | TabItem - 'Customize'    (L947, T558, R1007, B576)
+       |    | [u'CustomizeTabItem', 'TabItem5', u'Customize']
+       |    | child_window(title="Customize", control_type="TabItem")
+       | 
+       | TitleBar - 'None'    (L712, T521, R1057, B549)
+       | ['TitleBar', u'11']
+       |    | 
+       |    | Menu - 'System'    (L696, T526, R718, B548)
+       |    | [u'System0', u'System', u'System1', u'Menu', u'SystemMenu']
+       |    | child_window(title="System", auto_id="MenuBar", control_type="MenuBar")
+       |    |    | 
+       |    |    | MenuItem - 'System'    (L696, T526, R718, B548)
+       |    |    | [u'System2', u'MenuItem', u'SystemMenuItem']
+       |    |    | child_window(title="System", control_type="MenuItem")
+       |    | 
+       |    | Button - 'Close'    (L1024, T519, R1058, B549)
+       |    | [u'CloseButton', u'Close', 'Button5']
+       |    | child_window(title="Close", control_type="Button")
 
 
 Look at the examples

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -27,7 +27,7 @@ Manual installation
   - pyWin32_
   - comtypes_
   - six_
-  - *(optional)* Pillow_ (fork of PIL)
+  - *(optional)* Pillow_ (to make screenshoots)
 
 - Download latest pywinauto from https://github.com/pywinauto/pywinauto/releases
 - Unpack and run ``python setup.py install``
@@ -42,7 +42,7 @@ To check you have it installed correctly
 Run Python ::
 
   >>> from pywinauto.application import Application
-  >>> app = Application().start("notepad.exe")
+  >>> app = Application(backend="uia").start("notepad.exe")
   >>> app.UntitledNotepad.type_keys("%FX")
 
 

--- a/docs/wait_long_operations.txt
+++ b/docs/wait_long_operations.txt
@@ -59,7 +59,8 @@ Decorators :func:`pywinauto.timings.always_wait_until()` and
 :func:`pywinauto.timings.always_wait_until_passes()` can also be used
 if every function call should have timing control. ::
 
-    # call foo() every 2 sec until it's passed or timeout (4 sec) is expired
+    # call ensure_text_changed(ctrl) every 2 sec until it's passed or timeout (4 sec) is expired
+    
     @always_wait_until_passes(4, 2)
     def ensure_text_changed(ctrl):
         if previous_text == ctrl.window_text():

--- a/docs/wait_long_operations.txt
+++ b/docs/wait_long_operations.txt
@@ -55,17 +55,28 @@ There are also low-level methods useful for any Python code.
 .. _wait_until_passes: code/pywinauto.timings.html?highlight=wait_until_passes#pywinauto.timings.wait_until_passes
 
 
+Decorators :func:`pywinauto.timings.always_wait_until()` and
+:func:`pywinauto.timings.always_wait_until_passes()` can also be used
+if every function call should have timing control. ::
+
+    # call foo() every 2 sec until it's passed or timeout (4 sec) is expired
+    @always_wait_until_passes(4, 2)
+    def ensure_text_changed(ctrl):
+        if previous_text == ctrl.window_text():
+            raise ValueError('The ctrl text remains the same while change is expected')
+
+
 Identify controls
 -----------------
 
 The methods to help you to find a needed control.
 
-  * PrintControlIdentifiers_
-  * DrawOutline_
+  * print_control_identifiers_
+  * draw_outline_
 
 
-.. _PrintControlIdentifiers: code/pywinauto.application.html?highlight=PrintControlIdentifiers#pywinauto.application.WindowSpecification.PrintControlIdentifiers
-.. _DrawOutline: code/pywinauto.controls.hwndwrapper.html?highlight=DrawOutline#pywinauto.controls.hwndwrapper.HwndWrapper.DrawOutline
+.. _print_control_identifiers: code/pywinauto.application.html?highlight=print_control_identifiers#pywinauto.application.WindowSpecification.print_control_identifiers
+.. _draw_outline: code/pywinauto.controls.hwndwrapper.html?highlight=draw_outline#pywinauto.controls.hwndwrapper.HwndWrapper.draw_outline
 
 
 How To`s

--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -32,7 +32,7 @@
 
 """Python package for automating GUI manipulation on Windows"""
 
-__version__ = "0.6.0.rc1"
+__version__ = "0.6.0.rc2"
 
 import sys
 

--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -32,7 +32,7 @@
 
 """Python package for automating GUI manipulation on Windows"""
 
-__version__ = "0.6.0.rc2"
+__version__ = "0.6.0"
 
 import sys
 

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -59,7 +59,7 @@ in almost exactly the same ways. ::
 .. seealso::
 
    :func:`pywinauto.findwindows.find_elements` for the keyword arguments that
-   can be passed to both: :func:`Application.window_` and
+   can be passed to both: :func:`Application.window` and
    :func:`WindowSpecification.child_window`
 """
 from __future__ import print_function
@@ -1159,7 +1159,7 @@ class Application(object):
         return self.match_history[index]
 
 
-    def Kill_(self):
+    def kill(self):
         """
         Try to close and kill the application
 
@@ -1201,7 +1201,8 @@ class Application(object):
 
         return killed
 
-    kill_ = Kill_
+    # Non PEP-8 aliases
+    kill_ = Kill_ = kill
 
 
 #=========================================================================

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -588,29 +588,40 @@ class WindowSpecification(object):
 
             indent = (current_depth - 1) * u"   | "
             for ctrl in ctrls:
-                output = indent + '\n'
-                output += indent + u"{class_name} - '{text}'    {rect}\t\n"\
-                    "".format(class_name=ctrl.friendly_class_name(),
-                             text=ctrl.window_text(),
-                             rect=ctrl.rectangle())
-                output += indent + '{}\n'.format(control_name_map[ctrl])
+                if ctrl not in control_name_map.keys():
+                    continue
+                ctrl_text = ctrl.window_text()
+                if ctrl_text:
+                    # transform multi-line text to one liner
+                    ctrl_text = ctrl.window_text().replace('\n', r'\n').replace('\r', r'\r')
 
-                title = ctrl.window_text()
+                output = indent + u'\n'
+                output += indent + u"{class_name} - '{text}'    {rect}\n"\
+                    "".format(class_name=ctrl.friendly_class_name(),
+                             text=ctrl_text,
+                             rect=ctrl.rectangle())
+                output += indent + u'{}\n'.format(control_name_map[ctrl])
+
+                title = ctrl_text
                 class_name = ctrl.class_name()
                 auto_id = None
+                control_type = None
                 if hasattr(ctrl.element_info, 'automation_id'):
                     auto_id = ctrl.element_info.automation_id
+                if hasattr(ctrl.element_info, 'control_type'):
+                    control_type = ctrl.element_info.control_type
+                    class_name = None # no need for class_name if control_type exists
                 criteria_texts = []
                 if title:
-                    criteria_texts.append('title="{}"'.format(title))
+                    criteria_texts.append(u'title="{}"'.format(title))
                 if class_name:
-                    criteria_texts.append('class_name="{}"'.format(class_name))
+                    criteria_texts.append(u'class_name="{}"'.format(class_name))
                 if auto_id:
-                    criteria_texts.append('auto_id="{}"'.format(auto_id))
-                #if control_type:
-                #    criteria_texts.append('control_type="{}"'.format(control_type))
+                    criteria_texts.append(u'auto_id="{}"'.format(auto_id))
+                if control_type:
+                    criteria_texts.append('control_type="{}"'.format(control_type))
                 if title or class_name or auto_id:
-                    output += indent + 'child_window(' + ', '.join(criteria_texts) + ')'
+                    output += indent + u'child_window(' + u', '.join(criteria_texts) + u')'
                 print(output)
 
                 print_identifiers(ctrl.children(), current_depth + 1)

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -551,10 +551,7 @@ class BaseWrapper(object):
         Raise either ElementNotEnalbed or ElementNotVisible if not
         enabled or visible respectively.
         """
-        if self.backend.name == 'win32' and self.handle:
-            win32functions.WaitGuiThreadIdle(self)
-        # TODO: find WaitGuiThreadIdle function for elements without handle
-
+        self.wait_for_idle()
         self.verify_visible()
         self.verify_enabled()
 
@@ -712,12 +709,7 @@ class BaseWrapper(object):
 
         self.click_input(button='move', coords=coords, absolute=absolute, pressed=pressed)
 
-        if self.element_info.handle:
-            win32functions.WaitGuiThreadIdle(self)
-        else:
-            # TODO: get WaitGuiThreadIdle function for elements without handle
-            pass
-
+        self.wait_for_idle()
         return self
 
     # -----------------------------------------------------------
@@ -787,6 +779,12 @@ class BaseWrapper(object):
         return self
 
     #-----------------------------------------------------------
+    def wait_for_idle(self):
+        """Backend specific function to wait for idle state of a thread or a window"""
+        pass # do nothing by deafault
+        # TODO: implement wait_for_idle for backend="uia"
+
+    #-----------------------------------------------------------
     def type_keys(
         self,
         keys,
@@ -846,11 +844,7 @@ class BaseWrapper(object):
             # TODO: UIA stuff
             pass
 
-        if self.element_info.handle:
-            win32functions.WaitGuiThreadIdle(self)
-        else:
-            # TODO: get WaitGuiThreadIdle function for elements without handle
-            pass
+        self.wait_for_idle()
 
         self.actions.log('Typed text to the ' + self.friendly_class_name() + ': ' + aligned_keys)
         return self

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -551,11 +551,10 @@ class BaseWrapper(object):
         Raise either ElementNotEnalbed or ElementNotVisible if not
         enabled or visible respectively.
         """
-        if self.element_info.handle:
+        if self.backend.name == 'win32' and self.handle:
             win32functions.WaitGuiThreadIdle(self)
-        else:
-            # TODO: get WaitGuiThreadIdle function for elements without handle
-            pass
+        # TODO: find WaitGuiThreadIdle function for elements without handle
+
         self.verify_visible()
         self.verify_enabled()
 
@@ -800,9 +799,10 @@ class BaseWrapper(object):
         """
         Type keys to the element using keyboard.SendKeys
 
-        This uses the re-written keyboard python module like that
-        http://www.rutherfurd.net/python/sendkeys/ .This is the best place
-        to find documentation on what to use for the **keys**
+        This uses the re-written keyboard_ python module where you can
+        find documentation on what to use for the **keys**.
+
+        .. _keyboard: pywinauto.keyboard.html
         """
         self.verify_actionable()
 

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -600,6 +600,11 @@ class HwndWrapper(BaseWrapper):
         """Returns the hash value of the handle"""
         return hash(self.handle)
 
+    #-----------------------------------------------------------
+    def wait_for_idle(self):
+        """Backend specific function to wait for idle state of a thread or a window"""
+        win32functions.WaitGuiThreadIdle(self)
+
     # -----------------------------------------------------------
     def click(
         self, button = "left", pressed = "", coords = (0, 0), double = False, absolute = False):

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -509,8 +509,7 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
         Only items supporting Toggle pattern should answer.
         Raise NoPatternInterfaceError if the pattern is not supported
         """
-        res = (self.iface_toggle.ToggleState_On == toggle_state_on)
-        return res
+        return self.iface_toggle.ToggleState_On == toggle_state_on
 
     def texts(self):
         """Return a list of item texts"""

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -50,10 +50,9 @@ class ButtonWrapper(uiawrapper.UIAWrapper):
 
     """Wrap a UIA-compatible Button, CheckBox or RadioButton control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_ButtonControlTypeId,
-        IUIA().UIA_dll.UIA_CheckBoxControlTypeId,
-        IUIA().UIA_dll.UIA_RadioButtonControlTypeId
+    _control_types = ['Button',
+        'CheckBox',
+        'RadioButton',
     ]
 
     # -----------------------------------------------------------
@@ -120,9 +119,7 @@ class ComboBoxWrapper(uiawrapper.UIAWrapper):
 
     """Wrap a UIA CoboBox control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_ComboBoxControlTypeId
-    ]
+    _control_types = ['ComboBox']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -201,9 +198,7 @@ class EditWrapper(uiawrapper.UIAWrapper):
     # TODO: this class supports only 1-line textboxes so there is no point
     # TODO: in methods such as line_count(), line_length(), get_line(), etc
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_EditControlTypeId,
-    ]
+    _control_types = ['Edit']
     has_title = False
 
     # -----------------------------------------------------------
@@ -379,9 +374,7 @@ class TabControlWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Tab control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_TabControlTypeId,
-    ]
+    _control_types = ['Tab']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -415,9 +408,7 @@ class SliderWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Slider control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_SliderControlTypeId,
-    ]
+    _control_types = ['Slider']
     has_title = False
 
     # -----------------------------------------------------------
@@ -485,9 +476,7 @@ class HeaderWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Header control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_HeaderControlTypeId,
-    ]
+    _control_types = ['Header']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -500,10 +489,7 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible ListViewItem control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_DataItemControlTypeId,
-        IUIA().UIA_dll.UIA_ListItemControlTypeId,
-    ]
+    _control_types = ['DataItem', 'ListItem', ]
 
     # -----------------------------------------------------------
     def __init__(self, elem, container=None):
@@ -541,10 +527,7 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible ListView control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_DataGridControlTypeId,
-        IUIA().UIA_dll.UIA_ListControlTypeId,
-    ]
+    _control_types = ['DataGrid', 'List', ]
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -739,9 +722,7 @@ class MenuItemWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible MenuItem control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_MenuItemControlTypeId,
-    ]
+    _control_types = ['MenuItem']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -770,10 +751,7 @@ class MenuWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible MenuBar or Menu control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_MenuBarControlTypeId,
-        IUIA().UIA_dll.UIA_MenuControlTypeId
-    ]
+    _control_types = ['MenuBar', 'Menu', ]
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -882,9 +860,7 @@ class TooltipWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Tooltip control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_ToolTipControlTypeId
-    ]
+    _control_types = ['ToolTip']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -903,9 +879,7 @@ class ToolbarWrapper(uiawrapper.UIAWrapper):
     not of the toolbar.
     """
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_ToolBarControlTypeId
-    ]
+    _control_types = ['ToolBar']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -1003,9 +977,7 @@ class TreeItemWrapper(uiawrapper.UIAWrapper):
     click_input(), rectangle() and many others
     """
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_TreeItemControlTypeId
-    ]
+    _control_types = ['TreeItem']
 
     # -----------------------------------------------------------
     def __init__(self, elem):
@@ -1084,9 +1056,7 @@ class TreeViewWrapper(uiawrapper.UIAWrapper):
 
     """Wrap an UIA-compatible Tree control"""
 
-    _control_types = [
-        IUIA().UIA_dll.UIA_TreeControlTypeId
-    ]
+    _control_types = ['Tree']
 
     # -----------------------------------------------------------
     def __init__(self, elem):

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -134,6 +134,7 @@ lazy_property = LazyProperty
 
 # =========================================================================
 class UiaMeta(BaseMeta):
+
     """Metaclass for UiaWrapper objects"""
     control_type_to_cls = {}
 

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -334,10 +334,10 @@ class UIAWrapper(BaseWrapper):
         of a CheckBox is "Button" - but the friendly class is "CheckBox"
         """
         if self.friendlyclassname is None:
-            if self.element_info.control_type not in IUIA().known_control_type_ids.keys():
-                self.friendlyclassname = str(self.element_info.control_type)
+            if self.element_info.control_type not in IUIA().known_control_types.keys():
+                self.friendlyclassname = self.element_info.control_type
             else:
-                ctrl_type = IUIA().known_control_type_ids[self.element_info.control_type]
+                ctrl_type = self.element_info.control_type
                 if (ctrl_type not in _friendly_classes) or (_friendly_classes[ctrl_type] is None):
                     self.friendlyclassname = ctrl_type
                 else:

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -221,9 +221,6 @@ def find_elements(class_name=None,
     if control_id is not None and elements:
         elements = [elem for elem in elements if elem.control_id == control_id]
 
-    if auto_id is not None and elements:
-        elements = [elem for elem in elements if elem.automation_id == auto_id]
-
     if active_only:
         # TODO: re-write to use ElementInfo interface
         gui_info = win32structures.GUITHREADINFO()
@@ -250,6 +247,9 @@ def find_elements(class_name=None,
     if class_name_re is not None:
         class_name_regex = re.compile(class_name_re)
         elements = [elem for elem in elements if class_name_regex.match(elem.class_name)]
+
+    if auto_id is not None and elements:
+        elements = [elem for elem in elements if elem.automation_id == auto_id]
 
     if process is not None:
         elements = [elem for elem in elements if elem.process_id == process]

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -135,6 +135,7 @@ def find_elements(class_name=None,
                   predicate_func=None,
                   active_only=False,
                   control_id=None,
+                  control_type=None,
                   auto_id=None,
                   framework_id=None,
                   backend=None,
@@ -160,6 +161,7 @@ def find_elements(class_name=None,
     * **predicate_func** A user provided hook for a custom element validation
     * **active_only**    Active elements only (default=False)
     * **control_id**     Elements with this control id
+    * **control_type**   Elements with this control type (string; for UIAutomation elements)
     * **auto_id**        Elements with this automation id (for UIAutomation elements)
     * **framework_id**   Elements with this framework id (for UIAutomation elements)
     * **backend**        Back-end name to use while searching (default=None means current active backend)
@@ -184,7 +186,8 @@ def find_elements(class_name=None,
         elements = element.children(process=process,
                                     class_name=class_name,
                                     title=title,
-                                    cache_enable=True)  # root.children == enum_windows()
+                                    control_type=control_type,
+                                    cache_enable=True)
 
         # if we have been given a parent
         if parent:
@@ -200,7 +203,8 @@ def find_elements(class_name=None,
         elements = parent.descendants(process=process,
                                       class_name=class_name,
                                       title=title,
-                                      cache_enable=True)  # root.children == enum_windows()
+                                      control_type=control_type,
+                                      cache_enable=True)
 
         # if the ctrl_index has been specified then just return
         # that control

--- a/pywinauto/uia_defines.py
+++ b/pywinauto/uia_defines.py
@@ -87,7 +87,7 @@ class IUIA(object):
 
         for ctrl_type in self._control_types:
             type_id_name = 'UIA_' + ctrl_type + 'ControlTypeId'
-            type_id = self.UIA_dll.__getattribute__(type_id_name)
+            type_id = getattr(self.UIA_dll, type_id_name)
             self.known_control_types[ctrl_type] = type_id
             self.known_control_type_ids[type_id] = ctrl_type
     

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -100,7 +100,7 @@ class UIAElementInfo(ElementInfo):
     def _get_current_control_type(self):
         """Return an actual control type of the element"""
         try:
-            return self._element.CurrentControlType
+            return IUIA().known_control_type_ids[self._element.CurrentControlType]
         except COMError:
             return None # probably element already doesn't exist
 

--- a/setup.py
+++ b/setup.py
@@ -56,8 +56,13 @@ sys.path.append(setup_path())
 #    if not os.path.exists(setup_path("docs")):
 #        shutil.move(setup_path("website"), setup_path("docs"))
 
+if sys.platform == 'win32':
+    install_requires = ['six', 'pypiwin32', 'comtypes']
+else:
+    install_requires = ['six', 'python-xlib']
+
 setup(name='pywinauto',
-    version = '0.6.0.rc1',
+    version = '0.6.0',
     description = 'pywinauto is a set of python '
         'modules to automate the Microsoft Windows GUI',
     keywords = "windows automation gui GuiAuto",
@@ -92,6 +97,6 @@ controls also.
         'Topic :: Software Development :: User Interfaces',
         'Topic :: Software Development :: Quality Assurance',
         ],
-    install_requires=['six', 'pypiwin32', 'comtypes'],
+    install_requires=install_requires,
     setup_requires=['setuptools-scm'],
     )


### PR DESCRIPTION
* One more chapter of the Getting Started Guide
* `control_type` property returns a string now
* `control_type` can be used in window specifications as a string
* Issue #254 is fixed