### PR TITLE
Speed up unit tests and more PEP-8 fixes

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -1175,14 +1175,16 @@ class Application(object):
 
         for win in windows:
 
-            if hasattr(win, 'force_close') and win.force_close():
-                continue
-
             try:
                 if hasattr(win, 'close'):
                     win.close()
+                    continue
             except TimeoutError:
                 self.actions.log('Failed to close top level window')
+
+            if hasattr(win, 'force_close'):
+                self.actions.log('application.kill: call win.force_close')
+                win.force_close()
 
         try:
             process_wait_handle = win32api.OpenProcess(

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -92,17 +92,22 @@ from .sysinfo import is_x64_Python
 class AppStartError(Exception):
 
     """There was a problem starting the Application"""
-    pass    #pragma: no cover
+
+    pass    # pragma: no cover
+
 
 class ProcessNotFoundError(Exception):
 
     """Could not find that process"""
-    pass    #pragma: no cover
+
+    pass    # pragma: no cover
+
 
 class AppNotConnected(Exception):
 
     """Application has not been connected to a process yet"""
-    pass    #pragma: no cover
+
+    pass    # pragma: no cover
 
 
 # Display User and Deprecation warnings every time
@@ -161,8 +166,8 @@ class WindowSpecification(object):
         """No __call__ so return a usefull error"""
         if "best_match" in self.criteria[-1]:
             raise AttributeError(
-                "WindowSpecification class has no '{0}' method".\
-                format(self.criteria[-1]['best_match']) )
+                "WindowSpecification class has no '{0}' method".
+                format(self.criteria[-1]['best_match']))
 
         message = (
             "You tried to execute a function call on a WindowSpecification "
@@ -171,7 +176,6 @@ class WindowSpecification(object):
             "The criteria leading up to this is: " + str(self.criteria))
 
         raise AttributeError(message)
-
 
     def __get_ctrl(self, criteria_):
         """Get a control based on the various criteria"""
@@ -208,7 +212,6 @@ class WindowSpecification(object):
         else:
             return (dialog, )
 
-
     def __resolve_control(self, criteria, timeout=None, retry_interval=None):
         """
         Find a control using criteria
@@ -233,16 +236,15 @@ class WindowSpecification(object):
                 retry_interval,
                 self.__get_ctrl,
                 (findwindows.ElementNotFoundError,
-                findbestmatch.MatchError,
-                controls.InvalidWindowHandle,
-                controls.InvalidElement),
+                 findbestmatch.MatchError,
+                 controls.InvalidWindowHandle,
+                 controls.InvalidElement),
                 criteria)
 
         except TimeoutError as e:
             raise e.original_exception
 
         return ctrl
-
 
     def wrapper_object(self):
         """Allow the calling code to get the HwndWrapper object"""
@@ -311,10 +313,9 @@ class WindowSpecification(object):
         new_item = WindowSpecification(self.criteria[0])
 
         # add our new criteria
-        new_item.criteria.append({"best_match" : key})
+        new_item.criteria.append({"best_match": key})
 
         return new_item
-
 
     def __getattribute__(self, attr_name):
         """
@@ -365,7 +366,6 @@ class WindowSpecification(object):
         # deal with it
         return self[attr_name]
 
-
     def exists(self, timeout=None, retry_interval=None):
         """
         Check if the window exists, return True if the control exists
@@ -382,7 +382,6 @@ class WindowSpecification(object):
         if retry_interval is None:
             retry_interval = Timings.exists_retry
 
-
         # modify the criteria as exists should look for all
         # windows - including not visible and disabled
         exists_criteria = self.criteria[:]
@@ -394,11 +393,10 @@ class WindowSpecification(object):
             self.__resolve_control(exists_criteria, timeout, retry_interval)
 
             return True
-        except (
-            findwindows.ElementNotFoundError,
-            findbestmatch.MatchError,
-            controls.InvalidWindowHandle,
-            controls.InvalidElement):
+        except (findwindows.ElementNotFoundError,
+                findbestmatch.MatchError,
+                controls.InvalidWindowHandle,
+                controls.InvalidElement):
             return False
 
     @classmethod
@@ -601,8 +599,8 @@ class WindowSpecification(object):
                 output = indent + u'\n'
                 output += indent + u"{class_name} - '{text}'    {rect}\n"\
                     "".format(class_name=ctrl.friendly_class_name(),
-                             text=ctrl_text,
-                             rect=ctrl.rectangle())
+                              text=ctrl_text,
+                              rect=ctrl.rectangle())
                 output += indent + u'{}\n'.format(control_name_map[ctrl])
 
                 title = ctrl_text
@@ -613,7 +611,7 @@ class WindowSpecification(object):
                     auto_id = ctrl.element_info.automation_id
                 if hasattr(ctrl.element_info, 'control_type'):
                     control_type = ctrl.element_info.control_type
-                    class_name = None # no need for class_name if control_type exists
+                    class_name = None  # no need for class_name if control_type exists
                 criteria_texts = []
                 if title:
                     criteria_texts.append(u'title="{}"'.format(title))
@@ -634,8 +632,9 @@ class WindowSpecification(object):
 
 cur_item = 0
 
+
 def _resolve_from_appdata(
-    criteria_, app, timeout=None, retry_interval=None):
+        criteria_, app, timeout=None, retry_interval=None):
     """Should not be used at the moment!"""
     # TODO: take a look into this functionality
 
@@ -658,7 +657,6 @@ def _resolve_from_appdata(
         for c in criteria:
             if unloc_attrib in c.keys():
                 del c[unloc_attrib]
-
 
     #found_criteria = item[0]
     #for c in found_criteria:
@@ -737,8 +735,7 @@ def _resolve_from_appdata(
                 if len(ctrl_elems) > 1:
                     same_ids = \
                         [elem for elem in ctrl_elems
-                         if elem.control_id == \
-                         matched_control[2]['control_id']]
+                         if elem.control_id == matched_control[2]['control_id']]
 
                     if same_ids:
                         ctrl_elems = same_ids
@@ -752,7 +749,6 @@ def _resolve_from_appdata(
                     raise
 
                 break
-
 
     # it is possible that the dialog will not be found - so we
     # should raise an error
@@ -770,50 +766,48 @@ def _resolve_from_appdata(
     #print process_hwnds
 
 
-##
-##        # if best match was specified for the dialog
-##        # then we need to replace it with other values
-##        # for now we will just use class_name
-##        for crit in ['best_match', 'title', 'title_re']:
-##            if crit in criteria[0]:
-##                del(criteria[0][crit])
-##                criteria[0]['class_name'] = app_data[0].class_name()#['class_name']
-##
-##            if len(criteria) > 1:
-##                # find the best match of the application data
-##                if criteria[1].has_key('best_match'):
-##                    best_match = findbestmatch.find_best_control_matches(
-##                        criteria[1]['best_match'], app_data)[0]
-##
-##                    #visible_controls = [ctrl in app_data if ctrl.is_visible()]
-##
-##                    #find the index of the best match item
-##                    ctrl_index = app_data.index(best_match)
-##                    #print best_match[0].window_text()
-##                    ctrl_index, best_match.window_text()
-##
-##                    criteria[1]['ctrl_index'] = ctrl_index -1
-##                    #criteria[1]['class_name'] = best_match.class_name()
-##                    #del(criteria[1]['best_match'])
-##
-## One idea here would be to run the new criteria on the app_data dialog and
-## if it returns more then one control then you figure out which one would be
-## best - so that you have that info when running on the current dialog
-##
-##            #for criterion in criteria[1:]:
-##                # this part is weird - we now have to go off and find the
-##                # index, class, text of the control in the app_data
-##                # and then find the best match for this control in the
-##                # current dialog
-##            #    pass
-##
-##
+#
+#        # if best match was specified for the dialog
+#        # then we need to replace it with other values
+#        # for now we will just use class_name
+#        for crit in ['best_match', 'title', 'title_re']:
+#            if crit in criteria[0]:
+#                del(criteria[0][crit])
+#                criteria[0]['class_name'] = app_data[0].class_name()#['class_name']
+#
+#            if len(criteria) > 1:
+#                # find the best match of the application data
+#                if criteria[1].has_key('best_match'):
+#                    best_match = findbestmatch.find_best_control_matches(
+#                        criteria[1]['best_match'], app_data)[0]
+#
+#                    #visible_controls = [ctrl in app_data if ctrl.is_visible()]
+#
+#                    #find the index of the best match item
+#                    ctrl_index = app_data.index(best_match)
+#                    #print best_match[0].window_text()
+#                    ctrl_index, best_match.window_text()
+#
+#                    criteria[1]['ctrl_index'] = ctrl_index -1
+#                    #criteria[1]['class_name'] = best_match.class_name()
+#                    #del(criteria[1]['best_match'])
+#
+# One idea here would be to run the new criteria on the app_data dialog and
+# if it returns more then one control then you figure out which one would be
+# best - so that you have that info when running on the current dialog
+#
+#            #for criterion in criteria[1:]:
+#                # this part is weird - we now have to go off and find the
+#                # index, class, text of the control in the app_data
+#                # and then find the best match for this control in the
+#                # current dialog
+#            #    pass
+#
+#
 
 #    dialog = None
 
     #return _resolve_control(criteria_, timeout, retry_interval)
-
-
 
 
 #=========================================================================
@@ -947,8 +941,7 @@ class Application(object):
         except Exception as exc:
             # if it failed for some reason
             message = ('Could not create the process "%s"\n'
-                'Error returned by CreateProcess: %s')% (
-                    cmd_line, str(exc))
+                       'Error returned by CreateProcess: %s') % (cmd_line, str(exc))
             raise AppStartError(message)
 
         self.process = dw_process_id
@@ -1086,7 +1079,6 @@ class Application(object):
 
         return WindowSpecification(criteria)
 
-
     def windows(self, **kwargs):
         """Return a list of wrapped top level windows of the application"""
         if not self.process:
@@ -1107,7 +1099,6 @@ class Application(object):
 
         windows = findwindows.find_elements(**kwargs)
         return [self.backend.generic_wrapper_class(win) for win in windows]
-
 
     def window(self, **kwargs):
         """Return a window of the application
