### PR TITLE
Fix issue 270: Replace AttachThreadInput with ShowWindow in set_focus()

### DIFF
--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1164,7 +1164,7 @@ class HwndWrapper(BaseWrapper):
         """
         Set the focus to this control.
 
-        Bring the window to the foreground first if necessary.
+        Bring the window to the foreground first.
         The system restricts which processes can set the foreground window
         (https://msdn.microsoft.com/en-us/library/windows/desktop/ms633539(v=vs.85).aspx)
         so the mouse cursor is removed from the screen to prevent any side effects.
@@ -1173,68 +1173,17 @@ class HwndWrapper(BaseWrapper):
         # but we don't use the built-in methods of the class:
         # self.mouse_move doesn't do the job well even with absolute=True
         # self.move_mouse_input can't be used as it calls click_input->set_focus
+        mouse.move(coords=(10000, 20000))
 
-        # find the current foreground window
-        cur_foreground = win32gui.GetForegroundWindow()
+        # change active window
+        win32gui.ShowWindow(self.handle, win32con.SW_RESTORE)
+        win32gui.SetForegroundWindow(self.handle)
 
-        # if there is no active window bring our window into the foreground
-        if not cur_foreground:
-            mouse.move(coords=(10000, 20000))
-            win32gui.SetForegroundWindow(self.handle)
-            win32functions.WaitGuiThreadIdle(self)
-            time.sleep(Timings.after_setfocus_wait)
+        # make sure that we are idle before returning
+        win32functions.WaitGuiThreadIdle(self)
 
-        # "steel the focus" if there is another active window
-        # otherwise it is already into the foreground and no action required
-        elif self.handle != cur_foreground:
-            mouse.move(coords=(10000, 20000))
-
-            # get the thread of the window that is in the foreground
-            cur_fore_thread = win32process.GetWindowThreadProcessId(
-                cur_foreground)[0]
-
-            # get the thread of the window that we want to be in the foreground
-            control_thread = win32process.GetWindowThreadProcessId(
-                self.handle)[0]
-
-            # if a different thread owns the active window
-            if cur_fore_thread != control_thread:
-
-                # Attach the two threads and set the foreground window
-                win32process.AttachThreadInput(control_thread,
-                                               cur_fore_thread,
-                                               1)
-
-                win32gui.SetForegroundWindow(self.handle)
-
-                # ensure foreground window has changed to the target
-                # or is 0(no foreground window) before the threads detaching
-                timings.wait_until(
-                    Timings.setfocus_timeout,
-                    Timings.setfocus_retry,
-                    lambda: win32gui.GetForegroundWindow()
-                    in [self.top_level_parent().handle, 0])
-
-                # get the threads again to check they are still valid.
-                cur_fore_thread = win32process.GetWindowThreadProcessId(
-                    cur_foreground)[0]
-                control_thread = win32process.GetWindowThreadProcessId(
-                    self.handle)[0]
-
-                if cur_fore_thread and control_thread:  # both are valid
-                    # Detach the threads
-                    win32process.AttachThreadInput(control_thread,
-                                                   cur_fore_thread,
-                                                   0)
-            else:
-                # same threads - just set the foreground window
-                win32gui.SetForegroundWindow(self.handle)
-
-            # make sure that we are idle before returning
-            win32functions.WaitGuiThreadIdle(self)
-
-            # only sleep if we had to change something!
-            time.sleep(Timings.after_setfocus_wait)
+        # only sleep if we had to change something!
+        time.sleep(Timings.after_setfocus_wait)
 
         return self
     # Non PEP-8 alias

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -687,6 +687,46 @@ class NonActiveWindowFocusTests(unittest.TestCase):
         dlg1.set_focus()
         self.assertEqual(ws.GetFocus(), ws.Edit.wrapper_object())
 
+
+class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
+
+    """
+    Regression unit tests for setting focus when window does not have
+    a message loop.
+    """
+
+    def setUp(self):
+        """Set some data and ensure the application is in the state we want"""
+        Timings.Fast()
+
+        self.app1 = Application().start(u"cmd.exe",
+                                        create_new_console=True,
+                                        wait_for_idle=False)
+        self.app2 = Application().start(os.path.join(
+            mfc_samples_folder, u"CmnCtrl2.exe"))
+
+    def tearDown(self):
+        """Close the application after tests"""
+        self.app1.kill_()
+        self.app2.kill_()
+
+    def test_issue_270(self):
+        """
+        Set focus to a window without a message loop, then switch to a window
+        with one and type in it.
+        """
+        self.app1.window().set_focus()
+        # pywintypes.error:
+        #     (87, 'AttachThreadInput', 'The parameter is incorrect.')
+
+        self.app2.window().edit.type_keys("1")
+        # cmd.exe into python.exe;  pywintypes.error:
+        #     (87, 'AttachThreadInput', 'The parameter is incorrect.')
+        # python.exe on its own;  pywintypes.error:
+        #     (0, 'SetForegroundWindow', 'No error message is available')
+        self.assertTrue(self.app2.window().is_active())
+
+
 class NotepadRegressionTests(unittest.TestCase):
 
     """Regression unit tests for Notepad"""


### PR DESCRIPTION
```AttachThreadInput``` fails when the foreground window does not have a message loop, namely cmd.exe. Using ```ShowWindow``` instead avoids the need for a lot of the existing handling to juggle threads.

While it was suggested in #270 that the ```mouse.move()``` calls may cause problems as well, I left it alone since it was outside the scope of this specific issue.