### PR TITLE
Fix issue #322: implement BaseWrapper.__repr__() and ElementInfo.__repr__()

### DIFF
--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -162,8 +162,7 @@ class BaseWrapper(object):
         a windows specification to access the control, while the unique ID is more for
         debugging purposes helping to distinguish between the runtime objects.
         """
-        obj = ', <' + str(self.__hash__()) + '>'
-        return self.__str__() + obj
+        return '<{0}, {1}>'.format(self.__str__(), self.__hash__())
 
     def __str__(self):
         """Pretty print representation of the wrapper object

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -149,8 +149,33 @@ class BaseWrapper(object):
         else:
             raise RuntimeError('NULL pointer was used to initialize BaseWrapper')
 
+    def __repr__(self):
+        """Representation of the wrapper object
+
+        The method prints the following info:
+        * type name as a module name and a class name of the object
+        * title of the control or empty string
+        * friendly class name of the control
+        * unique ID of the control calculated as a hash value from a backend specific ID.
+
+        Notice that the reported title and class name can be used as hints to prepare
+        a windows specification to access the control, while the unique ID is more for
+        debugging purposes helping to distinguish between the runtime objects.
+        """
+        obj = ', <' + str(self.__hash__()) + '>'
+        return self.__str__() + obj
+
     def __str__(self):
-        """Pretty print representation of the wrapper object"""
+        """Pretty print representation of the wrapper object
+
+        The method prints the following info:
+        * type name as a module name and class name of the object
+        * title of the wrapped control or empty string
+        * friendly class name of the wrapped control
+
+        Notice that the reported title and class name can be used as hints
+        to prepare a windows specification to access the control
+        """
         module = self.__class__.__module__
         module = module[module.rfind('.') + 1:]
         type_name = module + "." + self.__class__.__name__
@@ -163,6 +188,11 @@ class BaseWrapper(object):
         class_name = self.friendly_class_name()
 
         return "{0} - '{1}', {2}".format(type_name, title, class_name)
+
+    def __hash__(self):
+        """Returns the hash value of the handle"""
+        # Must be implemented in a sub-class
+        raise NotImplementedError()
 
     #------------------------------------------------------------
     @property

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -151,22 +151,20 @@ class BaseWrapper(object):
 
     def __str__(self):
         """Pretty print representation of the wrapper object"""
-        type_name = str(self.__class__)[18:-2]
-        title = ''
+        module = self.__class__.__module__
+        module = module[module.rfind('.') + 1:]
+        type_name = module + "." + self.__class__.__name__
+        title = ' - "'
         try:
-            title = ' - "' + self.texts()[0] + '"'
+            title += self.texts()[0] + '"'
         except IndexError:
-            self.actions.log("{0}.__str__ () failed to get title of the object"
-                             .format(self.__class__))
+            title += '"'
 
-        res = "".join([
-            type_name,
-            title,
-            '  <object ',
-            hex(id(self))[:-1],
-            '>'
-        ])
-        return res
+        # Put an ID if no title
+        if title == ' - ""':
+            title += ' <object ' + hex(id(self))[:-1] + '>'
+
+        return type_name + title
 
     #------------------------------------------------------------
     @property

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -154,17 +154,15 @@ class BaseWrapper(object):
         module = self.__class__.__module__
         module = module[module.rfind('.') + 1:]
         type_name = module + "." + self.__class__.__name__
-        title = ' - "'
+
         try:
-            title += self.texts()[0] + '"'
+            title = self.texts()[0]
         except IndexError:
-            title += '"'
+            title = ""
 
-        # Put an ID if no title
-        if title == ' - ""':
-            title += ' <object ' + hex(id(self))[:-1] + '>'
+        class_name = self.friendly_class_name()
 
-        return type_name + title
+        return "{0} - '{1}', {2}".format(type_name, title, class_name)
 
     #------------------------------------------------------------
     @property

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -147,7 +147,26 @@ class BaseWrapper(object):
             self._cache = {}
             self.actions = ActionLogger()
         else:
-            raise RuntimeError('NULL pointer used to initialize BaseWrapper')
+            raise RuntimeError('NULL pointer was used to initialize BaseWrapper')
+
+    def __str__(self):
+        """Pretty print representation of the wrapper object"""
+        type_name = str(self.__class__)[18:-2]
+        title = ''
+        try:
+            title = ' - "' + self.texts()[0] + '"'
+        except IndexError:
+            self.actions.log("{0}.__str__ () failed to get title of the object"
+                             .format(self.__class__))
+
+        res = "".join([
+            type_name,
+            title,
+            '  <object ',
+            hex(id(self))[:-1],
+            '>'
+        ])
+        return res
 
     #------------------------------------------------------------
     @property

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -41,17 +41,13 @@ class ElementInfo(object):
         module = self.__class__.__module__
         module = module[module.rfind('.') + 1:]
         type_name = module + "." + self.__class__.__name__
-        title = ' - "'
+
         try:
-            title += self.name + '"'
+            title = self.name
         except TypeError:
-            title += '"'
+            title = ""
 