@@ -1161,7 +1152,6 @@ class Application(object):
         """Should not be used - part of application data implementation"""
         return self.match_history[index]
 
-
     def kill(self):
         """
         Try to close and kill the application
@@ -1192,7 +1182,7 @@ class Application(object):
                 0,
                 self.process)
         except win32gui.error:
-            return True # already closed
+            return True  # already closed
 
         # so we have either closed the windows - or the app is hung
         killed = True
@@ -1224,7 +1214,8 @@ def assert_valid_process(process_id):
 
     return process_handle
 
-AssertValidProcess = assert_valid_process # just in case
+AssertValidProcess = assert_valid_process  # just in case
+
 
 #=========================================================================
 def process_get_modules():
@@ -1234,12 +1225,13 @@ def process_get_modules():
     # collect all the running processes
     pids = win32process.EnumProcesses()
     for pid in pids:
-        if pid != 0 and isinstance(pid, int): # skip system process (0x00000000)
+        if pid != 0 and isinstance(pid, int):  # skip system process (0x00000000)
             try:
                 modules.append((pid, process_module(pid), None))
             except (win32gui.error, ProcessNotFoundError):
                 continue
     return modules
+
 
 #=========================================================================
 def _process_get_modules_wmi():
@@ -1252,8 +1244,9 @@ def _process_get_modules_wmi():
     processes = _wmi.ExecQuery('Select * from win32_process')
     for p in processes:
         if isinstance(p.ProcessId, int):
-            modules.append((p.ProcessId, p.ExecutablePath, p.CommandLine)) # p.Name
+            modules.append((p.ProcessId, p.ExecutablePath, p.CommandLine))  # p.Name
     return modules
+
 
 #=========================================================================
 def process_module(process_id):
@@ -1262,15 +1255,17 @@ def process_module(process_id):
 
     return win32process.GetModuleFileNameEx(process_handle, 0)
 
+
 #=========================================================================
 def _warn_incorrect_binary_bitness(exe_name):
     """Warn if the executable is of incorrect bitness"""
     if os.path.isabs(exe_name) and os.path.isfile(exe_name) and \
             handleprops.is64bitbinary(exe_name) and not is_x64_Python():
         warnings.warn(
-            "64-bit binary from 32-bit Python may work incorrectly " \
+            "64-bit binary from 32-bit Python may work incorrectly "
             "(please use 64-bit Python instead)",
             UserWarning, stacklevel=2)
+
 
 #=========================================================================
 def process_from_module(module):

--- a/pywinauto/controls/menuwrapper.py
+++ b/pywinauto/controls/menuwrapper.py
@@ -54,7 +54,11 @@ from .. import mouse
 from ..remote_memory_block import RemoteMemoryBlock
 from ..timings import Timings
 
+
 class MenuItemInfo(object):
+
+    """A holder for Menu Item Info"""
+
     def __init__(self):
         self.fType = 0
         self.fState = 0
@@ -68,6 +72,9 @@ class MenuItemInfo(object):
 
 
 class MenuInfo(object):
+
+    """A holder for Menu Info"""
+
     def __init__(self):
         self.dwStyle = 0
         self.cyMax = 0
@@ -77,12 +84,16 @@ class MenuInfo(object):
 
 
 class MenuItemNotEnabled(RuntimeError):
+
     """Raised when a menu item is not enabled"""
+
     pass
 
 
 class MenuInaccessible(RuntimeError):
+
     """Raised when a menu has handle but inaccessible."""
+
     pass
 
 
@@ -103,7 +114,7 @@ class MenuItem(object):
 
     """Wrap a menu item"""
 
-    def __init__(self, ctrl, menu, index, on_main_menu = False):
+    def __init__(self, ctrl, menu, index, on_main_menu=False):
         """
         Initialize the menu item
 
@@ -117,10 +128,8 @@ class MenuItem(object):
         self.ctrl = ctrl
         self.on_main_menu = on_main_menu
 
-
     def _read_item(self):
-        """
-        Read the menu item info
+        """Read the menu item info
 
         See https://msdn.microsoft.com/en-us/library/windows/desktop/ms647980.aspx
         for more information.
@@ -129,8 +138,8 @@ class MenuItem(object):
         buf, extras = win32gui_struct.EmptyMENUITEMINFO()
         win32gui.GetMenuItemInfo(self.menu.handle, self._index, True, buf)
         item_info.fType, item_info.fState, item_info.wID, item_info.hSubMenu, \
-        item_info.hbmpChecked, item_info.hbmpUnchecked, item_info.dwItemData, \
-        item_info.text, item_info.hbmpItem = win32gui_struct.UnpackMENUITEMINFO(buf)
+            item_info.hbmpChecked, item_info.hbmpUnchecked, item_info.dwItemData, \
+            item_info.text, item_info.hbmpItem = win32gui_struct.UnpackMENUITEMINFO(buf)
 
         return item_info
 
@@ -269,7 +278,7 @@ class MenuItem(object):
 
         if not self.is_enabled():
             raise MenuItemNotEnabled(
-                "MenuItem '%s' is disabled"% self.text())
+                "MenuItem {0} is disabled".format(self.text()))
 
         # if the item is not visible - work up along it's parents
         # until we find an item we CAN click on
@@ -281,7 +290,7 @@ class MenuItem(object):
         x_pt = int(float(rect.left + rect.right) / 2.)
         y_pt = int(float(rect.top + rect.bottom) / 2.)
 
-        mouse.click(coords = (x_pt, y_pt))
+        mouse.click(coords=(x_pt, y_pt))
 
         win32functions.WaitGuiThreadIdle(self.ctrl)
         time.sleep(Timings.after_menu_wait)
@@ -298,7 +307,7 @@ class MenuItem(object):
 
         if not self.is_enabled():
             raise MenuItemNotEnabled(
-                "MenuItem '%s' is disabled"% self.text())
+                "MenuItem {0} is disabled".format(self.text()))
 
         #if self.state() & win32defines.MF_BYPOSITION:
         #    print self.text(), "BYPOSITION"
@@ -358,21 +367,19 @@ class MenuItem(object):
         else:
             return "<MenuItem " + self.text().encode(locale.getpreferredencoding()) + ">"
 
-
-
 #    def check(self):
 #        item = self._read_item()
 #        item.fMask = win32defines.MIIM_STATE
 #        item.fState &= win32defines.MF_CHECKED
 #
-##        ret = win32functions.SetMenuItemInfo(
-##            self.menuhandle,
-##            self.item_id(),
-##            0, # by position
-##            ctypes.byref(item))
-##
-##        if not ret:
-##            raise ctypes.WinError()
+#        #ret = win32functions.SetMenuItemInfo(
+#        #    self.menuhandle,
+#        #    self.item_id(),
+#        #    0, # by position
+#        #    ctypes.byref(item))
+#        #
+#        #if not ret:
+#        #    raise ctypes.WinError()
 #
 #        print win32functions.CheckMenuItem(
 #            self.menuhandle,
@@ -397,23 +404,22 @@ class MenuItem(object):
 #
 #        win32functions.DrawMenuBar(self.ctrl)
 #
-#
+
 
 class Menu(object):
-    """
-    A simple wrapper around a menu handle
+
+    """A simple wrapper around a menu handle
 
     A menu supports methods for querying the menu
     and getting it's menu items.
     """
-    def __init__(
-        self,
-        owner_ctrl,
-        menuhandle,
-        is_main_menu = True,
-        owner_item = None):
-        """
-        Initialize the class
+
+    def __init__(self,
+                 owner_ctrl,
+                 menuhandle,
+                 is_main_menu=True,
+                 owner_item=None):
+        """Initialize the class
 
         * **owner_ctrl** is the Control that owns this menu
         * **menuhandle** is the menu handle of the menu
@@ -442,7 +448,7 @@ class Menu(object):
             self.accessible = False
         else:
             menu_info.dwStyle, menu_info.cyMax, menu_info.hbrBack, menu_info.dwContextHelpID,\
-            menu_info.dwMenuData = win32gui_struct.UnpackMENUINFO(buf)
+                menu_info.dwMenuData = win32gui_struct.UnpackMENUINFO(buf)
 
             if menu_info.dwStyle & win32defines.MNS_NOTIFYBYPOS:
                 self.COMMAND = win32defines.WM_MENUCOMMAND
@@ -457,7 +463,7 @@ class Menu(object):
     ItemCount = item_count
 
     @ensure_accessible
-    def item(self, index, exact = False):
+    def item(self, index, exact=False):
         """
         Return a specific menu item
 
@@ -470,7 +476,7 @@ class Menu(object):
                 menu_appdata = self.ctrl.appdata['menu_items']
             else:
                 menu_appdata = None
-            return self.get_menu_path(index, appdata = menu_appdata, exact=exact)[-1]
+            return self.get_menu_path(index, appdata=menu_appdata, exact=exact)[-1]
         return MenuItem(self.ctrl, self, index, self.is_main_menu)
     # Non PEP-8 alias
     Item = item
@@ -625,10 +631,6 @@ class Menu(object):
 #        item_prop['text'] = item.text()
 #
 #        props.append(item_props)
