### PR TITLE
Split HwndWrapper.send_chars into send_chars and send_keystrokes 

### DIFF
--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -307,6 +307,16 @@ class HwndWrapperTests(unittest.TestCase):
             self.dlg.Minimize()
             self.dlg.Edit.send_chars(testString)
 
+    def test_send_keystrokes_multikey_characters(self):
+        testString = "Hawaii#{%}@$"
+
+        self.dlg.Minimize()
+        self.dlg.Edit.send_keystrokes(testString)
+
+        actual = self.dlg.Edit.Texts()[0]
+        expected = "Hawaii#%@$"
+        self.assertEqual(expected, actual)
+
     def test_send_keystrokes_enter(self):
         with self.assertRaises(findbestmatch.MatchError):
             testString = "{ENTER}"
@@ -314,7 +324,7 @@ class HwndWrapperTests(unittest.TestCase):
             self.dlg.Minimize()
             self.dlg.Edit.send_keystrokes(testString)
 
-            actual = self.dlg.Edit.Texts()[0]
+            self.dlg.Restore()
 
     def test_send_keystrokes_virtual_keys_left_del_back(self):
         testString = "+hello123{LEFT 2}{DEL 2}{BACKSPACE} +world"

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -59,6 +59,8 @@ from pywinauto.timings import Timings
 from pywinauto import clipboard
 from pywinauto.base_wrapper import ElementNotEnabled
 from pywinauto.base_wrapper import ElementNotVisible
+from pywinauto import findbestmatch
+from pywinauto import keyboard
 
 
 mfc_samples_folder = os.path.join(
@@ -288,7 +290,7 @@ class HwndWrapperTests(unittest.TestCase):
         expected = 0x89 # 0x2000 + 0x40
         self.assertEqual(expected, code)
 
-    def test_send_chars_simple(self):
+    def test_send_chars(self):
         testString = "Hello World"
 
         self.dlg.Minimize()
@@ -298,44 +300,51 @@ class HwndWrapperTests(unittest.TestCase):
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
-    # def test_send_chars_enter(self):
-    #     with self.assertRaises(findbestmatch.MatchError):
-    #         testString = "{ENTER}"
-    #
-    #         self.dlg.Minimize()
-    #         self.dlg.Edit.send_chars(testString)
-    #
-    #         actual = self.dlg.Edit.Texts()[0]
+    def test_send_chars_invalid(self):
+        with self.assertRaises(keyboard.KeySequenceError):
+            testString = "Hello{LEFT 2}{DEL 2}"
 
-    def test_send_chars_virtual_keys_left_del_back(self):
-        testString = "Hello123{LEFT 2}{DEL 2}{BACKSPACE} World"
+            self.dlg.Minimize()
+            self.dlg.Edit.send_chars(testString)
+
+    def test_send_keystrokes_enter(self):
+        with self.assertRaises(findbestmatch.MatchError):
+            testString = "{ENTER}"
+
+            self.dlg.Minimize()
+            self.dlg.Edit.send_keystrokes(testString)
+
+            actual = self.dlg.Edit.Texts()[0]
+
+    def test_send_keystrokes_virtual_keys_left_del_back(self):
+        testString = "+hello123{LEFT 2}{DEL 2}{BACKSPACE} +world"
 
         self.dlg.Minimize()
-        self.dlg.Edit.send_chars(testString)
+        self.dlg.Edit.send_keystrokes(testString)
 
         actual = self.dlg.Edit.Texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
-    def test_send_chars_virtual_keys_shift(self):
+    def test_send_keystrokes_virtual_keys_shift(self):
         testString = "+hello +world"
 
         self.dlg.Minimize()
-        self.dlg.Edit.send_chars(testString)
+        self.dlg.Edit.send_keystrokes(testString)
 
         actual = self.dlg.Edit.Texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
-    # def test_send_chars_virtual_keys_ctrl(self):
-    #     testString = "^a^c{RIGHT}^v"
-    #
-    #     self.dlg.Minimize()
-    #     self.dlg.Edit.send_chars(testString)
-    #
-    #     actual = self.dlg.Edit.Texts()[0]
-    #     expected = "and the note goes here ...and the note goes here ..."
-    #     self.assertEqual(expected, actual)
+    def test_send_keystrokes_virtual_keys_ctrl(self):
+        testString = "^a^c{RIGHT}^v"
+
+        self.dlg.Minimize()
+        self.dlg.Edit.send_keystrokes(testString)
+
+        actual = self.dlg.Edit.Texts()[0]
+        expected = "and the note goes here ...and the note goes here ..."
+        self.assertEqual(expected, actual)
 
     def testSendMessageTimeout(self):
         default_timeout = Timings.sendmessagetimeout_timeout
@@ -974,4 +983,3 @@ class RemoteMemoryBlockTests(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
-

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -968,7 +968,7 @@ class SendKeystrokesAltComboTests(unittest.TestCase):
     """Unit test for Alt- combos sent via send_keystrokes"""
 
     def setUp(self):
-        Timings.Fast()
+        Timings.Defaults()
 
         self.app = Application().start(os.path.join(mfc_samples_folder, u'CtrlTest.exe'))
         self.dlg = self.app.Control_Test_App

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -963,6 +963,27 @@ class SendEnterKeyTest(unittest.TestCase):
         self.assertEquals(['Hello\r\nWorld'], self.dlg.Edit.Texts())
 
 
+class SendKeystrokesAltComboTests(unittest.TestCase):
+
+    """Unit test for Alt- combos sent via send_keystrokes"""
+
+    def setUp(self):
+        Timings.Fast()
+
+        self.app = Application().start(os.path.join(mfc_samples_folder, u'CtrlTest.exe'))
+        self.dlg = self.app.Control_Test_App
+
+
+    def tearDown(self):
+        self.app.kill_()
+
+
+    def test_send_keystrokes_alt_combo(self):
+        self.dlg.send_keystrokes('%(sc)')
+
+        self.assertTrue(self.app['Using C++ Derived Class'].Exists())
+
+
 class RemoteMemoryBlockTests(unittest.TestCase):
 
     """Unit tests for RemoteMemoryBlock"""


### PR DESCRIPTION
There are now 2 methods for silently sending input to the window:
* `send_chars` is supposed to be used to send character input (this includes Enter, Tab, Backspace);
* `send_keystrokes` is for key input (including key combinations with modifiers).

The modifiers in `send_keystrokes` are handled reliably (in my experience with manual testing in different apps) if the target window is inactive but not minimized. For minimized windows behavior varies, e.g.:
* Notepad handles Shift, but not Ctrl or Alt;
* MFC sample CmnCtrl3.exe handles Shift and Ctrl (tried for copy and paste), but not Alt;
* PuTTY handles all modifiers within its terminal emulator, but Alt+F4 fails.

Also, this patch fixes #334.