-        # Put an ID if no title
-        if title == ' - ""':
-            title += ' <object ' + hex(id(self))[:-1] + '>'
-
-        return type_name + title
+        return "{0} - '{1}', {2}".format(type_name, title, self.class_name)
 
     def set_cache_strategy(self, cached):
         """Set a cache strategy for frequently used attributes of the element"""

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -36,8 +36,26 @@ class ElementInfo(object):
 
     """Abstract wrapper for an element"""
 
+    def __repr__(self):
+        """Representation of the element info object
+
+        The method prints the following info:
+        * type name as a module name and a class name of the object
+        * title of the control or empty string
+        * class name of the control
+        * unique ID of the control, usually a handle
+        """
+        obj = ', <' + str(self.handle) + '>'
+        return self.__str__() + obj
+
     def __str__(self):
-        """Pretty print representation of the element info object"""
+        """Pretty print representation of the element info object
+
+        The method prints the following info:
+        * type name as a module name and class name of the object
+        * title of the control or empty string
+        * class name of the control
+        """
         module = self.__class__.__module__
         module = module[module.rfind('.') + 1:]
         type_name = module + "." + self.__class__.__name__

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -31,9 +31,27 @@
 
 """Interface for classes which should deal with different backend elements"""
 
+
 class ElementInfo(object):
 
     """Abstract wrapper for an element"""
+
+    def __str__(self):
+        """Pretty print representation of the element info object"""
+        module = self.__class__.__module__
+        module = module[module.rfind('.') + 1:]
+        type_name = module + "." + self.__class__.__name__
+        title = ' - "'
+        try:
+            title += self.name + '"'
+        except TypeError:
+            title += '"'
+
+        # Put an ID if no title
+        if title == ' - ""':
+            title += ' <object ' + hex(id(self))[:-1] + '>'
+
+        return type_name + title
 
     def set_cache_strategy(self, cached):
         """Set a cache strategy for frequently used attributes of the element"""

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -45,8 +45,7 @@ class ElementInfo(object):
         * class name of the control
         * unique ID of the control, usually a handle
         """
-        obj = ', <' + str(self.handle) + '>'
-        return self.__str__() + obj
+        return '<{0}, {1}>'.format(self.__str__(), self.handle)
 
     def __str__(self):
         """Pretty print representation of the element info object
@@ -60,12 +59,7 @@ class ElementInfo(object):
         module = module[module.rfind('.') + 1:]
         type_name = module + "." + self.__class__.__name__
 
-        try:
-            title = self.name
-        except TypeError:
-            title = ""
-
-        return "{0} - '{1}', {2}".format(type_name, title, self.class_name)
+        return "{0} - '{1}', {2}".format(type_name, self.name, self.class_name)
 
     def set_cache_strategy(self, cached):
         """Set a cache strategy for frequently used attributes of the element"""

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -60,12 +60,14 @@ def text(handle):
     # WM_GETTEXTLENGTH may hang even for notepad.exe main window!
     c_length = win32structures.DWORD(0)
     result = win32functions.SendMessageTimeout(
-                        handle,
-                        win32defines.WM_GETTEXTLENGTH,
-                        0, 0,
-                        win32defines.SMTO_ABORTIFHUNG,
-                        500,
-                        ctypes.byref(c_length))
+        handle,
+        win32defines.WM_GETTEXTLENGTH,
+        0,
+        0,
+        win32defines.SMTO_ABORTIFHUNG,
+        500,
+        ctypes.byref(c_length)
+    )
     if result == 0:
         ActionLogger().log('WARNING! Cannot retrieve text length for handle = ' + str(handle))
         return None
@@ -88,62 +90,74 @@ def text(handle):
 
     return textval
 
+
 #=========================================================================
 def classname(handle):
     """Return the class name of the window"""
     class_name = (ctypes.c_wchar * 257)()
-    win32functions.GetClassName (handle, ctypes.byref(class_name), 256)
+    win32functions.GetClassName(handle, ctypes.byref(class_name), 256)
     return class_name.value
+
 
 #=========================================================================
 def parent(handle):
     """Return the handle of the parent of the window"""
     return win32functions.GetParent(handle)
 
+
 #=========================================================================
 def style(handle):
     """Return the style of the window"""
-    return win32functions.GetWindowLong (handle, win32defines.GWL_STYLE)
+    return win32functions.GetWindowLong(handle, win32defines.GWL_STYLE)
+
 
 #=========================================================================
 def exstyle(handle):
     """Return the extended style of the window"""
-    return win32functions.GetWindowLong (handle, win32defines.GWL_EXSTYLE)
+    return win32functions.GetWindowLong(handle, win32defines.GWL_EXSTYLE)
+
 
 #=========================================================================
 def controlid(handle):
     """Return the ID of the control"""
-    return win32functions.GetWindowLong (handle, win32defines.GWL_ID)
+    return win32functions.GetWindowLong(handle, win32defines.GWL_ID)
+
 
 #=========================================================================
 def userdata(handle):
     """Return the value of any user data associated with the window"""
-    return win32functions.GetWindowLong (handle, win32defines.GWL_USERDATA)
+    return win32functions.GetWindowLong(handle, win32defines.GWL_USERDATA)
+
 
 #=========================================================================
 def contexthelpid(handle):
     """Return the context help id of the window"""
