### PR TITLE
actionlogger: fix issue #315, try to prevent import clashes, more tests

### DIFF
--- a/pywinauto/actionlogger.py
+++ b/pywinauto/actionlogger.py
@@ -28,15 +28,14 @@
 # CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+import logging
 
 # Try to find a custom logger
 try:
-    from logger import logger
-    foundLogger = True
-except ImportError:
-    foundLogger = False
-
-import logging
+    import logger
+    _found_logger = (logger.Logger.sectionStart is not None)
+except (ImportError, AttributeError) as exc:
+    _found_logger = False
 
 
 def set_level(level):
@@ -73,13 +72,18 @@ class _CustomLogger(object):
         self.logger = logger.Logger(logFilePath)
 
     @staticmethod
-    def set_log_level(level):
+    def set_level(level):
         """Set a logging level"""
         pass
 
     @staticmethod
     def reset_level():
         """Reset a logging level to a default"""
+        pass
+
+    @staticmethod
+    def disable():
+        """Set a logging level to one above INFO to disable logs emitting"""
         pass
 
     def log(self, *args):
@@ -101,7 +105,7 @@ def _setup_standard_logger():
     # For the meantime we allow only one handler.
     # This is the simplest way to avoid duplicates.
     if logger.handlers:
-        return
+        return logger
 
     # Create a handler with logging.DEBUG as the default logging level,
     # means - all messages will be processed by the handler
@@ -160,7 +164,7 @@ class _StandardLogger(object):
         pass
 
 # Define which logging facilities should be used for pywinauto traces
-if foundLogger:
+if _found_logger:
     ActionLogger = _CustomLogger
 else:
     ActionLogger = _StandardLogger

--- a/pywinauto/unittests/test_actionlogger.py
+++ b/pywinauto/unittests/test_actionlogger.py
@@ -154,7 +154,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
         reload_module(actionlogger)
 
         # verify on mock
-        self.logger_patcher = mock.patch('__main__.actionlogger.ActionLogger', spec=True)
+        self.logger_patcher = mock.patch('pywinauto.actionlogger.ActionLogger', spec=True)
         mockLogger = self.logger_patcher.start()
 
         actionlogger.disable()
@@ -168,7 +168,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
         reload_module(actionlogger)
 
         # verify on mock
-        self.logger_patcher = mock.patch('__main__.actionlogger.ActionLogger', spec=True)
+        self.logger_patcher = mock.patch('pywinauto.actionlogger.ActionLogger', spec=True)
         mockLogger = self.logger_patcher.start()
 
         actionlogger.enable()


### PR DESCRIPTION
Seems that the problem reported in issue #315 arose because the user had "logger" module available for import. As a result, pywinauto tried to switch to "Custom Logger" mode and failed. Now we try to prevent it harder - we make sure that there is an available "logger" module and there is a "Logger" object with "sectionStart" attribute. Hope it makes the code more bulletproof now. 

There was also a bug with a non-existing method in _CustomLogger class that I fixed too.

Edit: grammar