### PR TITLE
Fix #371 (argument 4: <type 'exceptions.OverflowError'>: long int too long to convert)

### DIFF
--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -1377,8 +1377,7 @@ class _treeview_element(object):
         remote_mem.Write(item)
 
         # read the entry
-        retval = win32functions.SendMessage(
-            self.tree_ctrl,
+        retval = self.tree_ctrl.send_message(
             win32defines.TVM_GETITEMW,
             0,
             remote_mem)
@@ -3042,10 +3041,10 @@ class UpDownWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def get_value(self):
         """Get the current value of the UpDown control"""
-        pos = win32functions.SendMessage(
-            self, win32defines.UDM_GETPOS,
+        pos = self.send_message(
+            win32defines.UDM_GETPOS,
             win32structures.LPARAM(0),
-            win32structures.WPARAM(0)
+            win32structures.WPARAM(0),
         )
         return win32functions.LoWord(pos)
     # Non PEP-8 alias

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -35,6 +35,7 @@ import ctypes
 from . import win32defines, win32structures
 from .actionlogger import ActionLogger
 from ctypes import c_uint, c_short, c_long
+from ctypes import wintypes
 
 import sys
 if sys.platform == "cygwin":
@@ -44,6 +45,7 @@ if sys.platform == "cygwin":
 
 UINT = c_uint
 SHORT = c_short
+LRESULT = wintypes.LPARAM
 
 
 CreateBrushIndirect	=	ctypes.windll.gdi32.CreateBrushIndirect
@@ -137,6 +139,8 @@ GlobalLock = ctypes.windll.kernel32.GlobalLock
 GlobalUnlock = ctypes.windll.kernel32.GlobalUnlock
 
 SendMessage			=	ctypes.windll.user32.SendMessageW
+SendMessage.argtypes = [wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM]
+SendMessage.restype = LRESULT
 SendMessageTimeout  =   ctypes.windll.user32.SendMessageTimeoutW
 SendMessageA		=	ctypes.windll.user32.SendMessageA
 PostMessage			=	ctypes.windll.user32.PostMessageW

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -35,7 +35,6 @@ import ctypes
 from . import win32defines, win32structures
 from .actionlogger import ActionLogger
 from ctypes import c_uint, c_short, c_long
-from ctypes import wintypes
 
 import sys
 if sys.platform == "cygwin":
@@ -45,7 +44,6 @@ if sys.platform == "cygwin":
 
 UINT = c_uint
 SHORT = c_short
-LRESULT = wintypes.LPARAM
 
 
 CreateBrushIndirect	=	ctypes.windll.gdi32.CreateBrushIndirect

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -139,8 +139,6 @@ GlobalLock = ctypes.windll.kernel32.GlobalLock
 GlobalUnlock = ctypes.windll.kernel32.GlobalUnlock
 
 SendMessage			=	ctypes.windll.user32.SendMessageW
-SendMessage.argtypes = [wintypes.HWND, wintypes.UINT, wintypes.WPARAM, wintypes.LPARAM]
-SendMessage.restype = LRESULT
 SendMessageTimeout  =   ctypes.windll.user32.SendMessageTimeoutW
 SendMessageA		=	ctypes.windll.user32.SendMessageA
 PostMessage			=	ctypes.windll.user32.PostMessageW


### PR DESCRIPTION
Initially the problem was reported on StackOverflow:
https://stackoverflow.com/questions/44210866/pywinauto-error-argument-4-int-too-long-to-convert

Suggested fix was to define function signature for `win32functions.SendMessage` but I decided to use `win32gui.SendMessage / self.send_message` everywhere instead (only 2 such calls was left in the whole library).