-    return win32functions.GetWindowContextHelpId (handle)
+    return win32functions.GetWindowContextHelpId(handle)
+
 
 #=========================================================================
 def iswindow(handle):
     """Return True if the handle is a window"""
     return bool(win32functions.IsWindow(handle))
 
+
 #=========================================================================
 def isvisible(handle):
     """Return True if the window is visible"""
     return bool(win32functions.IsWindowVisible(handle))
+
 
 #=========================================================================
 def isunicode(handle):
     """Return True if the window is a Unicode window"""
     return bool(win32functions.IsWindowUnicode(handle))
 
+
 #=========================================================================
 def isenabled(handle):
     """Return True if the window is enabled"""
     return bool(win32functions.IsWindowEnabled(handle))
+
 
 #=========================================================================
 def is64bitprocess(process_id):
@@ -162,12 +176,14 @@ def is64bitprocess(process_id):
 
     return (not is32)
 
+
 #=========================================================================
 def is64bitbinary(filename):
     """Check if the file is 64-bit binary"""
     import win32file
     binary_type = win32file.GetBinaryType(filename)
     return binary_type != win32file.SCS_32BIT_BINARY
+
 
 #=========================================================================
 def clientrect(handle):
@@ -176,12 +192,14 @@ def clientrect(handle):
     win32functions.GetClientRect(handle, ctypes.byref(client_rect))
     return client_rect
 
+
 #=========================================================================
 def rectangle(handle):
     """Return the rectangle of the window"""
     rect = win32structures.RECT()
     win32functions.GetWindowRect(handle, ctypes.byref(rect))
     return rect
+
 
 #=========================================================================
 def font(handle):
@@ -232,7 +250,7 @@ def font(handle):
     if is_toplevel_window(handle):
 
         if "MS Shell Dlg" in fontval.lfFaceName or \
-            fontval.lfFaceName == "System":
+           fontval.lfFaceName == "System":
             # these are not usually the fonts actaully used in for
             # title bars so we need to get the default title bar font
 
@@ -257,11 +275,13 @@ def font(handle):
 
     return fontval
 
+
 #=========================================================================
 def processid(handle):
     """Return the ID of process that controls this window"""
     _, process_id = win32process.GetWindowThreadProcessId(int(handle))
     return process_id
+
 
 #=========================================================================
 def children(handle):
@@ -280,9 +300,9 @@ def children(handle):
 
     # define the child proc type
     enum_child_proc_t = ctypes.WINFUNCTYPE(
-        ctypes.c_int, 			# return type
-        win32structures.HWND, 	# the window handle
-        win32structures.LPARAM)	# extra information
+        ctypes.c_int,            # return type
+        win32structures.HWND,    # the window handle
+        win32structures.LPARAM)  # extra information
 
     # update the proc to the correct type
     proc = enum_child_proc_t(enum_child_proc)
@@ -292,17 +312,20 @@ def children(handle):
 
     return child_windows
 
+
 #=========================================================================
 def has_style(handle, tocheck):
     """Return True if the control has style tocheck"""
     hwnd_style = style(handle)
     return tocheck & hwnd_style == tocheck
 
+
 #=========================================================================
 def has_exstyle(handle, tocheck):
     """Return True if the control has extended style tocheck"""
     hwnd_exstyle = exstyle(handle)
     return tocheck & hwnd_exstyle == tocheck
+
 
 #=========================================================================
 def is_toplevel_window(handle):
@@ -311,36 +334,36 @@ def is_toplevel_window(handle):
     # (handle, style) for each style I wan to check!
     style_ = style(handle)
 