-#
-#
-#
-#
 #
 #
 #

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -43,21 +43,22 @@ import win32api
 import six
 
 sys.path.append(".")
-from pywinauto.application import Application
-from pywinauto.win32structures import RECT
-from pywinauto import win32defines
-from pywinauto import findbestmatch
-from pywinauto.sysinfo import is_x64_Python
-from pywinauto.remote_memory_block import RemoteMemoryBlock
-from pywinauto.actionlogger import ActionLogger
-from pywinauto.timings import Timings
+from pywinauto.application import Application  # noqa: E402
+from pywinauto.win32structures import RECT  # noqa: E402
+from pywinauto import win32defines  # noqa: E402
+from pywinauto import findbestmatch  # noqa: E402
+from pywinauto.sysinfo import is_x64_Python  # noqa: E402
+from pywinauto.remote_memory_block import RemoteMemoryBlock  # noqa: E402
+from pywinauto.actionlogger import ActionLogger  # noqa: E402
+from pywinauto.timings import Timings  # noqa: E402
+from pywinauto import mouse  # noqa: E402
 
 
 controlspy_folder = os.path.join(
-   os.path.dirname(__file__), r"..\..\apps\controlspy0998")
+    os.path.dirname(__file__), r"..\..\apps\controlspy0998")
 controlspy_folder_32 = controlspy_folder
 mfc_samples_folder = os.path.join(
-   os.path.dirname(__file__), r"..\..\apps\MFC_samples")
+    os.path.dirname(__file__), r"..\..\apps\MFC_samples")
 mfc_samples_folder_32 = mfc_samples_folder
 if is_x64_Python():
     controlspy_folder = os.path.join(controlspy_folder, 'x64')
@@ -92,10 +93,10 @@ class ListViewTestCases32(unittest.TestCase):
         ]
 
         self.app = app
-        self.dlg = app.RowListSampleApplication #top_window()
+        self.dlg = app.RowListSampleApplication
         self.ctrl = app.RowListSampleApplication.ListView.WrapperObject()
-        self.dlg.Toolbar.Button(0).Click() # switch to icon view
-        self.dlg.Toolbar.Button(6).Click() # switch off states
+        self.dlg.Toolbar.Button(0).Click()  # switch to icon view
+        self.dlg.Toolbar.Button(6).Click()  # switch off states
 
     def tearDown(self):
         """Close the application after tests"""
@@ -103,15 +104,15 @@ class ListViewTestCases32(unittest.TestCase):
 
     def testFriendlyClass(self):
         """Make sure the ListView friendly class is set correctly"""
-        self.assertEquals (self.ctrl.friendly_class_name(), u"ListView")
+        self.assertEquals(self.ctrl.friendly_class_name(), u"ListView")
 
     def testColumnCount(self):
         """Test the ListView ColumnCount method"""
-        self.assertEquals (self.ctrl.ColumnCount(), 8)
+        self.assertEquals(self.ctrl.ColumnCount(), 8)
 
     def testItemCount(self):
         """Test the ListView ItemCount method"""
-        self.assertEquals (self.ctrl.ItemCount(), 7)
+        self.assertEquals(self.ctrl.ItemCount(), 7)
 
     def testItemText(self):
         """Test the ListView item.Text property"""
@@ -156,12 +157,11 @@ class ListViewTestCases32(unittest.TestCase):
     def testColumn(self):
         """Test the ListView Columns method"""
         cols = self.ctrl.Columns()
-        self.assertEqual (len(cols), self.ctrl.ColumnCount())
+        self.assertEqual(len(cols), self.ctrl.ColumnCount())
 
         # TODO: add more checking of column values
         #for col in cols:
         #    print(col)
-
 
     def testGetSelectionCount(self):
         """Test the ListView GetSelectedCount method"""
@@ -183,7 +183,6 @@ class ListViewTestCases32(unittest.TestCase):
 #
 #        self.assertEquals(self.ctrl.GetSelectedCount(), 2)
 
-
     def testIsSelected(self):
         """Test ListView IsSelected for some items"""
         # ensure that the item is not selected
@@ -194,7 +193,6 @@ class ListViewTestCases32(unittest.TestCase):
 
         # now ensure that the item is selected
         self.assertEquals(self.ctrl.IsSelected(1), True)
-
 
     def _testFocused(self):
         """Test checking the focus of some ListView items"""
@@ -211,7 +209,6 @@ class ListViewTestCases32(unittest.TestCase):
         #for col in cols:
         #    print(col)
 
-
     def testSelect(self):
         """Test ListView Selecting some items"""
         self.ctrl.Select(1)
@@ -222,7 +219,6 @@ class ListViewTestCases32(unittest.TestCase):
 
         self.assertEquals(self.ctrl.GetSelectedCount(), 3)
 
-
     def testSelectText(self):
         """Test ListView Selecting some items"""
         self.ctrl.Select(u"Green")
@@ -232,7 +228,6 @@ class ListViewTestCases32(unittest.TestCase):
         self.assertRaises(ValueError, self.ctrl.Deselect, u"Item not in list")
 
         self.assertEquals(self.ctrl.GetSelectedCount(), 3)
-
 
     def testDeselect(self):
         """Test ListView Selecting some items"""
@@ -246,10 +241,9 @@ class ListViewTestCases32(unittest.TestCase):
 
         self.assertEquals(self.ctrl.GetSelectedCount(), 1)
 
-
     def testGetProperties(self):
         """Test getting the properties for the listview control"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             "ListView", props['friendly_class_name'])
@@ -263,14 +257,12 @@ class ListViewTestCases32(unittest.TestCase):
         self.assertEquals(props['column_count'], 8)
         self.assertEquals(props['item_count'], 7)
 
-
     def testGetColumnTexts(self):
         """Test columns titles text"""
         self.assertEquals(self.ctrl.GetColumn(0)['text'], u"Color")
         self.assertEquals(self.ctrl.GetColumn(1)['text'], u"Red")
         self.assertEquals(self.ctrl.GetColumn(2)['text'], u"Green")
         self.assertEquals(self.ctrl.GetColumn(3)['text'], u"Blue")
-
 
     def testItemRectangles(self):
         """Test getting item rectangles"""
@@ -293,7 +285,6 @@ class ListViewTestCases32(unittest.TestCase):
         self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
         self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), False)
 
-
     def testItemCheck(self):
         """Test checking/unchecking item"""
         if not self.dlg.Toolbar.Button(6).IsChecked():
@@ -313,7 +304,6 @@ class ListViewTestCases32(unittest.TestCase):
         self.ctrl.UnCheck('Yellow')
         self.assertEquals(self.ctrl.IsChecked('Yellow'), False)
 
-
     def testItemClick(self):
         """Test clicking item rectangles by Click() method"""
         self.ctrl.GetItem('Green').Click(where='select')
@@ -327,35 +317,34 @@ class ListViewTestCases32(unittest.TestCase):
 
         self.ctrl.GetItem('Green').Click(where='select')
         self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
-        self.assertEquals(self.ctrl.IsSelected('Green'), True) # TODO: deprecated method
+        self.assertEquals(self.ctrl.IsSelected('Green'), True)  # TODO: deprecated method
         self.assertEquals(self.ctrl.GetItem('Green').IsFocused(), True)
-        self.assertEquals(self.ctrl.IsFocused('Green'), True) # TODO: deprecated method
+        self.assertEquals(self.ctrl.IsFocused('Green'), True)  # TODO: deprecated method
         self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), False)
 
         # Test click on checkboxes
-        if not self.dlg.Toolbar.Button(6).IsChecked(): # switch on states
+        if not self.dlg.Toolbar.Button(6).IsChecked():  # switch on states
             self.dlg.Toolbar.Button(6).Click()
 
         for i in range(1, 6):
             self.dlg.Toolbar.Button(i - 1).Click()
 
-            self.ctrl.GetItem(i).Click(where='check') # check item
+            self.ctrl.GetItem(i).Click(where='check')  # check item
             time.sleep(0.5)
             self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
             self.assertEquals(self.ctrl.GetItem(i - 1).IsChecked(), False)
 
-            self.ctrl.GetItem(i).Click(where='check') # uncheck item
+            self.ctrl.GetItem(i).Click(where='check')  # uncheck item
             time.sleep(0.5)
             self.assertEquals(self.ctrl.GetItem(i).IsChecked(), False)
 
-            self.ctrl.GetItem(i).Click(where='check') # recheck item
+            self.ctrl.GetItem(i).Click(where='check')  # recheck item
             time.sleep(0.5)
             self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
 
-        self.dlg.Toolbar.Button(6).Click() # switch off states
+        self.dlg.Toolbar.Button(6).Click()  # switch off states
 
         self.assertRaises(RuntimeError, self.ctrl.GetItem(6).Click, where="check")
-
 
     def testItemClickInput(self):
         """Test clicking item rectangles by click_input() method"""
@@ -372,35 +361,34 @@ class ListViewTestCases32(unittest.TestCase):
 
         self.ctrl.GetItem('Green').click_input(where='select')
         self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
-        self.assertEquals(self.ctrl.IsSelected('Green'), True) # TODO: deprecated method
+        self.assertEquals(self.ctrl.IsSelected('Green'), True)  # TODO: deprecated method
         self.assertEquals(self.ctrl.GetItem('Green').IsFocused(), True)
-        self.assertEquals(self.ctrl.IsFocused('Green'), True) # TODO: deprecated method
+        self.assertEquals(self.ctrl.IsFocused('Green'), True)  # TODO: deprecated method
         self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), False)
 
         # Test click on checkboxes
-        if not self.dlg.Toolbar.Button(6).IsChecked(): # switch on states
+        if not self.dlg.Toolbar.Button(6).IsChecked():  # switch on states
             self.dlg.Toolbar.Button(6).Click()
 
         for i in range(1, 6):
             self.dlg.Toolbar.Button(i - 1).Click()
 
-            self.ctrl.GetItem(i).click_input(where='check') # check item
+            self.ctrl.GetItem(i).click_input(where='check')  # check item
             time.sleep(0.5)
             self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
             self.assertEquals(self.ctrl.GetItem(i - 1).IsChecked(), False)
 
-            self.ctrl.GetItem(i).click_input(where='check') # uncheck item
+            self.ctrl.GetItem(i).click_input(where='check')  # uncheck item
             time.sleep(0.5)
             self.assertEquals(self.ctrl.GetItem(i).IsChecked(), False)
 
-            self.ctrl.GetItem(i).click_input(where='check') # recheck item
+            self.ctrl.GetItem(i).click_input(where='check')  # recheck item
             time.sleep(0.5)
             self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
 
-        self.dlg.Toolbar.Button(6).Click() # switch off states
+        self.dlg.Toolbar.Button(6).Click()  # switch off states
 
         self.assertRaises(RuntimeError, self.ctrl.GetItem(6).click_input, where="check")
-
 
     def testItemMethods(self):
         """Test short item methods like Text(), State() etc"""
@@ -414,7 +402,7 @@ class ListViewTestCases32(unittest.TestCase):
         # Gray is not selected by click because it's not visible
         self.ctrl.GetItem('Gray').Click()
         self.assertEquals(self.ctrl.GetItem('Gray').IsSelected(), False)
-        self.dlg.set_focus() # just in case
+        self.dlg.set_focus()  # just in case
 
         self.ctrl.GetItem('Gray').EnsureVisible()
         self.ctrl.GetItem('Gray').Click()
@@ -472,7 +460,7 @@ class TreeViewTestCases32(unittest.TestCase):
             ("Uranus",  '2,870,990,000', '51,118', '8.683e25'),
             ("Neptune", '4,504,000,000', '49,532', '1.0247e26'),
             ("Pluto",   '5,913,520,000', '2,274', '1.27e22'),
-         ]
+        ]
 
         self.app = Application()
         self.app.start(self.path)
@@ -485,12 +473,11 @@ class TreeViewTestCases32(unittest.TestCase):
 
     def test_friendly_class_name(self):
         """Make sure the friendly class name is set correctly (TreeView)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "TreeView")
