### PR TITLE
Add output to file in print_control_identifiers()

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -583,14 +583,6 @@ class WindowSpecification(object):
         for name, control in name_control_map.items():
             control_name_map.setdefault(control, []).append(name)
 
-        log_func = print
-        log_file = None
-        if filename is not None:
-            log_file = open(filename, "w")
-            log_func = lambda arg: log_file.write(str(arg) + os.linesep)
-
-        log_func("Control Identifiers:")
-
         def print_identifiers(ctrls, current_depth=1, log_func=print):
             """Recursively print ids for ctrls and their descendants in a tree-like format"""
             if len(ctrls) == 0 or current_depth > depth:
@@ -640,9 +632,15 @@ class WindowSpecification(object):
 
                 print_identifiers(ctrl.children(), current_depth + 1, log_func)
 
-        print_identifiers([this_ctrl, ], log_func=log_func)
-
-        if log_file is not None:
+        if filename is None:
+            print("Control Identifiers:")
+            print_identifiers([this_ctrl, ])
+        else:
+            log_file = open(filename, "w")
+            def log_func(msg):
+                log_file.write(str(msg) + os.linesep)
+            log_func("Control Identifiers:")
+            print_identifiers([this_ctrl, ], log_func=log_func)
             log_file.close()
 
     print_ctrl_ids = print_control_identifiers

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -583,14 +583,15 @@ class WindowSpecification(object):
         for name, control in name_control_map.items():
             control_name_map.setdefault(control, []).append(name)
 
+        log_func = print
         log_file = None
-        if filename is None:
-            print("Control Identifiers:")
-        else:
+        if filename is not None:
             log_file = open(filename, "w")
-            log_file.write("Control Identifiers:")
+            log_func = log_file.write
 
-        def print_identifiers(ctrls, current_depth=1, log_file=None):
+        log_func("Control Identifiers:")
+
+        def print_identifiers(ctrls, current_depth=1, log_func=print):
             """Recursively print ids for ctrls and their descendants in a tree-like format"""
             if len(ctrls) == 0 or current_depth > depth:
                 return
@@ -632,20 +633,14 @@ class WindowSpecification(object):
                 if title or class_name or auto_id:
                     output += indent + u'child_window(' + u', '.join(criteria_texts) + u')'
 