-    if (style_ & win32defines.WS_OVERLAPPED == win32defines.WS_OVERLAPPED or \
+    if (style_ & win32defines.WS_OVERLAPPED == win32defines.WS_OVERLAPPED or
         style_ & win32defines.WS_CAPTION == win32defines.WS_CAPTION) and \
-        not (style_ & win32defines.WS_CHILD == win32defines.WS_CHILD):
+       not (style_ & win32defines.WS_CHILD == win32defines.WS_CHILD):
         return True
     else:
         return False
+
 
 #=========================================================================
 def dumpwindow(handle):
     """Dump a window to a set of properties"""
     props = {}
 
-    for func in (
-        text,
-        classname,
-        rectangle,
-        clientrect,
-        style,
-        exstyle,
-        contexthelpid,
-        controlid,
-        userdata,
-        font,
-        parent,
-        processid,
-        isenabled,
-        isunicode,
-        isvisible,
-        children,
-        ):
+    for func in (text,
+                 classname,
+                 rectangle,
+                 clientrect,
+                 style,
+                 exstyle,
+                 contexthelpid,
+                 controlid,
+                 userdata,
+                 font,
+                 parent,
+                 processid,
+                 isenabled,
+                 isunicode,
+                 isvisible,
+                 children,
+                 ):
 
         props[func.__name__] = func(handle)
 

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -514,12 +514,15 @@ class HwndWrapperTests(unittest.TestCase):
 
         wrp = self.dlg.wrapper_object()
         assert_regex(wrp.__str__(), "^hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog$")
+        assert_regex(wrp.__repr__(), "^hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog, <[0-9-]+>$")
 
         wrp = self.ctrl
         assert_regex(wrp.__str__(), "^win32_controls.ButtonWrapper - 'Command button here', Button$")
+        assert_regex(wrp.__repr__(), "^win32_controls.ButtonWrapper - 'Command button here', Button, <[0-9-]+>$")
 
         wrp = self.dlg.TabControl.wrapper_object()
         assert_regex(wrp.__str__(), "^common_controls.TabControlWrapper - '', TabControl$")
+        assert_regex(wrp.__repr__(), "^common_controls.TabControlWrapper - '', TabControl, <[0-9-]+>$")
 
 
 class HwndWrapperMenuTests(unittest.TestCase):

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -514,15 +514,15 @@ class HwndWrapperTests(unittest.TestCase):
 
         wrp = self.dlg.wrapper_object()
         assert_regex(wrp.__str__(), "^hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog$")
-        assert_regex(wrp.__repr__(), "^hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog, <[0-9-]+>$")
+        assert_regex(wrp.__repr__(), "^<hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog, [0-9-]+>$")
 
         wrp = self.ctrl
         assert_regex(wrp.__str__(), "^win32_controls.ButtonWrapper - 'Command button here', Button$")
-        assert_regex(wrp.__repr__(), "^win32_controls.ButtonWrapper - 'Command button here', Button, <[0-9-]+>$")
+        assert_regex(wrp.__repr__(), "^<win32_controls.ButtonWrapper - 'Command button here', Button, [0-9-]+>$")
 
         wrp = self.dlg.TabControl.wrapper_object()
         assert_regex(wrp.__str__(), "^common_controls.TabControlWrapper - '', TabControl$")
-        assert_regex(wrp.__repr__(), "^common_controls.TabControlWrapper - '', TabControl, <[0-9-]+>$")
+        assert_regex(wrp.__repr__(), "^<common_controls.TabControlWrapper - '', TabControl, [0-9-]+>$")
 
 
 class HwndWrapperMenuTests(unittest.TestCase):

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -513,13 +513,13 @@ class HwndWrapperTests(unittest.TestCase):
             assert_regex = self.assertRegexpMatches
 
         wrp = self.dlg.wrapper_object()
-        assert_regex(wrp.__str__(), '^hwndwrapper.DialogWrapper - "Common Controls Sample"$')
+        assert_regex(wrp.__str__(), "^hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog$")
 
         wrp = self.ctrl
-        assert_regex(wrp.__str__(), '^win32_controls.ButtonWrapper - "Command button here"$')
+        assert_regex(wrp.__str__(), "^win32_controls.ButtonWrapper - 'Command button here', Button$")
 
         wrp = self.dlg.TabControl.wrapper_object()
-        assert_regex(wrp.__str__(), '^common_controls.TabControlWrapper - "" <object 0x.+>$')
+        assert_regex(wrp.__str__(), "^common_controls.TabControlWrapper - '', TabControl$")
 
 
 class HwndWrapperMenuTests(unittest.TestCase):

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -33,6 +33,7 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import six
 import time
 #import pprint
 #import pdb
@@ -503,6 +504,22 @@ class HwndWrapperTests(unittest.TestCase):
         self.assertNotEqual(self.dlg.get_focus(), self.dlg.set.handle)
         self.dlg.set.set_keyboard_focus()
         self.assertEqual(self.dlg.get_focus(), self.dlg.set.handle)
+
+    def test_pretty_print(self):
+        """Test __str__ method for HwndWrapper based controls"""
+        if six.PY3:
+            assert_regex = self.assertRegex
+        else:
+            assert_regex = self.assertRegexpMatches
+
+        wrp = self.dlg.wrapper_object()
+        assert_regex(wrp.__str__(), '^hwndwrapper.DialogWrapper - "Common Controls Sample"$')
+
+        wrp = self.ctrl
+        assert_regex(wrp.__str__(), '^win32_controls.ButtonWrapper - "Command button here"$')
+
+        wrp = self.dlg.TabControl.wrapper_object()
+        assert_regex(wrp.__str__(), '^common_controls.TabControlWrapper - "" <object 0x.+>$')
 
 
 class HwndWrapperMenuTests(unittest.TestCase):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -340,45 +340,45 @@ if UIA_support:
                 assert_regex = self.assertRegexpMatches
 
             prefix = '^uia_controls\.'
-            suffix = ' <object 0x.+>$'
 
             wrp = self.dlg.OK.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + 'ButtonWrapper - "OK"')
+            assert_regex(wrp.__str__(), prefix + "ButtonWrapper - 'OK', Button$")
 
             wrp = self.dlg.CheckBox.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + 'ButtonWrapper - "CheckBox"')
+            assert_regex(wrp.__str__(), prefix + "ButtonWrapper - 'CheckBox', CheckBox$", )
 
             wrp = self.dlg.child_window(class_name="TextBox").wrapper_object()