+        self.assertEquals(self.ctrl.friendly_class_name(), "TreeView")
 
     def testItemCount(self):
         """Test the TreeView ItemCount method"""
-        self.assertEquals (self.ctrl.ItemCount(), 37)
-
+        self.assertEquals(self.ctrl.ItemCount(), 37)
 
     def testGetItem(self):
         """Test the GetItem method"""
@@ -505,10 +492,9 @@ class TreeViewTestCases32(unittest.TestCase):
             self.ctrl.GetItem(r"\The Planets\Venus\4.869e24 kg", exact=True).Text(), self.texts[1][3] + " kg")
 
         self.assertEquals(
-            self.ctrl.GetItem(
-                    ["The Planets", "Venus", "4.869"]).Text(),
-            self.texts[1][3] + " kg")
-
+            self.ctrl.GetItem(["The Planets", "Venus", "4.869"]).Text(),
+            self.texts[1][3] + " kg"
+        )
 
     def testItemText(self):
         """Test the TreeView item Text() method"""
@@ -525,7 +511,6 @@ class TreeViewTestCases32(unittest.TestCase):
 
         self.assertEquals(True, self.ctrl.IsSelected((0, 1, 2)))
 
-
     def testEnsureVisible(self):
         """make sure that the item is visible"""
         # TODO: note this is partially a fake test at the moment because
@@ -535,10 +520,9 @@ class TreeViewTestCases32(unittest.TestCase):
         # make sure that the item is not hidden
         self.assertNotEqual(None, self.ctrl.GetItem((0, 8, 2)).client_rect())
 
-
     def testGetProperties(self):
         """Test getting the properties for the treeview control"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             "TreeView", props['friendly_class_name'])
@@ -601,9 +585,9 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
 
         self.app = Application().start(os.path.join(mfc_samples_folder, "CmnCtrl1.exe"))
 
-        self.dlg = self.app.CommonControlsSample #top_window()
+        self.dlg = self.app.CommonControlsSample
         self.ctrl = self.app.CommonControlsSample.TreeView.WrapperObject()
-        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
+        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=1)
 
     def tearDown(self):
         """Close the application after tests"""
@@ -616,9 +600,9 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         self.dlg.TVS_CHECKBOXES.check_by_click()
         birds = self.ctrl.GetItem(r'\Birds')
         birds.Click(where='check')
-        self.assertEquals (birds.IsChecked(), True)
+        self.assertEquals(birds.IsChecked(), True)
         birds.click_input(where='check')
-        self.assertEquals (birds.IsChecked(), False)
+        self.assertEquals(birds.IsChecked(), False)
 
     def testPrintItems(self):
         """Test TreeView method PrintItems()"""
@@ -703,19 +687,18 @@ class HeaderTestCases(unittest.TestCase):
 
         self.texts = [u'Color', u'Red', u'Green', u'Blue', u'Hue', u'Sat', u'Lum', u'Type']
         self.item_rects = [
-            RECT (  0, 0, 150, 19),
-            RECT (150, 0, 200, 19),
-            RECT (200, 0, 250, 19),
-            RECT (250, 0, 300, 19),
-            RECT (300, 0, 400, 19),
-            RECT (400, 0, 450, 19),
-            RECT (450, 0, 500, 19),
-            RECT (500, 0, 650, 19)]
+            RECT(000, 0, 150, 19),
+            RECT(150, 0, 200, 19),
+            RECT(200, 0, 250, 19),
+            RECT(250, 0, 300, 19),
+            RECT(300, 0, 400, 19),
+            RECT(400, 0, 450, 19),
+            RECT(450, 0, 500, 19),
+            RECT(500, 0, 650, 19)]
 
         self.app = app
-        self.dlg = app.RowListSampleApplication #top_window()
+        self.dlg = app.RowListSampleApplication
         self.ctrl = app.RowListSampleApplication.Header.WrapperObject()
-
 
     def tearDown(self):
         "Close the application after tests"
@@ -724,15 +707,15 @@ class HeaderTestCases(unittest.TestCase):
 
     def testFriendlyClass(self):
         "Make sure the friendly class is set correctly (Header)"
-        self.assertEquals (self.ctrl.friendly_class_name(), "Header")
+        self.assertEquals(self.ctrl.friendly_class_name(), "Header")
 
     def testTexts(self):
         "Make sure the texts are set correctly"
-        self.assertEquals (self.ctrl.texts()[1:], self.texts)
+        self.assertEquals(self.ctrl.texts()[1:], self.texts)
 
     def testGetProperties(self):
         "Test getting the properties for the header control"
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
@@ -763,15 +746,13 @@ class HeaderTestCases(unittest.TestCase):
             self.assertEquals(test_rects[i].left, client_rects[i].left)
             self.assertEquals(test_rects[i].right, client_rects[i].right)
             self.assertEquals(test_rects[i].top, client_rects[i].top)
-            self.failIf(abs(test_rects[i].bottom - client_rects[i].bottom) > 2) # may be equal to 17 or 19
+            self.failIf(abs(test_rects[i].bottom - client_rects[i].bottom) > 2)  # may be equal to 17 or 19
 
     def testGetColumnText(self):
         for i in range(0, 3):
             self.assertEquals(
                 self.texts[i],
                 self.ctrl.GetColumnText(i))
-
-
 
 
 class StatusBarTestCases(unittest.TestCase):
@@ -800,15 +781,15 @@ class StatusBarTestCases(unittest.TestCase):
 
     def test_friendly_class_name(self):
         """Make sure the friendly class name is set correctly (StatusBar)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "StatusBar")
+        self.assertEquals(self.ctrl.friendly_class_name(), "StatusBar")
 
     def test_texts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals (self.ctrl.texts()[1:], self.texts)
