### PR TITLE
Fix wait/wait_not timings, extend list view detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ MS UI Automation (`backend="uia"`). User input emulation modules
 ### Setup
 * run `pip install -U pywinauto` (dependencies will be installed automatically)
 
+### Documentation / Help
+* [Intro on ReadTheDocs](http://pywinauto.readthedocs.io/en/latest/)
+* [Getting Started Guide](http://pywinauto.readthedocs.io/en/latest/getting_started.html) (core concept, Spy tools etc.)
+* [StackOverflow tag](http://stackoverflow.com/questions/tagged/pywinauto)
+* [Mailing list](https://sourceforge.net/p/pywinauto/mailman/)
+
 ### Examples
 It is simple and the resulting scripts are very readable. How simple?
 
@@ -52,12 +58,6 @@ Properties.print_control_identifiers()
 Properties.Cancel.click()
 Properties.wait_not('visible') # make sure the dialog is closed
 ```
-
-### Documentation
-* [Latest documentation on ReadTheDocs](http://pywinauto.readthedocs.io/en/latest/)
-* [Getting Started Guide](http://pywinauto.readthedocs.io/en/latest/getting_started.html)
-* [Code examples (gists) on gist.github.com](https://gist.github.com/vasily-v-ryabov)
-* [Mailing list](https://sourceforge.net/p/pywinauto/mailman/)
 
 ### Dependencies (if install manually)
 * Windows:

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -443,7 +443,8 @@ class WindowSpecification(object):
             # timeout = retry_interval because the timeout is handled at higher level
             if check_name == 'exists':
                 check = getattr(self, check_name)
-                return check(retry_interval, float(retry_interval) // 2)
+                if not check(retry_interval, float(retry_interval) // 2):
+                    return False
             try:
                 # resolve control explicitly to pass correct timing params
                 ctrls = self.__resolve_control(self.criteria, retry_interval, float(retry_interval) // 2)

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -432,7 +432,7 @@ class WindowSpecification(object):
         # unique_check_names = set(['is_enabled', 'is_active', 'is_visible', 'Exists'])
         return unique_check_names, timeout, retry_interval
 
-    def __check_all_conditions(self, check_names):
+    def __check_all_conditions(self, check_names, retry_interval):
         """
         Checks for all conditions
 
@@ -440,9 +440,14 @@ class WindowSpecification(object):
         True will be returned when all checks passed and all of them equal True.
         """
         for check_name in check_names:
-            try:
-                # Hidden __resolve_control call, handle the exceptions.
+            # timeout = retry_interval because the timeout is handled at higher level
+            if check_name == 'exists':
                 check = getattr(self, check_name)
+                return check(retry_interval, float(retry_interval) // 2)
+            try:
+                # resolve control explicitly to pass correct timing params
+                ctrls = self.__resolve_control(self.criteria, retry_interval, float(retry_interval) // 2)
+                check = getattr(ctrls[-1], check_name)
             except (findwindows.ElementNotFoundError,
                     findbestmatch.MatchError,
                     controls.InvalidWindowHandle,
@@ -488,7 +493,8 @@ class WindowSpecification(object):
             :func:`pywinauto.timings.TimeoutError`
         """
         check_method_names, timeout, retry_interval = self.__parse_wait_args(wait_for, timeout, retry_interval)
-        wait_until(timeout, retry_interval, lambda: self.__check_all_conditions(check_method_names))
+        wait_until(timeout, retry_interval,
+                   lambda: self.__check_all_conditions(check_method_names, retry_interval))
 
         # Return the wrapped control
         return self.wrapper_object()
@@ -524,7 +530,8 @@ class WindowSpecification(object):
         """
         check_method_names, timeout, retry_interval = \
             self.__parse_wait_args(wait_for_not, timeout, retry_interval)
-        wait_until(timeout, retry_interval, lambda: not self.__check_all_conditions(check_method_names))
+        wait_until(timeout, retry_interval,
+                   lambda: not self.__check_all_conditions(check_method_names, retry_interval))
         # None return value, since we are waiting for a `negative` state of the control.
         # Expect that you will have nothing to do with the window closed, disabled, etc.
 

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -445,6 +445,8 @@ class WindowSpecification(object):
                 check = getattr(self, check_name)
                 if not check(retry_interval, float(retry_interval) // 2):
                     return False
+                else:
+                    continue
             try:
                 # resolve control explicitly to pass correct timing params
                 ctrls = self.__resolve_control(self.criteria, retry_interval, float(retry_interval) // 2)

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -667,7 +667,8 @@ class ListViewWrapper(hwndwrapper.HwndWrapper):
         "SysListView32",
         r"WindowsForms\d*\.SysListView32\..*",
         "TSysListView",
-        "ListView20WndClass"]
+        "ListView.*WndClass",
+        ]
     if sysinfo.UIA_support:
         #controltypes is empty to make wrapper search result unique
         #possible control types: IUIA().UIA_dll.UIA_ListControlTypeId

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -59,7 +59,8 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         "Button",
         ".*Button",
         r"WindowsForms\d*\.BUTTON\..*",
-        ".*CheckBox", ]
+        ".*CheckBox",
+        ]
     can_be_label = True
 
     #-----------------------------------------------------------

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -144,6 +144,10 @@ def find_elements(class_name=None,
     """
     Find elements based on criteria passed in
 
+    WARNING! Direct usage of this function is not recommended! It's a very low level API.
+    Better use Application and WindowSpecification objects described in the
+    Getting Started Guide.
+
     Possible values are:
 
     * **class_name**     Elements with this window class
@@ -152,8 +156,8 @@ def find_elements(class_name=None,
     * **process**        Elements running in this process
     * **title**          Elements with this text
     * **title_re**       Elements whose text matches this regular expression
-    * **top_level_only** Top level elements only (default=True)
-    * **visible_only**   Visible elements only (default=True)
+    * **top_level_only** Top level elements only (default=**True**)
+    * **visible_only**   Visible elements only (default=**True**)
     * **enabled_only**   Enabled elements only (default=False)
     * **best_match**     Elements with a title similar to this
     * **handle**         The handle of the element to return

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -203,12 +203,18 @@ class UIAElementInfo(ElementInfo):
     @property
     def process_id(self):
         """Return ProcessId of the element"""
-        return self._element.CurrentProcessId
+        try:
+            return self._element.CurrentProcessId
+        except COMError:
+            return None # probably element already doesn't exist
 
     @property
     def framework_id(self):
         """Return FrameworkId of the element"""
-        return self._element.CurrentFrameworkId
+        try:
+            return self._element.CurrentFrameworkId
+        except COMError:
+            return None # probably element already doesn't exist
 
     @property
     def runtime_id(self):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -193,20 +193,6 @@ class ApplicationTestCases(unittest.TestCase):
 
         app.UntitledNotepad.MenuSelect("File->Exit")
 
-#    def test_start(self):
-#        "test start() works correctly"
-#        app = Application()
-#        self.assertEqual(app.process, None)
-#        app._start("notepad.exe")
-#        self.assertNotEqual(app.process, None)
-#
-#        self.assertEqual(app.UntitledNotepad.process_id(), app.process)
-#
-#        notepadpath = os.path.join(os.environ['systemroot'], r"system32\notepad.exe")
-#        self.assertEqual(str(process_module(app.process)).lower(), str(notepadpath).lower())
-#
-#        app.UntitledNotepad.MenuSelect("File->Exit")
-
     def testStart_bug01(self):
         """On SourceForge forum AppStartError forgot to include %s for application name"""
         app = Application()
@@ -717,7 +703,13 @@ class WindowSpecificationTestCases(unittest.TestCase):
         # TODO: test a control that is not visible but exists
         #self.assertEquals(True, self.app.DefaultIME.Exists())
 
-        self.assertEquals(False, self.app.BlahBlah.Exists(.1))
+        start = time.time()
+        self.assertEquals(False, self.app.BlahBlah.Exists(timeout=.1))
+        self.assertEquals(True, time.time() - start < .3)
+
+        start = time.time()
+        self.assertEquals(False, self.app.BlahBlah.exists(timeout=3))
+        self.assertEquals(True, 2.7 < time.time() - start < 3.3)
 
     def test_exists_timing(self):
         """test the timing of the exists method"""
@@ -775,6 +767,39 @@ class WindowSpecificationTestCases(unittest.TestCase):
         self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
 
         self.assertRaises(SyntaxError, self.dlgspec.Wait, "Invalid_criteria")
+
+    def test_wait_non_existing(self):
+        """test timing of the wait method for non-existing element"""
+        allowable_error = .2
+
+        start = time.time()
+        self.assertRaises(TimeoutError, self.app.BlahBlah.wait, 'exists')
+        expected = Timings.window_find_timeout
+        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+
+    def test_wait_invisible(self):
+        """test timing of the wait method for non-existing element"""
+        # TODO: re-use an MFC sample for this test
+        allowable_error = .2
+
+        start = time.time()
+        self.assertRaises(TimeoutError, self.app.BlahBlah.wait, 'visible')
+        expected = Timings.window_find_timeout
+        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+
+        # make sure Status Bar is not visible
+        status_bar_menu = self.app.UntitledNotepad.menu().item('&View').sub_menu().item('&Status Bar')
+        if status_bar_menu.is_checked():
+            status_bar_menu.select()
+
+        # check that existing invisible control is still found with 'exists' criterion
+        status_bar_spec = self.app.UntitledNotepad.child_window(class_name="msctls_statusbar32", visible_only=False)
+        self.assertEqual('StatusBar', status_bar_spec.wait('exists').friendly_class_name())
+
+        start = time.time()
+        self.assertRaises(TimeoutError, status_bar_spec.wait, 'exists visible')
+        expected = Timings.window_find_timeout
+        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
 
     def test_wait_not(self):
         """

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -778,7 +778,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
         self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
 
     def test_wait_invisible(self):
-        """test timing of the wait method for non-existing element"""
+        """test timing of the wait method for non-existing element and existing invisible one"""
         # TODO: re-use an MFC sample for this test
         allowable_error = .2
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -798,7 +798,10 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
         start = time.time()
         self.assertRaises(TimeoutError, status_bar_spec.wait, 'exists visible')
-        expected = Timings.window_find_timeout
+        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+
+        start = time.time()
+        self.assertRaises(TimeoutError, status_bar_spec.wait, 'visible exists')
         self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
 
     def test_wait_not(self):


### PR DESCRIPTION
* `wait / wait_not` timings are handled properly now (passing params to `_resolve_control`) fixing #347.
* Extended list view detection list (thanks @KirillMoizik ).

@airelil the case with `'exists visible'` for an existing invisible control works somehow so I decided to leave the code as is.