-            assert_regex(wrp.__str__(), prefix + 'EditWrapper - ""' + suffix)
-            assert_regex(wrp.element_info.__str__(), 'uia_element_info.UIAElementInfo - ""' + suffix)
+            assert_regex(wrp.__str__(), prefix + "EditWrapper - '', Edit$")
+            assert_regex(wrp.element_info.__str__(), "uia_element_info.UIAElementInfo - '', TextBox$")
 
             wrp = self.dlg.TabControl.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + 'TabControlWrapper - "General"')
+            assert_regex(wrp.__str__(), prefix + "TabControlWrapper - 'General', TabControl$")
 
             wrp = self.dlg.MenuBar.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + 'MenuWrapper - "System"')
+            assert_regex(wrp.__str__(), prefix + "MenuWrapper - 'System', Menu$")
 
             wrp = self.dlg.Slider.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + 'SliderWrapper - ""' + suffix)
+            assert_regex(wrp.__str__(), prefix + "SliderWrapper - '', Slider$")
 
             wrp = self.dlg.wrapper_object()
-            assert_regex(wrp.__str__(), '^uiawrapper\.UIAWrapper - "WPF Sample Application"$')
+            assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog$")
 
             # ElementInfo.__str__
-            assert_regex(wrp.element_info.__str__(), '^uia_element_info.UIAElementInfo - "WPF Sample Application"$')
+            assert_regex(wrp.element_info.__str__(),
+                         "^uia_element_info.UIAElementInfo - 'WPF Sample Application', Window$")
 
             # mock a failure in texts() method
             orig = wrp.texts
             wrp.texts = mock.Mock(return_value=[])  # empty texts
-            assert_regex(wrp.__str__(), '^uiawrapper\.UIAWrapper - ""' + suffix)
+            assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '', Dialog$")
             wrp.texts.return_value = [u'\xd1\xc1\\\xa1\xb1\ua000']  # unicode string
-            assert_regex(wrp.__str__(), '^uiawrapper\.UIAWrapper - ".+"$')
+            assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '.+', Dialog$")
             wrp.texts = orig  # restore the original method
 
             # mock a failure in element_info.name property (it's based on _get_name())
             orig = wrp.element_info._get_name
             wrp.element_info._get_name = mock.Mock(return_value=None)
-            assert_regex(wrp.element_info.__str__(), '^uia_element_info\.UIAElementInfo - ""' + suffix)
+            assert_regex(wrp.element_info.__str__(), "^uia_element_info\.UIAElementInfo - 'None', Window$")
             wrp.element_info._get_name = orig
 
         def test_friendly_class_names(self):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -343,34 +343,45 @@ if UIA_support:
 
             wrp = self.dlg.OK.wrapper_object()
             assert_regex(wrp.__str__(), prefix + "ButtonWrapper - 'OK', Button$")
+            assert_regex(wrp.__repr__(), prefix + "ButtonWrapper - 'OK', Button, <[0-9-]+>$")
 
             wrp = self.dlg.CheckBox.wrapper_object()
             assert_regex(wrp.__str__(), prefix + "ButtonWrapper - 'CheckBox', CheckBox$", )
+            assert_regex(wrp.__repr__(), prefix + "ButtonWrapper - 'CheckBox', CheckBox, <[0-9-]+>$", )
 
             wrp = self.dlg.child_window(class_name="TextBox").wrapper_object()
             assert_regex(wrp.__str__(), prefix + "EditWrapper - '', Edit$")
+            assert_regex(wrp.__repr__(), prefix + "EditWrapper - '', Edit, <[0-9-]+>$")
             assert_regex(wrp.element_info.__str__(), "uia_element_info.UIAElementInfo - '', TextBox$")
+            assert_regex(wrp.element_info.__repr__(), "uia_element_info.UIAElementInfo - '', TextBox, <None>$")
 
             wrp = self.dlg.TabControl.wrapper_object()
             assert_regex(wrp.__str__(), prefix + "TabControlWrapper - 'General', TabControl$")
+            assert_regex(wrp.__repr__(), prefix + "TabControlWrapper - 'General', TabControl, <[0-9-]+>$")
 
             wrp = self.dlg.MenuBar.wrapper_object()
             assert_regex(wrp.__str__(), prefix + "MenuWrapper - 'System', Menu$")
+            assert_regex(wrp.__repr__(), prefix + "MenuWrapper - 'System', Menu, <[0-9-]+>$")
 
             wrp = self.dlg.Slider.wrapper_object()
             assert_regex(wrp.__str__(), prefix + "SliderWrapper - '', Slider$")
+            assert_regex(wrp.__repr__(), prefix + "SliderWrapper - '', Slider, <[0-9-]+>$")
 
             wrp = self.dlg.wrapper_object()
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog$")
+            assert_regex(wrp.__repr__(), "^uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog, <[0-9-]+>$")
 
             # ElementInfo.__str__
             assert_regex(wrp.element_info.__str__(),
                          "^uia_element_info.UIAElementInfo - 'WPF Sample Application', Window$")