+        self.assertEquals(self.ctrl.texts()[1:], self.texts)
 
     def testGetProperties(self):
         """Test getting the properties for the status bar control"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
@@ -819,40 +800,39 @@ class StatusBarTestCases(unittest.TestCase):
         for prop_name in props:
             self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
 
-
     def testBorderWidths(self):
         """Make sure the border widths are retrieved correctly"""
-        self.assertEquals (
+        self.assertEquals(
             self.ctrl.BorderWidths(),
             dict(
-                Horizontal = 0,
-                Vertical = 2,
-                Inter = 2,
-                )
+                Horizontal=0,
+                Vertical=2,
+                Inter=2,
             )
+        )
 
     def testPartCount(self):
         "Make sure the number of parts is retrieved correctly"
-        self.assertEquals (self.ctrl.PartCount(), 3)
+        self.assertEquals(self.ctrl.PartCount(), 3)
 
     def testPartRightEdges(self):
         "Make sure the part widths are retrieved correctly"
 
-        for i in range(0, self.ctrl.PartCount()-1):
-            self.assertEquals (self.ctrl.PartRightEdges()[i], self.part_rects[i].right)
+        for i in range(0, self.ctrl.PartCount() - 1):
+            self.assertEquals(self.ctrl.PartRightEdges()[i], self.part_rects[i].right)
 
-        self.assertEquals(self.ctrl.PartRightEdges()[i+1], -1)
+        self.assertEquals(self.ctrl.PartRightEdges()[i + 1], -1)
 
     def testGetPartRect(self):
         "Make sure the part rectangles are retrieved correctly"
 
         for i in range(0, self.ctrl.PartCount()):
             part_rect = self.ctrl.GetPartRect(i)
-            self.assertEquals (part_rect.left, self.part_rects[i].left)
+            self.assertEquals(part_rect.left, self.part_rects[i].left)
             if i != self.ctrl.PartCount() - 1:
-                self.assertEquals (part_rect.right, self.part_rects[i].right)
-            self.assertEquals (part_rect.top, self.part_rects[i].top)
-            self.failIf (abs(part_rect.bottom - self.part_rects[i].bottom) > 2)
+                self.assertEquals(part_rect.right, self.part_rects[i].right)
+            self.assertEquals(part_rect.top, self.part_rects[i].top)
+            self.failIf(abs(part_rect.bottom - self.part_rects[i].bottom) > 2)
 
         self.assertRaises(IndexError, self.ctrl.GetPartRect, 99)
 
@@ -861,11 +841,11 @@ class StatusBarTestCases(unittest.TestCase):
         client_rects = self.ctrl.ClientRects()[1:]
         for i in range(len(client_rects)):
             client_rect = client_rects[i]
-            self.assertEquals (self.part_rects[i].left, client_rect.left)
+            self.assertEquals(self.part_rects[i].left, client_rect.left)
             if i != len(client_rects) - 1:
-                self.assertEquals (self.part_rects[i].right, client_rect.right)
-            self.assertEquals (self.part_rects[i].top, client_rect.top)
-            self.failIf (abs(self.part_rects[i].bottom - client_rect.bottom) > 2)
+                self.assertEquals(self.part_rects[i].right, client_rect.right)
+            self.assertEquals(self.part_rects[i].top, client_rect.top)
+            self.failIf(abs(self.part_rects[i].bottom - client_rect.bottom) > 2)
 
     def testGetPartText(self):
         self.assertRaises(IndexError, self.ctrl.GetPartText, 99)
@@ -909,15 +889,15 @@ class TabControlTestCases(unittest.TestCase):
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (TabControl)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "TabControl")
+        self.assertEquals(self.ctrl.friendly_class_name(), "TabControl")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals (self.ctrl.texts()[1:], self.texts)
+        self.assertEquals(self.ctrl.texts()[1:], self.texts)
 
     def testGetProperties(self):
         """Test getting the properties for the tabcontrol"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
@@ -931,7 +911,7 @@ class TabControlTestCases(unittest.TestCase):
     def testRowCount(self):
         self.assertEquals(1, self.ctrl.RowCount())
 
-        dlgClientRect = self.ctrl.parent().rectangle() # use the parent as a reference
+        dlgClientRect = self.ctrl.parent().rectangle()  # use the parent as a reference
         prev_rect = self.ctrl.rectangle() - dlgClientRect
 
         # squeeze the tab control to force two rows
@@ -943,7 +923,7 @@ class TabControlTestCases(unittest.TestCase):
             new_rect.top,
             new_rect.width(),
             new_rect.height(),
-            )
+        )
         time.sleep(0.1)
 
         # verify two tab rows
@@ -962,12 +942,12 @@ class TabControlTestCases(unittest.TestCase):
 
     def testTabCount(self):
         """Make sure the number of parts is retrieved correctly"""
-        self.assertEquals (self.ctrl.TabCount(), 5)
+        self.assertEquals(self.ctrl.TabCount(), 5)
 
     def testGetTabRect(self):
         """Make sure the part rectangles are retrieved correctly"""
         for i, _ in enumerate(self.rects):
-            self.assertEquals (self.ctrl.GetTabRect(i), self.rects[i])
+            self.assertEquals(self.ctrl.GetTabRect(i), self.rects[i])
 
         self.assertRaises(IndexError, self.ctrl.GetTabRect, 99)
 
@@ -982,12 +962,11 @@ class TabControlTestCases(unittest.TestCase):
 #        time.sleep(2)
 #        print("==\n",self.ctrl.TabStates())
 #
-#        self.assertEquals (self.ctrl.GetTabState(1), 1)
+#        self.assertEquals(self.ctrl.GetTabState(1), 1)
 #
 #    def testTabStates(self):
 #        print(self.ctrl.TabStates())
 #        raise "tabstates hiay"
-
 
     def testGetTabText(self):
         for i, text in enumerate(self.texts):
@@ -1043,16 +1022,16 @@ class ToolbarTestCases(unittest.TestCase):
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (Toolbar)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "Toolbar")
+        self.assertEquals(self.ctrl.friendly_class_name(), "Toolbar")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
         for txt in self.ctrl.texts():
-            self.assertEquals (isinstance(txt, six.string_types), True)
+            self.assertEquals(isinstance(txt, six.string_types), True)
 
     def testGetProperties(self):
         """Test getting the properties for the toolbar control"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
@@ -1098,14 +1077,13 @@ class ToolbarTestCases(unittest.TestCase):
     def testGetToolTipsControls(self):
         tips = self.ctrl.GetToolTipsControl()
         tt = tips.texts()
-        self.assertEquals(u"New" in tt,True)
-        self.assertEquals(u"About" in tt,True)
+        self.assertEquals(u"New" in tt, True)
+        self.assertEquals(u"About" in tt, True)
 
         tips = self.ctrl2.GetToolTipsControl()
         tt = tips.texts()
-        self.assertEquals(u"Pencil" in tt,True)
-        self.assertEquals(u"Ellipse" in tt,True)
-
+        self.assertEquals(u"Pencil" in tt, True)
+        self.assertEquals(u"Ellipse" in tt, True)
 
     def testPressButton(self):
 
@@ -1161,7 +1139,7 @@ class RebarTestCases(unittest.TestCase):
         Timings.Fast()
         app = Application()
         app.start(os.path.join(mfc_samples_folder, "RebarTest.exe"))
-
+        mouse.move((-500, 200))  # remove the mouse from the screen to avoid side effects
         self.app = app
         self.dlg = app.RebarTest_RebarTest
         self.dlg.Wait('ready', 20)
@@ -1170,16 +1148,16 @@ class RebarTestCases(unittest.TestCase):
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.app.kill()
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (ReBar)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "ReBar")
+        self.assertEquals(self.ctrl.friendly_class_name(), "ReBar")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
         for txt in self.ctrl.texts():
-            self.assertEquals (isinstance(txt, six.string_types), True)
+            self.assertEquals(isinstance(txt, six.string_types), True)
 
     def testBandCount(self):
         """Make sure BandCount() returns 2"""
@@ -1271,15 +1249,15 @@ class DatetimeTestCases(unittest.TestCase):
         second = 3
         milliseconds = 781
         self.ctrl.SetTime(
-                year=year,
-                month=month,
-                day_of_week=day_of_week,
-                day=day,
-                hour=hour,
-                minute=minute,
-                second=second,
-                milliseconds=milliseconds
-                )
+            year=year,
+            month=month,
+            day_of_week=day_of_week,
+            day=day,
+            hour=hour,
+            minute=minute,
+            second=second,
+            milliseconds=milliseconds
+        )
 
         # Retrive back the values we set
         test_date_time = self.ctrl.GetTime()
@@ -1324,11 +1302,11 @@ class ToolTipsTestCases(unittest.TestCase):
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (ToolTips)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "ToolTips")
+        self.assertEquals(self.ctrl.friendly_class_name(), "ToolTips")
 
     def testGetProperties(self):
         """Test getting the properties for the tooltips control"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
@@ -1370,7 +1348,7 @@ class UpDownTestCases(unittest.TestCase):
         """Set some data and ensure the application is in the state we want"""
         Timings.Fast()
         app = Application()
-        app.start(os.path.join(controlspy_folder,  "Up-Down.exe"))
+        app.start(os.path.join(controlspy_folder, "Up-Down.exe"))
 
         self.app = app
         self.dlg = app.MicrosoftControlSpy
