### PR TITLE
Handle 'parent' filter as WindowSpecification

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -193,6 +193,9 @@ class WindowSpecification(object):
                 if "parent" not in ctrl_criteria:
                     ctrl_criteria["parent"] = previous_parent
 
+                if isinstance(ctrl_criteria["parent"], WindowSpecification):
+                    ctrl_criteria["parent"] = ctrl_criteria["parent"].wrapper_object()
+
                 # resolve the control and return it
                 if 'backend' not in ctrl_criteria:
                     ctrl_criteria['backend'] = self.backend.name

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -375,31 +375,25 @@ class BaseWrapper(object):
         return texts_list
 
     #-----------------------------------------------------------
-    def children(self, class_name=None, title=None, control_type=None, content_only=None):
+    def children(self, **kwargs):
         """
         Return the children of this element as a list
 
         It returns a list of BaseWrapper (or subclass) instances.
         An empty list is returned if there are no children.
         """
-        child_elements = self.element_info.children(class_name=class_name,
-                                                    title=title,
-                                                    control_type=control_type,
-                                                    content_only=content_only)
+        child_elements = self.element_info.children(**kwargs)
         return [self.backend.generic_wrapper_class(element_info) for element_info in child_elements]
 
     #-----------------------------------------------------------
-    def descendants(self, class_name=None, title=None, control_type=None, content_only=None):
+    def descendants(self, **kwargs):
         """
         Return the descendants of this element as a list
 
         It returns a list of BaseWrapper (or subclass) instances.
         An empty list is returned if there are no descendants.
         """
-        desc_elements = self.element_info.descendants(class_name=class_name,
-                                                      title=title,
-                                                      control_type=control_type,
-                                                      content_only=content_only)
+        desc_elements = self.element_info.descendants(**kwargs)
         return [self.backend.generic_wrapper_class(element_info) for element_info in desc_elements]
 
     #-----------------------------------------------------------

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -176,8 +176,10 @@ def find_elements(class_name=None,
     if handle is not None:
         return [backend_obj.element_info_class(handle), ]
 
-    # check if parent is a handle of element (in case of searching native controls)
-    if parent and isinstance(parent, six.integer_types):
+    if isinstance(parent, backend_obj.generic_wrapper_class):
+        parent = parent.element_info
+    elif isinstance(parent, six.integer_types):
+        # check if parent is a handle of element (in case of searching native controls)
         parent = backend_obj.element_info_class(parent)
 
     if top_level_only:

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -440,7 +440,7 @@ class ApplicationTestCases(unittest.TestCase):
         self.assertRaises(AppNotConnected, app.windows_, **{'title' : 'not connected'})
 
         app.start('notepad.exe')
-        
+
         self.assertRaises(ValueError, app.windows_, **{'backend' : 'uia'})
 
         notepad_handle = app.UntitledNotepad.handle
@@ -639,6 +639,9 @@ class WindowSpecificationTestCases(unittest.TestCase):
             "Notepad",
             self.dlgspec.class_name())
 
+        # Check handling 'parent' as a WindowSpecification
+        spec = self.ctrlspec.child_window(parent=self.dlgspec)
+        self.assertEqual(spec.class_name(), "Edit")
 
     def test_exists(self):
         """Check that windows exist"""
@@ -870,34 +873,34 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
 class WaitUntilDecoratorTests(unittest.TestCase):
     """Unit tests for always_wait_until and always_wait_until_passes decorators"""
-    
+
     def test_always_wait_until_decorator_success(self):
         """Test always_wait_until_decorator success"""
-        
+
         @always_wait_until(4, 2)
         def foo():
             return True
         self.assertTrue(foo())
-        
+
     def test_always_wait_until_decorator_failure(self):
         """Test wait_until_decorator failure"""
-        
+
         @always_wait_until(4, 2)
         def foo():
             return False
         self.assertRaises(TimeoutError, foo)
-        
+
     def test_always_wait_until_passes_decorator_success(self):
         """Test always_wait_until_passes_decorator success"""
-        
+
         @always_wait_until_passes(4, 2)
         def foo():
             return True
         self.assertTrue(foo())
-        
+
     def test_always_wait_until_passes_decorator_failure(self):
         """Test always_wait_until_passes_decorator failure"""
-        
+
         @always_wait_until_passes(4, 2)
         def foo():
             raise Exception("Unexpected Error in foo")


### PR DESCRIPTION
findwindows: handle 'parent' filter when it's passed as WindowSpecification
base_wrapper: fix passing through **kwargs for BaseWrapper.children() and BaseWrapper.descendants()

The fix should help for following example from the issue #256 when child_window gets 'parent' parameter as WindowSpecification:
```
app = pywinauto.Application(backend='uia')
appconnect = app.connect(path='WpfApplication1.exe')
appwindow = appconnect.window(title="WPF Sample Application", control_type="Window")
secondwindow = appwindow.child_window(title="Alpha", control_type="ToolBar")
button = secondwindow.child_window(parent=secondwindow, title="button 1", auto_id="toolbar_button1", control_type="Button")
button.click_input()
```