+            assert_regex(wrp.element_info.__repr__(),
+                         "^uia_element_info.UIAElementInfo - 'WPF Sample Application', Window, <[0-9-]+>$")
 
             # mock a failure in texts() method
             orig = wrp.texts
             wrp.texts = mock.Mock(return_value=[])  # empty texts
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '', Dialog$")
+            assert_regex(wrp.__repr__(), "^uiawrapper\.UIAWrapper - '', Dialog, <[0-9-]+>$")
             wrp.texts.return_value = [u'\xd1\xc1\\\xa1\xb1\ua000']  # unicode string
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '.+', Dialog$")
             wrp.texts = orig  # restore the original method
@@ -379,6 +390,7 @@ if UIA_support:
             orig = wrp.element_info._get_name
             wrp.element_info._get_name = mock.Mock(return_value=None)
             assert_regex(wrp.element_info.__str__(), "^uia_element_info\.UIAElementInfo - 'None', Window$")
+            assert_regex(wrp.element_info.__repr__(), "^uia_element_info\.UIAElementInfo - 'None', Window, <[0-9-]+>$")
             wrp.element_info._get_name = orig
 
         def test_friendly_class_names(self):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -339,49 +339,47 @@ if UIA_support:
             else:
                 assert_regex = self.assertRegexpMatches
 
-            prefix = '^uia_controls\.'
-
             wrp = self.dlg.OK.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + "ButtonWrapper - 'OK', Button$")
-            assert_regex(wrp.__repr__(), prefix + "ButtonWrapper - 'OK', Button, <[0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.ButtonWrapper - 'OK', Button$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.ButtonWrapper - 'OK', Button, [0-9-]+>$")
 
             wrp = self.dlg.CheckBox.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + "ButtonWrapper - 'CheckBox', CheckBox$", )
-            assert_regex(wrp.__repr__(), prefix + "ButtonWrapper - 'CheckBox', CheckBox, <[0-9-]+>$", )
+            assert_regex(wrp.__str__(), "^uia_controls\.ButtonWrapper - 'CheckBox', CheckBox$", )
+            assert_regex(wrp.__repr__(), "^<uia_controls\.ButtonWrapper - 'CheckBox', CheckBox, [0-9-]+>$", )
 
             wrp = self.dlg.child_window(class_name="TextBox").wrapper_object()
-            assert_regex(wrp.__str__(), prefix + "EditWrapper - '', Edit$")
-            assert_regex(wrp.__repr__(), prefix + "EditWrapper - '', Edit, <[0-9-]+>$")
-            assert_regex(wrp.element_info.__str__(), "uia_element_info.UIAElementInfo - '', TextBox$")
-            assert_regex(wrp.element_info.__repr__(), "uia_element_info.UIAElementInfo - '', TextBox, <None>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.EditWrapper - '', Edit$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.EditWrapper - '', Edit, [0-9-]+>$")
+            assert_regex(wrp.element_info.__str__(), "^uia_element_info.UIAElementInfo - '', TextBox$")
+            assert_regex(wrp.element_info.__repr__(), "^<uia_element_info.UIAElementInfo - '', TextBox, None>$")
 
             wrp = self.dlg.TabControl.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + "TabControlWrapper - 'General', TabControl$")
-            assert_regex(wrp.__repr__(), prefix + "TabControlWrapper - 'General', TabControl, <[0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.TabControlWrapper - 'General', TabControl$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.TabControlWrapper - 'General', TabControl, [0-9-]+>$")
 
             wrp = self.dlg.MenuBar.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + "MenuWrapper - 'System', Menu$")
-            assert_regex(wrp.__repr__(), prefix + "MenuWrapper - 'System', Menu, <[0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.MenuWrapper - 'System', Menu$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.MenuWrapper - 'System', Menu, [0-9-]+>$")
 
             wrp = self.dlg.Slider.wrapper_object()
-            assert_regex(wrp.__str__(), prefix + "SliderWrapper - '', Slider$")
-            assert_regex(wrp.__repr__(), prefix + "SliderWrapper - '', Slider, <[0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.SliderWrapper - '', Slider$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.SliderWrapper - '', Slider, [0-9-]+>$")
 
             wrp = self.dlg.wrapper_object()
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog$")
-            assert_regex(wrp.__repr__(), "^uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog, <[0-9-]+>$")
+            assert_regex(wrp.__repr__(), "^<uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog, [0-9-]+>$")
 
             # ElementInfo.__str__
             assert_regex(wrp.element_info.__str__(),
                          "^uia_element_info.UIAElementInfo - 'WPF Sample Application', Window$")
             assert_regex(wrp.element_info.__repr__(),
-                         "^uia_element_info.UIAElementInfo - 'WPF Sample Application', Window, <[0-9-]+>$")
+                         "^<uia_element_info.UIAElementInfo - 'WPF Sample Application', Window, [0-9-]+>$")
 
             # mock a failure in texts() method
             orig = wrp.texts
             wrp.texts = mock.Mock(return_value=[])  # empty texts
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '', Dialog$")
-            assert_regex(wrp.__repr__(), "^uiawrapper\.UIAWrapper - '', Dialog, <[0-9-]+>$")
+            assert_regex(wrp.__repr__(), "^<uiawrapper\.UIAWrapper - '', Dialog, [0-9-]+>$")
             wrp.texts.return_value = [u'\xd1\xc1\\\xa1\xb1\ua000']  # unicode string
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '.+', Dialog$")
             wrp.texts = orig  # restore the original method