@@ -1383,15 +1361,15 @@ class UpDownTestCases(unittest.TestCase):
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (UpDown)"""
-        self.assertEquals (self.ctrl.friendly_class_name(), "UpDown")
+        self.assertEquals(self.ctrl.friendly_class_name(), "UpDown")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals (self.ctrl.texts()[1:], [])
+        self.assertEquals(self.ctrl.texts()[1:], [])
 
     def testGetProperties(self):
         """Test getting the properties for the updown control"""
-        props  = self.ctrl.GetProperties()
+        props = self.ctrl.GetProperties()
 
         self.assertEquals(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
@@ -1404,31 +1382,31 @@ class UpDownTestCases(unittest.TestCase):
 
     def testGetValue(self):
         """Test getting up-down position"""
-        self.assertEquals (self.ctrl.GetValue(), 0)
+        self.assertEquals(self.ctrl.GetValue(), 0)
 
         self.ctrl.SetValue(23)
-        self.assertEquals (self.ctrl.GetValue(), 23)
+        self.assertEquals(self.ctrl.GetValue(), 23)
 
     def testSetValue(self):
         """Test setting up-down position"""
-        self.assertEquals (self.ctrl.GetValue(), 0)
+        self.assertEquals(self.ctrl.GetValue(), 0)
 
         self.ctrl.SetValue(23)
-        self.assertEquals (self.ctrl.GetValue(), 23)
+        self.assertEquals(self.ctrl.GetValue(), 23)
         self.assertEquals(
             int(self.ctrl.GetBuddyControl().texts()[1]),
             23)
 
     def testGetBase(self):
         """Test getting the base of the up-down control"""
-        self.assertEquals (self.ctrl.GetBase(), 10)
+        self.assertEquals(self.ctrl.GetBase(), 10)
         #self.dlg.StatementEdit.SetEditText ("MSG (UDM_SETBASE, 16, 0)")
 
         # use CloseClick to allow the control time to respond to the message
         #self.dlg.Send.click_input()
         self.ctrl.SetBase(16)
 
-        self.assertEquals (self.ctrl.GetBase(), 16)
+        self.assertEquals(self.ctrl.GetBase(), 16)
 
     def testGetRange(self):
         """Test getting the range of the up-down control"""
@@ -1436,21 +1414,20 @@ class UpDownTestCases(unittest.TestCase):
 
     def testGetBuddy(self):
         """Test getting the buddy control"""
-        self.assertEquals (self.ctrl.GetBuddyControl().handle, self.dlg.Edit6.handle)
-
+        self.assertEquals(self.ctrl.GetBuddyControl().handle, self.dlg.Edit6.handle)
 
     def testIncrement(self):
         """Test incremementing up-down position"""
         Timings.Defaults()
         self.ctrl.Increment()
-        self.assertEquals (self.ctrl.GetValue(), 1)
+        self.assertEquals(self.ctrl.GetValue(), 1)
 
     def testDecrement(self):
         """Test decrementing up-down position"""
         Timings.Defaults()
         self.ctrl.SetValue(23)
         self.ctrl.Decrement()
-        self.assertEquals (self.ctrl.GetValue(), 22)
+        self.assertEquals(self.ctrl.GetValue(), 22)
 
 
 class TrackbarWrapperTestCases(unittest.TestCase):
@@ -1472,7 +1449,6 @@ class TrackbarWrapperTestCases(unittest.TestCase):
         # close the application
         self.dlg.send_message(win32defines.WM_CLOSE)
 
-
     def test_friendly_class(self):
         """Make sure the Trackbar friendly class is set correctly"""
         self.assertEquals(self.ctrl.friendly_class_name(), u"Trackbar")
@@ -1489,7 +1465,7 @@ class TrackbarWrapperTestCases(unittest.TestCase):
 
     def test_set_range_min_more_then_range_max(self):
         """Test the set_range_min method with error"""
-        self.assertRaises(ValueError, self.ctrl.set_range_min, self.ctrl.get_range_max()+1)
+        self.assertRaises(ValueError, self.ctrl.set_range_min, self.ctrl.get_range_max() + 1)
 
     def test_set_position_more_than_max_range(self):
         """Test the set_position method with error"""
@@ -1498,7 +1474,7 @@ class TrackbarWrapperTestCases(unittest.TestCase):
 
     def test_set_position_less_than_min_range(self):
         """Test the set_position method with error"""
-        self.assertRaises(ValueError, self.ctrl.set_position, self.ctrl.get_range_min()-10)
+        self.assertRaises(ValueError, self.ctrl.set_position, self.ctrl.get_range_min() - 10)
 
     def test_set_correct_position(self):
         """Test the set_position method"""

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -603,6 +603,7 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
 
         self.dlg = self.app.CommonControlsSample #top_window()
         self.ctrl = self.app.CommonControlsSample.TreeView.WrapperObject()
+        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
 
     def tearDown(self):
         """Close the application after tests"""
@@ -641,7 +642,7 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         birds = self.ctrl.GetItem(r'\Birds')
         birds.Expand()
         self.assertEquals(birds.IsExpanded(), True)
-        
+
         birds.Collapse()
         self.assertEquals(birds.IsExpanded(), False)
 
@@ -651,12 +652,12 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         self.dlg.TVS_HASLINES.click_input()
         self.dlg.TVS_LINESATROOT.click_input()
         birds = self.ctrl.GetItem(r'\Birds')
-        
+
         birds.Click(where='button')
         self.assertEquals(birds.IsExpanded(), True)
         birds.Click(double=True, where='icon')
         self.assertEquals(birds.IsExpanded(), False)
-        
+
         birds.click_input(where='button')
         self.assertEquals(birds.IsExpanded(), True)
         birds.click_input(double=True, where='icon')
@@ -672,18 +673,18 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         """Make sure tree view item methods StartDragging() and Drop() work as expected"""
         birds = self.ctrl.GetItem(r'\Birds')
         birds.Expand()
-        
+
         pigeon = self.ctrl.GetItem(r'\Birds\Pigeon')
         pigeon.StartDragging()
-        
+
         eagle = self.ctrl.GetItem(r'\Birds\Eagle')
         eagle.Drop()
-        
+
         self.assertRaises(IndexError, birds.GetChild, 'Pigeon')
         self.assertRaises(IndexError, self.ctrl.GetItem, r'\Birds\Pigeon')
         self.assertRaises(IndexError, self.ctrl.GetItem, [0, 2])
         self.assertRaises(IndexError, self.ctrl.GetItem, r'\Bread', exact=True)
-        
+
         new_pigeon = self.ctrl.GetItem(r'\Birds\Eagle\Pigeon')
         self.assertEquals(len(birds.children()), 2)
         self.assertEquals(new_pigeon.children(), [])
@@ -710,7 +711,7 @@ class HeaderTestCases(unittest.TestCase):
             RECT (400, 0, 450, 19),
             RECT (450, 0, 500, 19),
             RECT (500, 0, 650, 19)]
-           
+
         self.app = app
         self.dlg = app.RowListSampleApplication #top_window()
         self.ctrl = app.RowListSampleApplication.Header.WrapperObject()
@@ -1085,7 +1086,7 @@ class ToolbarTestCases(unittest.TestCase):
         self.failIf((rect_ctrl.bottom - rect_ctrl.top) > 38)
         self.failIf((rect_ctrl.bottom - rect_ctrl.top) < 36)
         #self.assertEquals(rect_ctrl, RECT(0, 0, 40, 38))
-        
+
         rect_ctrl2 = self.ctrl2.GetButtonRect(0)
         self.assertEquals((rect_ctrl2.left, rect_ctrl2.top), (0, 0))
         self.failIf((rect_ctrl2.right - rect_ctrl2.left) > 70)
@@ -1210,11 +1211,11 @@ class RebarTestCases(unittest.TestCase):
     def testMenuBarClickInput(self):
         """Make sure we can click on Menu Bar items by indexed path"""
         self.assertRaises(TypeError, self.dlg.MenuBar.MenuBarClickInput, '#one->#0', self.app)
-        
+
         self.dlg.MenuBar.MenuBarClickInput('#1->#0->#0', self.app)
         self.app.Customize.CloseButton.Click()
         self.app.Customize.WaitNot('visible')
-        
+
         self.dlg.MenuBar.MenuBarClickInput([2, 0], self.app)
         self.app.Window_(title='About RebarTest').OK.Click()
         self.app.Window_(title='About RebarTest').WaitNot('visible')
@@ -1311,7 +1312,7 @@ class ToolTipsTestCases(unittest.TestCase):
         # Make sure the mouse doesn't hover over tested controls
         # so it won't generate an unexpected tooltip
         self.dlg.move_mouse_input(coords=(-100, -100), absolute=True)
-        
+
         self.dlg.TabControl.Select(u'CToolBarCtrl')
 
         self.ctrl = self.dlg.Toolbar.GetToolTipsControl()

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -704,7 +704,7 @@ class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
                                         wait_for_idle=False)
         self.app2 = Application().start(os.path.join(
             mfc_samples_folder, u"CmnCtrl2.exe"))
-        self.app2.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
+        self.app2.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=1)
 
     def tearDown(self):
         """Close the application after tests"""
@@ -717,6 +717,7 @@ class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
         with one and type in it.
         """
         self.app1.window().set_focus()
+        self.app1.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=1)
         # pywintypes.error:
         #     (87, 'AttachThreadInput', 'The parameter is incorrect.')
 

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -704,6 +704,7 @@ class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
                                         wait_for_idle=False)
         self.app2 = Application().start(os.path.join(
             mfc_samples_folder, u"CmnCtrl2.exe"))
+        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
 
     def tearDown(self):
         """Close the application after tests"""

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -704,7 +704,7 @@ class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
                                         wait_for_idle=False)
         self.app2 = Application().start(os.path.join(
             mfc_samples_folder, u"CmnCtrl2.exe"))
-        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
+        self.app2.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
 
     def tearDown(self):
         """Close the application after tests"""

--- a/pywinauto/unittests/test_menuwrapper.py
+++ b/pywinauto/unittests/test_menuwrapper.py
@@ -139,8 +139,9 @@ class OwnerDrawnMenuTests(unittest.TestCase):
         self.app.kill_()
 
     def testCorrectText(self):
-        self.assertEqual(u'&New', self.dlg.Menu().GetMenuPath('&File->#0')[-1].Text()[:4])
-        self.assertEqual(u'&Open...', self.dlg.Menu().GetMenuPath('&File->#1')[-1].Text()[:8])
+        menu = self.dlg.Menu()
+        self.assertEqual(u'&New', menu.GetMenuPath('&File->#0')[-1].Text()[:4])
+        self.assertEqual(u'&Open...', menu.GetMenuPath('&File->#1')[-1].Text()[:8])
 
 
 if __name__ == "__main__":

--- a/pywinauto/unittests/test_menuwrapper.py
+++ b/pywinauto/unittests/test_menuwrapper.py
@@ -133,7 +133,8 @@ class OwnerDrawnMenuTests(unittest.TestCase):
 
         self.app = Application().Start(os.path.join(mfc_samples_folder, u"BCDialogMenu.exe"))
         self.dlg = self.app.BCDialogMenu
-        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
+        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=1)
+        self.dlg.wait('ready')
 
     def tearDown(self):
         """Close the application after tests"""

