### PR TITLE
Refactoring the "hooks" module (part 1)

### DIFF
--- a/examples/hook_and_listen.py
+++ b/examples/hook_and_listen.py
@@ -1,9 +1,9 @@
 import win32api
 import win32con
 from threading import Timer
-from pywinauto.hooks import Hook
-from pywinauto.hooks import KeyboardEvent
-from pywinauto.hooks import MouseEvent
+from pywinauto.win32_hooks import Hook
+from pywinauto.win32_hooks import KeyboardEvent
+from pywinauto.win32_hooks import MouseEvent
 
 
 def on_timer():

--- a/pywinauto/win32_hooks.py
+++ b/pywinauto/win32_hooks.py
@@ -58,6 +58,7 @@ from ctypes import c_uint
 from ctypes import c_void_p
 from ctypes import byref
 import atexit
+import sys
 import time
 
 cmp_func = CFUNCTYPE(c_int, c_int, wintypes.HINSTANCE, POINTER(c_void_p))
@@ -347,9 +348,9 @@ class Hook(object):
                 if not res:
                     break
                 if message.message == WM_QUIT:
-                    hk.unhook_keyboard()
-                    hk.unhook_mouse()
-                    exit(0)
+                    self.unhook_keyboard()
+                    self.unhook_mouse()
+                    sys.exit(0)
                 else:
                     windll.user32.TranslateMessage(byref(message))
                     windll.user32.DispatchMessageW(byref(message))


### PR DESCRIPTION
Refactorings as per #258 
-  rename hooks.py to win32_hooks.py
- switch the hooks listening loop to PeekMessageW instead of GetMessageW

(more work still to be done: unit tests, the code style)