@@ -390,7 +388,7 @@ if UIA_support:
             orig = wrp.element_info._get_name
             wrp.element_info._get_name = mock.Mock(return_value=None)
             assert_regex(wrp.element_info.__str__(), "^uia_element_info\.UIAElementInfo - 'None', Window$")
-            assert_regex(wrp.element_info.__repr__(), "^uia_element_info\.UIAElementInfo - 'None', Window, <[0-9-]+>$")
+            assert_regex(wrp.element_info.__repr__(), "^<uia_element_info\.UIAElementInfo - 'None', Window, [0-9-]+>$")
             wrp.element_info._get_name = orig
 
         def test_friendly_class_names(self):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -6,6 +6,7 @@ import time
 import os
 import sys
 import unittest
+import mock
 
 sys.path.append(".")
 from pywinauto.application import Application, WindowSpecification  # noqa: E402
@@ -329,6 +330,44 @@ if UIA_support:
         def tearDown(self):
             """Close the application after tests"""
             self.app.kill_()
+
+        def test_pretty_print(self):
+            """Test __str__ method for UIA based controls"""
+            prefix = 'controls\.uia_controls\.'
+            suffix = '  <object 0x.+>$'
+
+            wrp = self.dlg.OK.wrapper_object()
+            self.assertRegexpMatches(wrp.__str__(), prefix + 'ButtonWrapper - "OK"' + suffix)
+
+            wrp = self.dlg.CheckBox.wrapper_object()
+            self.assertRegexpMatches(wrp.__str__(), prefix + 'ButtonWrapper - "CheckBox"' + suffix)
+
+            wrp = self.dlg.window(class_name="TextBox").wrapper_object()
+            self.assertRegexpMatches(wrp.__str__(), prefix + 'EditWrapper - ""' + suffix)
+
+            wrp = self.dlg.TabControl.wrapper_object()
+            self.assertRegexpMatches(wrp.__str__(), prefix + 'TabControlWrapper - "General"' + suffix)
+
+            wrp = self.dlg.MenuBar.wrapper_object()
+            self.assertRegexpMatches(wrp.__str__(), prefix + 'MenuWrapper - "System"' + suffix)
+
+            wrp = self.dlg.Slider.wrapper_object()
+            self.assertRegexpMatches(wrp.__str__(), prefix + 'SliderWrapper - ""' + suffix)
+
+            wrp = self.dlg.wrapper_object()
+            self.assertRegexpMatches(
+                wrp.__str__(),
+                'controls\.uiawrapper\.UIAWrapper - "WPF Sample Application"' + suffix
+            )
+
+            # mock a failure in texts() method
+            orig = wrp.texts
+            wrp.texts = mock.Mock(return_value=[])
+            self.assertRegexpMatches(
+                wrp.__str__(),
+                'controls\.uiawrapper\.UIAWrapper' + suffix
+            )
+            wrp.texts = orig  # restore the original method
 
         def test_friendly_class_names(self):
             """Test getting friendly class names of common controls"""

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -63,14 +63,14 @@ class HwndElementInfo(ElementInfo):
     @property
     def rich_text(self):
         """Return the text of the window"""
-        return handleprops.text(self)
+        return handleprops.text(self.handle)
 
     name = rich_text
 
     @property
     def control_id(self):
         """Return the ID of the window"""
-        return handleprops.controlid(self)
+        return handleprops.controlid(self.handle)
 
     @property
     def process_id(self):
@@ -80,22 +80,22 @@ class HwndElementInfo(ElementInfo):
     @property
     def class_name(self):
         """Return the class name of the window"""
-        return handleprops.classname(self)
+        return handleprops.classname(self.handle)
 
     @property
     def enabled(self):
         """Return True if the window is enabled"""
-        return handleprops.isenabled(self)
+        return handleprops.isenabled(self.handle)
 
     @property
     def visible(self):
         """Return True if the window is visible"""
-        return handleprops.isvisible(self)
+        return handleprops.isvisible(self.handle)
 
     @property
     def parent(self):
         """Return the parent of the window"""
-        parent_hwnd = handleprops.parent(self)
+        parent_hwnd = handleprops.parent(self.handle)
         if parent_hwnd:
             return HwndElementInfo(parent_hwnd)
         else:
@@ -129,17 +129,17 @@ class HwndElementInfo(ElementInfo):
 
     def descendants(self, **kwargs):
         """Return descendants of the window (all children from sub-tree)"""
-        child_handles = handleprops.children(self)
+        child_handles = handleprops.children(self.handle)
         return [HwndElementInfo(ch) for ch in child_handles]
 
     @property
     def rectangle(self):
         """Return rectangle of the element"""
-        return handleprops.rectangle(self)
+        return handleprops.rectangle(self.handle)
 
     def dump_window(self):
         """Dump a window as a set of properties"""