--- a/pywinauto/unittests/test_menuwrapper.py
+++ b/pywinauto/unittests/test_menuwrapper.py
@@ -133,6 +133,7 @@ class OwnerDrawnMenuTests(unittest.TestCase):
 
         self.app = Application().Start(os.path.join(mfc_samples_folder, u"BCDialogMenu.exe"))
         self.dlg = self.app.BCDialogMenu
+        self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
 
     def tearDown(self):
         """Close the application after tests"""

--- a/pywinauto/unittests/test_taskbar.py
+++ b/pywinauto/unittests/test_taskbar.py
@@ -33,29 +33,31 @@
 
 import unittest
 import sys
-#import time
 import os
+
 sys.path.append(".")
-from pywinauto import taskbar, \
-                      findwindows
-from pywinauto.application import Application, \
-                                  ProcessNotFoundError, \
-                                  WindowSpecification
-from pywinauto.sysinfo import is_x64_Python, \
-                              is_x64_OS
-from pywinauto import win32defines
-from pywinauto.timings import WaitUntil
-import pywinauto.actionlogger
-from pywinauto.timings import Timings
+from pywinauto import taskbar  # noqa: E402
+from pywinauto import findwindows  # noqa: E402
+from pywinauto.application import Application  # noqa: E402
+from pywinauto.application import ProcessNotFoundError  # noqa: E402
+from pywinauto.application import WindowSpecification  # noqa: E402
+from pywinauto.sysinfo import is_x64_Python, is_x64_OS  # noqa: E402
+from pywinauto import win32defines  # noqa: E402
+from pywinauto.timings import WaitUntil  # noqa: E402
+import pywinauto.actionlogger  # noqa: E402
+from pywinauto.timings import Timings  # noqa: E402
 
 #pywinauto.actionlogger.enable()
 mfc_samples_folder = os.path.join(
-   os.path.dirname(__file__), r"..\..\apps\MFC_samples")
+    os.path.dirname(__file__), r"..\..\apps\MFC_samples"
+)
 if is_x64_Python():
     mfc_samples_folder = os.path.join(mfc_samples_folder, 'x64')
 
 _ready_timeout = 60
 _retry_interval = 0.5
+
+
 def _toggle_notification_area_icons(show_all=True, debug_img=None):
     """
     A helper function to change 'Show All Icons' settings.
@@ -67,18 +69,17 @@ def _toggle_notification_area_icons(show_all=True, debug_img=None):
     window should be accessed with a localized title"
     """
 
-    app = Application()
-    starter = app.start(r'explorer.exe')
+    Application().start(r'explorer.exe')
     class_name = 'CabinetWClass'
 
     def _cabinetwclass_exist():
         "Verify if at least one active 'CabinetWClass' window is created"
-        l = findwindows.find_elements(active_only = True, class_name = class_name)
+        l = findwindows.find_elements(active_only=True, class_name=class_name)
         return (len(l) > 0)
 
     WaitUntil(_ready_timeout, _retry_interval, _cabinetwclass_exist)
-    handle = findwindows.find_elements(active_only = True,
-                                      class_name = class_name)[-1].handle
+    handle = findwindows.find_elements(active_only=True,
+                                       class_name=class_name)[-1].handle
     window = WindowSpecification({'handle': handle, 'backend': 'win32', })
     explorer = Application().Connect(process=window.process_id())
     cur_state = None
@@ -88,15 +89,17 @@ def _toggle_notification_area_icons(show_all=True, debug_img=None):
         window.Wait("ready", timeout=_ready_timeout)
         window.AddressBandRoot.click_input()
         window.type_keys(
-                    r'control /name Microsoft.NotificationAreaIcons',
-                    with_spaces=True,
-                    set_foreground=True)
+            r'control /name Microsoft.NotificationAreaIcons',
+            with_spaces=True,
+            set_foreground=True
+        )
         # Send 'ENTER' separately, this is to make sure
         # the window focus hasn't accidentally been lost
         window.type_keys(
-                    '{ENTER}',
-                    with_spaces=True,
-                    set_foreground=True)
+            '{ENTER}',
+            with_spaces=True,
+            set_foreground=True
+        )
         explorer.WaitCPUUsageLower(threshold=5, timeout=_ready_timeout)
 
         # Get the new opened applet
@@ -125,6 +128,7 @@ def _toggle_notification_area_icons(show_all=True, debug_img=None):
 
     return cur_state
 
+
 def _wait_minimized(dlg):
     """A helper function to verify that the specified dialog is minimized
 
@@ -133,10 +137,12 @@ def _wait_minimized(dlg):
     because we test hiding the window to the tray.
     """
     WaitUntil(
-        timeout = _ready_timeout,
-        retry_interval = _retry_interval,
-        func = lambda: (dlg.GetShowState() == win32defines.SW_SHOWMINIMIZED))
+        timeout=_ready_timeout,
+        retry_interval=_retry_interval,
+        func=lambda: (dlg.GetShowState() == win32defines.SW_SHOWMINIMIZED)
+    )
     return True
+
 
 class TaskbarTestCases(unittest.TestCase):
 
@@ -148,7 +154,7 @@ class TaskbarTestCases(unittest.TestCase):
 
         self.tm = _ready_timeout
         app = Application(backend='win32')
-        app.start(os.path.join(mfc_samples_folder, u"TrayMenu.exe"), wait_for_idle = False)
+        app.start(os.path.join(mfc_samples_folder, u"TrayMenu.exe"), wait_for_idle=False)
         self.app = app
         self.dlg = app.top_window()
         self.dlg.Wait('ready', timeout=self.tm)
@@ -204,8 +210,7 @@ class TaskbarTestCases(unittest.TestCase):
 
         # Launch Clock applet
         taskbar.Clock.click_input()
-        ClockWindow = taskbar.explorer_app.Window_(
-                               class_name='ClockFlyoutWindow')
+        ClockWindow = taskbar.explorer_app.Window_(class_name='ClockFlyoutWindow')
         ClockWindow.Wait('visible', timeout=self.tm)
 
         # Close the applet with Esc, we don't click again on it because
@@ -227,9 +232,9 @@ class TaskbarTestCases(unittest.TestCase):
 
         # Make sure that the hidden icons area is disabled
         orig_hid_state = _toggle_notification_area_icons(
-                show_all=True,
-                debug_img="%s_01" % (self.id())
-                )
+            show_all=True,
+            debug_img="%s_01" % (self.id())
+        )
 
         self.dlg.Minimize()
         _wait_minimized(self.dlg)
@@ -267,9 +272,9 @@ class TaskbarTestCases(unittest.TestCase):
 
         # Make sure that the hidden icons area is enabled
         orig_hid_state = _toggle_notification_area_icons(
-                show_all=False,
-                debug_img="%s_01" % (self.id())
-                )
+            show_all=False,
+            debug_img="%s_01" % (self.id())
+        )
 
         self.dlg.Minimize()
         _wait_minimized(self.dlg)
@@ -303,9 +308,9 @@ class TaskbarTestCases(unittest.TestCase):
 
         # Make sure that the hidden icons area is enabled
         orig_hid_state = _toggle_notification_area_icons(
-                show_all=False,
-                debug_img="%s_01" % (self.id())
-                )
+            show_all=False,
+            debug_img="%s_01" % (self.id())
+        )
 
         # Run one more instance of the sample app
         # hopefully one of the icons moves into the hidden area
@@ -318,14 +323,16 @@ class TaskbarTestCases(unittest.TestCase):
 
         # Test click on "Show Hidden Icons" button
         taskbar.ShowHiddenIconsButton.click_input()
-        niow_dlg = taskbar.explorer_app.Window_(
-                class_name='NotifyIconOverflowWindow')
+        niow_dlg = taskbar.explorer_app.Window_(class_name='NotifyIconOverflowWindow')
         niow_dlg.OverflowNotificationAreaToolbar.Wait('ready', timeout=self.tm)
         niow_dlg.SysLink.click_input()
-        nai = taskbar.explorer_app.Window_(
-                title="Notification Area Icons",
-                class_name="CabinetWClass"
-                )
+
+        tmp_app = Application().connect(path="explorer.exe")
+        nai = tmp_app.window_(
+            title="Notification Area Icons",
+            class_name="CabinetWClass"
+        )
+        nai.draw_outline()
         origAlwaysShow = nai.CheckBox.GetCheckState()
         if not origAlwaysShow:
             nai.CheckBox.click_input()
@@ -340,4 +347,3 @@ class TaskbarTestCases(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -11,6 +11,7 @@ sys.path.append(".")
 from pywinauto.application import Application  # noqa: E402
 from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
 from pywinauto.timings import Timings  # noqa: E402
+from pywinauto.actionlogger import ActionLogger
 if UIA_support:
     import pywinauto.uia_defines as uia_defs
     import pywinauto.controls.uia_controls as uia_ctls
@@ -1041,7 +1042,12 @@ if UIA_support:
             self.app = Application(backend='uia')
             self.app = self.app.start("notepad.exe")
             self.dlg = self.app.UntitledNotepad
-            self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
+            log = ActionLogger()
+            log.log("MenuWrapperNotepadTests::setUp, wait for CPU low")
+            self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=1)
+            log.log("MenuWrapperNotepadTests::setUp, wait for the dialog is ready")
+            self.dlg.wait("ready")
+            log.log("MenuWrapperNotepadTests::setUp, Notepad is ready")
 
         def tearDown(self):
             """Close the application after tests"""

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -5,19 +5,15 @@ from __future__ import unicode_literals
 import time
 import os
 import sys
+import unittest
 
 sys.path.append(".")
-from pywinauto.application import Application
-from pywinauto.sysinfo import is_x64_Python, UIA_support
+from pywinauto.application import Application  # noqa: E402
+from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
+from pywinauto.timings import Timings  # noqa: E402
 if UIA_support:
     import pywinauto.uia_defines as uia_defs
     import pywinauto.controls.uia_controls as uia_ctls