-                if log_file is None:
-                    if six.PY3:
-                        print(output)
-                    else:
-                        print(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
+                if six.PY3:
+                    log_func(output)
                 else:
-                    if six.PY3:
-                        log_file.write(output)
-                    else:
-                        log_file.write(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
+                    log_func(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
 
-                print_identifiers(ctrl.children(), current_depth + 1, log_file)
+                print_identifiers(ctrl.children(), current_depth + 1, log_func)
 
-        print_identifiers([this_ctrl, ], log_file=log_file)
+        print_identifiers([this_ctrl, ], log_func=log_func)
 
         if log_file is not None:
             log_file.close()

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -587,7 +587,7 @@ class WindowSpecification(object):
         log_file = None
         if filename is not None:
             log_file = open(filename, "w")
-            log_func = log_file.write
+            log_func = lambda arg: log_file.write(str(arg) + os.linesep)
 
         log_func("Control Identifiers:")
 

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -553,7 +553,7 @@ class WindowSpecification(object):
 
         return control_name_map
 
-    def print_control_identifiers(self, depth=None):
+    def print_control_identifiers(self, depth=None, filename=None):
         """
         Prints the 'identifiers'
 
@@ -583,9 +583,14 @@ class WindowSpecification(object):
         for name, control in name_control_map.items():
             control_name_map.setdefault(control, []).append(name)
 
-        print("Control Identifiers:")
+        log_file = None
+        if filename is None:
+            print("Control Identifiers:")
+        else:
+            log_file = open(filename, "w")
+            log_file.write("Control Identifiers:")
 
-        def print_identifiers(ctrls, current_depth=1):
+        def print_identifiers(ctrls, current_depth=1, log_file=None):
             """Recursively print ids for ctrls and their descendants in a tree-like format"""
             if len(ctrls) == 0 or current_depth > depth:
                 return
@@ -626,15 +631,27 @@ class WindowSpecification(object):
                     criteria_texts.append(u'control_type="{}"'.format(control_type))
                 if title or class_name or auto_id:
                     output += indent + u'child_window(' + u', '.join(criteria_texts) + u')'
-                if six.PY3:
-                    print(output)
+
+                if log_file is None:
+                    if six.PY3:
+                        print(output)
+                    else:
+                        print(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
                 else:
-                    print(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
+                    if six.PY3:
+                        log_file.write(output)
+                    else:
+                        log_file.write(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
 
-                print_identifiers(ctrl.children(), current_depth + 1)
+                print_identifiers(ctrl.children(), current_depth + 1, log_file)
 
-        print_identifiers([this_ctrl, ])
+        print_identifiers([this_ctrl, ], log_file=log_file)
 
+        if log_file is not None:
+            log_file.close()
+
+    print_ctrl_ids = print_control_identifiers
+    dump_tree = print_control_identifiers
 
 cur_item = 0
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -898,7 +898,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
                 self.assertTrue("child_window(class_name=\"msctls_statusbar32\")" in content)
             os.remove(output_filename)
         else:
-            self.self.fail("print_control_identifiers can't create a file")
+            self.fail("print_control_identifiers can't create a file")
 
         self.ctrlspec.dump_tree(filename=output_filename)
         if os.path.isfile(output_filename):
@@ -907,7 +907,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
                 self.assertTrue("child_window(class_name=\"Edit\")" in content)
             os.remove(output_filename)
         else:
-            self.self.fail("print_control_identifiers can't create a file")
+            self.fail("print_control_identifiers can't create a file")
 
     def test_find_elements_re(self):
         """Test for bug #90: A crash in 'find_elements' when called with 'title_re' argument"""

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -886,6 +886,29 @@ class WindowSpecificationTestCases(unittest.TestCase):
         self.dlgspec.print_control_identifiers()
         self.ctrlspec.print_control_identifiers()
 
+    def test_print_control_identifiers_file_output(self):
+        """Make sure print_control_identifiers() creates correct file"""
+        output_filename = "test_print_control_identifiers.txt"
+        self.dlgspec.print_ctrl_ids(filename=output_filename)
+        if os.path.isfile(output_filename):
+            with open(output_filename, "r") as test_log_file:
+                content = str(test_log_file.readlines())
+                self.assertTrue(content.find("['Untitled - NotepadEdit', 'Edit']") != -1)
+                self.assertTrue(content.find("child_window(class_name=\"msctls_statusbar32\")") != -1)
+            os.remove(output_filename)
+        else:
+            self.self.fail("print_control_identifiers can't create a file")
+
+        self.ctrlspec.dump_tree(filename=output_filename)
+        if os.path.isfile(output_filename):
+            with open(output_filename, "r") as test_log_file:
+                content = str(test_log_file.readlines())
+                self.assertTrue(content.find("Edit - ''    (L8, T270, R192, B392)") != -1)
+            os.remove(output_filename)
+        else:
+            self.self.fail("print_control_identifiers can't create a file")
+
+
     def test_find_elements_re(self):
         """Test for bug #90: A crash in 'find_elements' when called with 'title_re' argument"""
         self.dlgspec.Wait('visible')
@@ -1010,4 +1033,3 @@ class DesktopWindowSpecificationTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -893,8 +893,9 @@ class WindowSpecificationTestCases(unittest.TestCase):
         if os.path.isfile(output_filename):
             with open(output_filename, "r") as test_log_file:
                 content = str(test_log_file.readlines())
-                self.assertTrue(content.find("['Untitled - NotepadEdit', 'Edit']") != -1)
-                self.assertTrue(content.find("child_window(class_name=\"msctls_statusbar32\")") != -1)
+                self.assertTrue("['Untitled - NotepadEdit', 'Edit']" in content
+                    or "['Edit', 'Untitled - NotepadEdit']" in content)
+                self.assertTrue("child_window(class_name=\"msctls_statusbar32\")" in content)
             os.remove(output_filename)
         else:
             self.self.fail("print_control_identifiers can't create a file")
@@ -903,11 +904,10 @@ class WindowSpecificationTestCases(unittest.TestCase):
         if os.path.isfile(output_filename):
             with open(output_filename, "r") as test_log_file:
                 content = str(test_log_file.readlines())
-                self.assertTrue(content.find("Edit - ''    (L8, T270, R192, B392)") != -1)
+                self.assertTrue("child_window(class_name=\"Edit\")" in content)
             os.remove(output_filename)
         else:
             self.self.fail("print_control_identifiers can't create a file")
-
 
     def test_find_elements_re(self):
         """Test for bug #90: A crash in 'find_elements' when called with 'title_re' argument"""

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -893,8 +893,8 @@ class WindowSpecificationTestCases(unittest.TestCase):
         if os.path.isfile(output_filename):
             with open(output_filename, "r") as test_log_file:
                 content = str(test_log_file.readlines())
-                self.assertTrue("['Untitled - NotepadEdit', 'Edit']" in content
-                    or "['Edit', 'Untitled - NotepadEdit']" in content)
+                self.assertTrue("'Untitled - NotepadEdit'" in content
+                    and "'Edit'" in content)
                 self.assertTrue("child_window(class_name=\"msctls_statusbar32\")" in content)
             os.remove(output_filename)
         else:


### PR DESCRIPTION
- Add `filename` parameter
- Add unit tests
- Add aliases for `print_control_identifiers()`: `print_ctrl_ids` and `dump_tree`