-        return handleprops.dumpwindow(self)
+        return handleprops.dumpwindow(self.handle)
 
     def __eq__(self, other):
         """Check if 2 HwndElementInfo objects describe 1 actual element"""

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -37,14 +37,15 @@ from . import win32functions
 from . import handleprops
 from .element_info import ElementInfo
 
+
 class HwndElementInfo(ElementInfo):
 
     """Wrapper for window handler"""
 
-    def __init__(self, handle = None):
+    def __init__(self, handle=None):
         """Create element by handle (default is root element)"""
         self._cache = {}
-        if handle is None: # root element
+        if handle is None:  # root element
             self._handle = win32functions.GetDesktopWindow()
         else:
             self._handle = handle
@@ -103,7 +104,7 @@ class HwndElementInfo(ElementInfo):
 
     def children(self, **kwargs):
         """Return a list of immediate children of the window"""
-        if self == HwndElementInfo(): # self == root
+        if self == HwndElementInfo():  # self == root
             child_handles = []
 
             # The callback function that will be called for each HWND

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -50,8 +50,6 @@ class HwndElementInfo(ElementInfo):
         else:
             self._handle = handle
 
-        self._as_parameter_ = self._handle
-
     def set_cache_strategy(self, cached):
         """Set a cache strategy for frequently used attributes of the element"""
         pass  # TODO: implement a cache strategy for native elements


### PR DESCRIPTION
- Implement  ```__repr__()``` and ```__str__()``` methods for BaseWrapper and ElementInfo classes (issue #322)
- PEP-8 cleanups in win32_element_info and handleprops modules
- Pass ```HwndElementInfo.handle``` explicitly instead of ```__as_parameter__```. This is to prevent infinite ```ElementInfo.__str__()``` recursion. A scenario I observed in Python 2: ```element_info.name``` property, used inside of ```ElementInfo.__str__()``` method, contains calls to ```str(handle)```

These are examples of output for ```__repr__()``` and ```__str__()```.
UIA backend:
```
In [23]: for w in app.windows(): print(w)
uiawrapper.UIAWrapper - '', Pane
uiawrapper.UIAWrapper - 'This PC', Dialog
uiawrapper.UIAWrapper - 'airelil_pywinauto_hggit', Dialog
uiawrapper.UIAWrapper - 'Program Manager', Pane

In [24]: for w in app.windows(): print(w.__repr__())
uiawrapper.UIAWrapper - '', Pane, <90619241>
uiawrapper.UIAWrapper - 'This PC', Dialog, <1572560665>
uiawrapper.UIAWrapper - 'airelil_pywinauto_hggit', Dialog, <-7905663>
uiawrapper.UIAWrapper - 'Program Manager', Pane, <14842491>

In [25]: for w in app.windows(): print(w.element_info)
uia_element_info.UIAElementInfo - '', Shell_TrayWnd
uia_element_info.UIAElementInfo - 'This PC', CabinetWClass
uia_element_info.UIAElementInfo - 'airelil_pywinauto_hggit', CabinetWClass
uia_element_info.UIAElementInfo - 'Program Manager', Progman

In [26]: for w in app.windows(): print(w.element_info.__repr__())
uia_element_info.UIAElementInfo - '', Shell_TrayWnd, <65712>
uia_element_info.UIAElementInfo - 'This PC', CabinetWClass, <984640>
uia_element_info.UIAElementInfo - 'airelil_pywinauto_hggit', CabinetWClass, <459464>
uia_element_info.UIAElementInfo - 'Program Manager', Progman, <65782>
```
Win32 backend:
```
ipdb> for d in self.dlg.descendants(): print(d.__repr__())
hwndwrapper.HwndWrapper - 'CButton (Command Link)', #32770, <13961090>
win32_controls.ButtonWrapper - 'Note', GroupBox, <4458298>
win32_controls.EditWrapper - 'and the note goes here ...', Edit, <12715750>
win32_controls.ButtonWrapper - 'Set', Button, <5703392>
win32_controls.ButtonWrapper - 'Elevation Icon', GroupBox, <3933912>
win32_controls.ButtonWrapper - 'Show', CheckBox, <12715668>
win32_controls.ButtonWrapper - 'Command button here', Button, <6686314>
win32_controls.ButtonWrapper - 'OK', Button, <17303714>
win32_controls.ButtonWrapper - 'Cancel', Button, <17107096>
win32_controls.ButtonWrapper - '&Apply', Button, <14813326>
win32_controls.ButtonWrapper - 'Help', Button, <12978276>
common_controls.TabControlWrapper - '', TabControl, <15796322>
hwndwrapper.HwndWrapper - 'CPagerCtrl', #32770, <5310502>
win32_controls.ButtonWrapper - 'Border size', GroupBox, <15075358>
win32_controls.ComboBoxWrapper - 'Gray', ComboBox, <9898020>
win32_controls.ButtonWrapper - 'Button Size', GroupBox, <9111572>
win32_controls.ButtonWrapper - 'Set', Button, <16123922>
win32_controls.EditWrapper - '32', Edit, <19924992>
common_controls.TrackbarWrapper - '', Trackbar, <14813182>

```