-    # from pywinauto.controls.uiawrapper import UIAWrapper
-# from pywinauto import findwindows
-from pywinauto.timings import Timings
-# from pywinauto.timings import TimeoutError
-
-import unittest
 
 wpf_samples_folder = os.path.join(
     os.path.dirname(__file__), r"..\..\apps\WPF_samples")
@@ -36,7 +32,6 @@ if UIA_support:
         """Setup timings for UIA related tests"""
         Timings.Defaults()
         Timings.window_find_timeout = 20
-
 
     class UIAWrapperTests(unittest.TestCase):
 
@@ -88,7 +83,7 @@ if UIA_support:
         def test_class(self):
             """Test getting the classname of the dialog"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.class_name(), "Button")
 
         def test_window_text(self):
@@ -99,32 +94,32 @@ if UIA_support:
         def test_control_id(self):
             """Test getting control ID"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.control_id(), None)
 
         def test_is_visible(self):
             """Test is_visible method of a control"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.is_visible(), True)
 
         def test_is_enabled(self):
             """Test is_enabled method of a control"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.is_enabled(), True)
 
         def test_process_id(self):
             """Test process_id method of a control"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.process_id(), self.dlg.process_id())
             self.assertNotEqual(button.process_id(), 0)
 
         def test_is_dialog(self):
             """Test is_dialog method of a control"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.is_dialog(), False)
 
         def test_parent(self):
@@ -135,7 +130,7 @@ if UIA_support:
         def test_top_level_parent(self):
             """Test getting a top-level parent of a control"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.top_level_parent(), self.dlg.wrapper_object())
 
         def test_texts(self):
@@ -145,7 +140,7 @@ if UIA_support:
         def test_children(self):
             """Test getting children of a control"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(len(button.children()), 1)
             self.assertEqual(button.children()[0].class_name(), "TextBlock")
 
@@ -157,7 +152,7 @@ if UIA_support:
         def test_equals(self):
             """Test controls comparisons"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertNotEqual(button, self.dlg.wrapper_object())
             self.assertEqual(button, button.element_info)
             self.assertEqual(button, button)
@@ -176,7 +171,7 @@ if UIA_support:
             edit = self.dlg.TestLabelEdit.wrapper_object()
             label = self.dlg.TestLabel.wrapper_object()
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             self.assertEqual(button.is_keyboard_focusable(), True)
             self.assertEqual(edit.is_keyboard_focusable(), True)
             self.assertEqual(label.is_keyboard_focusable(), False)
@@ -202,7 +197,7 @@ if UIA_support:
         def test_no_pattern_interface_error(self):
             """Test a query interface exception handling"""
             button = self.dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
             elem = button.element_info.element
             self.assertRaises(
                 uia_defs.NoPatternInterfaceError,
@@ -262,7 +257,6 @@ if UIA_support:
             #     img2 = self.dlg.capture_as_image()
             #     self.assertEqual(img2.getpixel((0, 0)), (0, 0, 255))  # blue
 
-
     class UIAWrapperMouseTests(unittest.TestCase):
 
         """Unit tests for mouse actions of the UIAWrapper class"""
@@ -276,7 +270,7 @@ if UIA_support:
 
             dlg = self.app.WPFSampleApplication
             self.button = dlg.window(class_name="Button",
-                                      title="OK").wrapper_object()
+                                     title="OK").wrapper_object()
 
             self.label = dlg.window(class_name="Text", title="TestLabel").wrapper_object()
 
@@ -312,7 +306,6 @@ if UIA_support:
 
             # def test_press_move_release(self):
             #    pass
-
 
     class UiaControlsTests(unittest.TestCase):
 
@@ -407,7 +400,7 @@ if UIA_support:
         def test_button_click(self):
             """Test the click method for the Button control"""
             label = self.dlg.window(class_name="Text",
-                                     title="TestLabel").wrapper_object()
+                                    title="TestLabel").wrapper_object()
             self.dlg.Apply.click()
             self.assertEqual(label.window_text(), "ApplyClick")
 
@@ -479,7 +472,6 @@ if UIA_support:
             collapsed = combo_box.collapse().is_collapsed()
             self.assertEqual(collapsed, True)
 
-
     class TabControlWrapperTests(unittest.TestCase):
 
         """Unit tests for the TabControlWrapper class"""
@@ -517,7 +509,6 @@ if UIA_support:
         def test_texts(self):
             """Make sure the tabs captions are read correctly"""
             self.assertEqual(self.ctrl.texts(), self.texts)
-
 
     class EditWrapperTests(unittest.TestCase):
 
@@ -602,7 +593,6 @@ if UIA_support:
 
             self.assertRaises(RuntimeError, self.edit.select, "123")
 
-
     class SliderWrapperTests(unittest.TestCase):
 
         """Unit tests for the EditWrapper class"""
@@ -659,7 +649,6 @@ if UIA_support:
             self.assertRaises(ValueError, self.slider.set_value, 102)
 
             self.assertRaises(ValueError, self.slider.set_value, [50, ])
-
 
     class ListViewWrapperTests(unittest.TestCase):
 
@@ -977,7 +966,6 @@ if UIA_support:
             texts = [u"2", u"Cucumber", u"Green"]
             self.assertEqual(listview_item.texts(), texts)
 
-
     class MenuWrapperWpfTests(unittest.TestCase):
 
         """Unit tests for the MenuWrapper class on WPF demo"""
@@ -996,7 +984,7 @@ if UIA_support:
             self.app.kill_()
 
         def test_menu_by_index(self):
-            """Test selecting a menu item by index"""
+            """Test selecting a WPF menu item by index"""
             path = "#0->#1->#1"  # "File->Close->Later"
             self.dlg.menu_select(path)
             label = self.dlg.MenuLaterClickLabel.wrapper_object()
@@ -1009,7 +997,7 @@ if UIA_support:
             self.assertRaises(IndexError, self.dlg.menu_select, path)
 
         def test_menu_by_exact_text(self):
-            """Test selecting a menu item by exact text match"""
+            """Test selecting a WPF menu item by exact text match"""
             path = "File->Close->Later"
             self.dlg.menu_select(path, True)
             label = self.dlg.MenuLaterClickLabel.wrapper_object()
@@ -1020,14 +1008,14 @@ if UIA_support:
             self.assertRaises(IndexError, self.dlg.menu_select, path, True)
 
         def test_menu_by_best_match_text(self):
-            """Test selecting a menu item by best match text"""
+            """Test selecting a WPF menu item by best match text"""
             path = "file-> close -> later"
             self.dlg.menu_select(path, False)
             label = self.dlg.MenuLaterClickLabel.wrapper_object()
             self.assertEqual(label.window_text(), u"MenuLaterClick")
 
         def test_menu_by_mixed_match(self):
-            """Test selecting a menu item by a path with mixed specifiers"""
+            """Test selecting a WPF menu item by a path with mixed specifiers"""
             path = "file-> #1 -> later"
             self.dlg.menu_select(path, False)
             label = self.dlg.MenuLaterClickLabel.wrapper_object()
@@ -1041,7 +1029,6 @@ if UIA_support:
             path = "0->#1->1"
             self.assertRaises(IndexError, self.dlg.menu_select, path)
 
-
     class MenuWrapperNotepadTests(unittest.TestCase):
 
         """Unit tests for the MenuWrapper class on Notepad"""
@@ -1054,6 +1041,7 @@ if UIA_support:
             self.app = Application(backend='uia')
             self.app = self.app.start("notepad.exe")
             self.dlg = self.app.UntitledNotepad
+            self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=2)
 
         def tearDown(self):
             """Close the application after tests"""
@@ -1105,7 +1093,7 @@ if UIA_support:
             self.assertRaises(IndexError, self.dlg.menu_select, path, True)
 
         def test_menu_by_best_match_text(self):
-            """Test selecting a menu item by best match text"""
+            """Test selecting a Win32 menu item by best match text"""
             path = "help->aboutnotepad"
             self.dlg.menu_select(path, False)
             self.dlg.AboutNotepad.close()
@@ -1147,7 +1135,6 @@ if UIA_support:
             self.assertRaises(IndexError, self.dlg.menu_select, path)
             path = " -> #1 -> #2"
             self.assertRaises(IndexError, self.dlg.menu_select, path)
-
 
     class ToolbarWpfTests(unittest.TestCase):
 
@@ -1198,7 +1185,6 @@ if UIA_support:
             # Notice that findbestmatch.MatchError is subclassed from IndexError
             self.assertRaises(IndexError, tb.button, "BaD n_$E ", exact=False)
 
-
     class ToolbarNativeTests(unittest.TestCase):
 
         """Unit tests for ToolbarWrapper class on a native application"""
@@ -1223,7 +1209,7 @@ if UIA_support:
 
             # Find a tooltip by class name
             tt = self.app.window(top_level_only=False,
-                                  class_name="tooltips_class32").wait('visible')
+                                 class_name="tooltips_class32").wait('visible')
             self.assertEqual(isinstance(tt, uia_ctls.TooltipWrapper), True)
             self.assertEqual(tt.window_text(), "Large Icons")
 


### PR DESCRIPTION
This PR has a lot of noise because there is a plenty of PEP-8 related typos but the main point is my changes in Application.kill() (see: baf6553). After these changes  the AppVeyor tests run 30 minutes faster.

Other changes:
- Add wait_cpu_usage_lower() to Setup routine of several flaky tests 
- Use "#  noqa: E..." - a special comment to ignore flake8 warnings.  For example: Not importing files at top of the file
- PEP-8 typos and fixes
