### PR TITLE
Send WM_CHAR when possible during a send_keys

### DIFF
--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -470,40 +470,39 @@ class HwndWrapper(BaseWrapper):
         For more information about Sequences and Modifiers navigate to keyboard.py
         """
 
+        input_locale_id = ctypes.windll.User32.GetKeyboardLayout(0)
+
         keys = keyboard.parse_keys(message, with_spaces, with_tabs, with_newlines)
         for key in keys:
 
             vk, scan, flags = key.get_key_info()
 
-            lparam = 1 << 0 | scan << 16 | flags << 24
-
-            if isinstance(key, keyboard.VirtualKeyAction):                
-                if key.down:
-                    # TODO: {CTRL} (^) modifier doesn't work
-                    # + SHIFT down
-                    # - CTRL down
-                    # print('key', key, 'down')
-                    lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 0 << 31
-                    win32api.SendMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
-            
+            if flags & keyboard.KEYEVENTF_UNICODE == 0:
                 char = keyboard.MapVirtualKey(vk, 2)    
-                if key.down and key.up and char > 0:
-                    lparam = 1 << 0 | scan << 16
-                    win32api.SendMessage(self.handle, win32con.WM_CHAR, char, lparam)
-
-                if key.up:
-                    # + SHIFT up
-                    # - CTRL up
-                    # print('key', key, 'up')
-                    lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 1 << 30 | 1 << 31
-                    win32api.SendMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
-            elif isinstance(key, keyboard.EscapedKeyAction):
-                # An escaped key action e.g. F9 DOWN, etc
-                # And key between Shifts. a -> A
-                win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
             else:
-                # Usual key
-                win32api.SendMessage(self.handle, win32con.WM_CHAR, scan, lparam)
+                # Indicates that we actually just have a unicode codepoint
+                char = scan
+                vk = ctypes.windll.User32.VkKeyScanExW(char, input_locale_id) & 0xFF # TODO: use shift state in high order byte
+                scan = keyboard.MapVirtualKey(vk, 0)
+
+            if key.down and vk > 0:
+                # TODO: {CTRL} (^) modifier doesn't work
+                # + SHIFT down
+                # - CTRL down
+                # print('key', key, 'down')
+                lparam = 1 << 0 | scan << 16 | (flags & 1) << 24 | 0 << 29 | 0 << 31
+                win32api.SendMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
+
+            if char > 0:
+                lparam = 1 << 0 | scan << 16 | (flags & 1) << 24
+                win32api.SendMessage(self.handle, win32con.WM_CHAR, char, lparam)
+
+            if key.up and vk > 0:
+                # + SHIFT up
+                # - CTRL up
+                # print('key', key, 'up')
+                lparam = 1 << 0 | scan << 16 | (flags & 1) << 24 | 0 << 29 | 1 << 30 | 1 << 31
+                win32api.SendMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
 
             # time.sleep(Timings.after_sendkeys_key_wait)
 

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -477,25 +477,21 @@ class HwndWrapper(BaseWrapper):
 
             lparam = 1 << 0 | scan << 16 | flags << 24
 
-            if isinstance(key, keyboard.VirtualKeyAction):
-
-                if key.down and key.up and (flags == 0):
-                    lparam = 1 << 0 | scan << 16
-                    win32api.SendMessage(self.handle, win32con.WM_CHAR, vk, lparam)
-                elif key.down and key.up and (flags == 1):
-                    # + LEFT, DELETE
-                    lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 0 << 31
-                    win32api.SendMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
-                    lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 1 << 30 | 1 << 31
-                    win32api.SendMessage(self.handle, win32con.WM_KEYUP, vk, lparam)
-                elif key.down:
+            if isinstance(key, keyboard.VirtualKeyAction):                
+                if key.down:
                     # TODO: {CTRL} (^) modifier doesn't work
                     # + SHIFT down
                     # - CTRL down
                     # print('key', key, 'down')
                     lparam = 1 << 0 | scan << 16 | flags << 24 | 0 << 29 | 0 << 31
                     win32api.SendMessage(self.handle, win32con.WM_KEYDOWN, vk, lparam)
-                elif key.up:
+            
+                char = keyboard.MapVirtualKey(vk, 2)    
+                if key.down and key.up and char > 0:
+                    lparam = 1 << 0 | scan << 16
+                    win32api.SendMessage(self.handle, win32con.WM_CHAR, char, lparam)
+
+                if key.up:
                     # + SHIFT up
                     # - CTRL up
                     # print('key', key, 'up')

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -478,7 +478,7 @@ class HwndWrapper(BaseWrapper):
             vk, scan, flags = key.get_key_info()
 
             if flags & keyboard.KEYEVENTF_UNICODE == 0:
-                char = keyboard.MapVirtualKey(vk, 2)    
+                char = keyboard.MapVirtualKey(vk, 2)
             else:
                 # Indicates that we actually just have a unicode codepoint
                 char = scan

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -885,6 +885,31 @@ class GetDialogPropsFromHandleTest(unittest.TestCase):
         self.assertEquals(props_from_handle, props_from_dialog)
 
 
+class SendEnterKeyTest(unittest.TestCase):
+    def setUp(self):
+        """Set some data and ensure the application is in the state we want"""
+        Timings.Fast()
+
+        self.app = Application()
+        self.app.start(_notepad_exe())
+
+        self.dlg = self.app.UntitledNotepad
+        self.ctrl = HwndWrapper(self.dlg.Edit.handle)
+
+    def tearDown(self):
+        """Close the application after tests"""
+        self.dlg.MenuSelect('File -> Exit')
+        if self.dlg["Do&n't Save"].Exists():
+            self.dlg["Do&n't Save"].Click()
+        self.app.kill_()
+
+
+    def test_sendEnterChar(self):
+        """Test some small stuff regarding GetDialogPropsFromHandle"""
+        self.ctrl.send_chars('Hello{ENTER}World')
+        self.assertEquals(['Hello\r\nWorld'], self.dlg.Edit.Texts())
+
+
 class RemoteMemoryBlockTests(unittest.TestCase):
 
     """Unit tests for RemoteMemoryBlock"""

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -897,7 +897,6 @@ class SendEnterKeyTest(unittest.TestCase):
         self.ctrl = HwndWrapper(self.dlg.Edit.handle)
 
     def tearDown(self):
-        """Close the application after tests"""
         self.dlg.MenuSelect('File -> Exit')
         if self.dlg["Do&n't Save"].Exists():
             self.dlg["Do&n't Save"].Click()
@@ -905,7 +904,6 @@ class SendEnterKeyTest(unittest.TestCase):
 
 
     def test_sendEnterChar(self):
-        """Test some small stuff regarding GetDialogPropsFromHandle"""
         self.ctrl.send_chars('Hello{ENTER}World')
         self.assertEquals(['Hello\r\nWorld'], self.dlg.Edit.Texts())
 


### PR DESCRIPTION
In particular this is necessary for the enter key to work with some apps (they expect a WM_CHAR with keycode 13, not just the WM_KEYDOWN/UP).

Enter still doesn't work in all situations (e.g. the commented out test_send_chars_enter still fails) but this is an improvement on the status quo, I think.