### PR TITLE
Wrapper for time.clock/time.perf_counter, PEP-8

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -655,6 +655,7 @@ class WindowSpecification(object):
             print_identifiers([this_ctrl, ])
         else:
             log_file = open(filename, "w")
+
             def log_func(msg):
                 log_file.write(str(msg) + os.linesep)
             log_func("Control Identifiers:")
@@ -1068,10 +1069,10 @@ class Application(object):
         if timeout is None:
             timeout = Timings.cpu_usage_wait_timeout
 
-        start_time = time.time()
+        start_time = timings.timestamp()
 
         while self.cpu_usage(usage_interval) > threshold:
-            if time.time() - start_time > timeout:
+            if timings.timestamp() - start_time > timeout:
                 raise RuntimeError('Waiting CPU load <= {}% timed out!'.format(threshold))
 
         return self

--- a/pywinauto/timings.py
+++ b/pywinauto/timings.py
@@ -283,9 +283,7 @@ else:
 
 
 def timestamp():
-    """
-    Get a precise timestamp
-    """
+    """ Get a precise timestamp"""
     return _clock_func()
 
 

--- a/pywinauto/timings.py
+++ b/pywinauto/timings.py
@@ -283,7 +283,7 @@ else:
 
 
 def timestamp():
-    """ Get a precise timestamp"""
+    """Get a precise timestamp"""
     return _clock_func()
 
 

--- a/pywinauto/timings.py
+++ b/pywinauto/timings.py
@@ -106,6 +106,7 @@ The Following are the individual timing settings that can be adjusted:
 
 """
 
+import six
 import time
 import operator
 from functools import wraps
@@ -275,6 +276,20 @@ class TimeoutError(RuntimeError):
 
 
 #=========================================================================
+if six.PY3:
+    _clock_func = time.perf_counter
+else:
+    _clock_func = time.clock
+
+
+def timestamp():
+    """
+    Get a precise timestamp
+    """
+    return _clock_func()
+
+
+#=========================================================================
 def always_wait_until(timeout,
                       retry_interval,
                       value=True,
@@ -322,14 +337,14 @@ def wait_until(timeout,
         except TimeoutError as e:
             print("timed out")
     """
-    start = time.time()
+    start = timestamp()
 
     func_val = func(*args)
     # while the function hasn't returned what we are waiting for
     while not op(func_val, value):
 
         # find out how much of the time is left
-        time_left = timeout - (time.time() - start)
+        time_left = timeout - (timestamp() - start)
 
         # if we have to wait some more
         if time_left > 0:
@@ -394,7 +409,7 @@ def wait_until_passes(timeout,
             print("timed out")
             raise e.
     """
-    start = time.time()
+    start = timestamp()
 
     # keep trying until the timeout is passed
     while True:
@@ -409,7 +424,7 @@ def wait_until_passes(timeout,
         except exceptions as e:
 
             # find out how much of the time is left
-            time_left = timeout - (time.time() - start)
+            time_left = timeout - (timestamp() - start)
 
             # if we have to wait some more
             if time_left > 0:

--- a/pywinauto/timings.py
+++ b/pywinauto/timings.py
@@ -117,42 +117,42 @@ class TimeConfig(object):
     """Central storage and manipulation of timing values"""
 
     __default_timing = {
-        'window_find_timeout' : 5.,
-        'window_find_retry' : .09,
+        'window_find_timeout': 5.,
+        'window_find_retry': .09,
 
-        'app_start_timeout' : 10.,
-        'app_start_retry' : .90,
+        'app_start_timeout': 10.,
+        'app_start_retry': .90,
 
-        'cpu_usage_interval' : .5,
-        'cpu_usage_wait_timeout' : 20.,
+        'cpu_usage_interval': .5,
+        'cpu_usage_wait_timeout': 20.,
 
-        'exists_timeout' : .5,
-        'exists_retry' : .3,
+        'exists_timeout': .5,
+        'exists_retry': .3,
 
-        'after_click_wait' : .09,
-        'after_clickinput_wait' : .09,
+        'after_click_wait': .09,
+        'after_clickinput_wait': .09,
 
-        'after_menu_wait' : .1,
+        'after_menu_wait': .1,
 
-        'after_sendkeys_key_wait' : .01,
+        'after_sendkeys_key_wait': .01,
 
-        'after_button_click_wait' : 0,
+        'after_button_click_wait': 0,
 
-        'before_closeclick_wait' : .1,
-        'closeclick_retry' : .05,
-        'closeclick_dialog_close_wait' : 2.,
-        'after_closeclick_wait' : .2,
+        'before_closeclick_wait': .1,
+        'closeclick_retry': .05,
+        'closeclick_dialog_close_wait': 2.,
+        'after_closeclick_wait': .2,
 
         'after_windowclose_timeout': 2,
-        'after_windowclose_retry':  .5,
+        'after_windowclose_retry': .5,
 
         'after_setfocus_wait': .06,
         'setfocus_timeout': 2,
         'setfocus_retry': .1,
 
-        'after_setcursorpos_wait' : .01,
+        'after_setcursorpos_wait': .01,
 
-        'sendmessagetimeout_timeout' : .01,
+        'sendmessagetimeout_timeout': .01,
 
         'after_tabselect_wait': .05,
 
@@ -179,7 +179,7 @@ class TimeConfig(object):
         'scroll_step_wait': 0.1,
     }
 
-    assert(__default_timing['window_find_timeout'] >=\
+    assert(__default_timing['window_find_timeout'] >=
            __default_timing['window_find_retry'] * 2)
 
     _timings = __default_timing.copy()
@@ -232,7 +232,6 @@ class TimeConfig(object):
 
             #self._timings['app_start_timeout'] = .5
 
-
     def Slow(self):
         """Set slow timing values
 
@@ -260,7 +259,7 @@ class TimeConfig(object):
                     self._timings[setting])
 
             if self._timings[setting] < .2:
-                self._timings[setting]= .2
+                self._timings[setting] = .2
 
     def Defaults(self):
         """Set all timings to the default time"""
@@ -274,12 +273,12 @@ Timings = TimeConfig()
 class TimeoutError(RuntimeError):
     pass
 
+
 #=========================================================================
-def always_wait_until(
-    timeout,
-    retry_interval,
-    value = True,
-    op = operator.eq):
+def always_wait_until(timeout,
+                      retry_interval,
+                      value=True,
+                      op=operator.eq):
     """Decorator to call wait_until(...) every time for a decorated function/method"""
     def wait_until_decorator(func):
         """Callable object that must be returned by the @always_wait_until decorator"""
@@ -291,15 +290,16 @@ def always_wait_until(
         return wrapper
     return wait_until_decorator
 
+
 #=========================================================================
-def wait_until(
-    timeout,
-    retry_interval,
-    func,
-    value = True,
-    op = operator.eq,
-    *args):
-    r"""Wait until ``op(function(*args), value)`` is True or until timeout expires
+def wait_until(timeout,
+               retry_interval,
+               func,
+               value=True,
+               op=operator.eq,
+               *args):
+    r"""
+    Wait until ``op(function(*args), value)`` is True or until timeout expires
 
     * **timeout**  how long the function will try the function
     * **retry_interval**  how long to wait between retries
@@ -329,7 +329,7 @@ def wait_until(
     while not op(func_val, value):
 
         # find out how much of the time is left
-        time_left = timeout - ( time.time() - start)
+        time_left = timeout - (time.time() - start)
 
         # if we have to wait some more
         if time_left > 0:
@@ -347,11 +347,11 @@ def wait_until(
 # Non PEP-8 alias
 WaitUntil = wait_until
 
+
 #=========================================================================
-def always_wait_until_passes(
-    timeout,
-    retry_interval,
-    exceptions = (Exception)):
+def always_wait_until_passes(timeout,
+                             retry_interval,
+                             exceptions=(Exception)):
     """Decorator to call wait_until_passes(...) every time for a decorated function/method"""
     def wait_until_passes_decorator(func):
         """Callable object that must be returned by the @always_wait_until_passes decorator"""
@@ -363,14 +363,15 @@ def always_wait_until_passes(
         return wrapper
     return wait_until_passes_decorator
 
+
 #=========================================================================
-def wait_until_passes(
-    timeout,
-    retry_interval,
-    func,
-    exceptions = (Exception),
-    *args):
-    """Wait until ``func(*args)`` does not raise one of the exceptions in exceptions
+def wait_until_passes(timeout,
+                      retry_interval,
+                      func,
+                      exceptions=(Exception),
+                      *args):
+    """
+    Wait until ``func(*args)`` does not raise one of the exceptions in exceptions
 
     * **timeout**  how long the function will try the function
     * **retry_interval**  how long to wait between retries
@@ -408,7 +409,7 @@ def wait_until_passes(
         except exceptions as e:
 
             # find out how much of the time is left
-            time_left = timeout - ( time.time() - start)
+            time_left = timeout - (time.time() - start)
 
             # if we have to wait some more
             if time_left > 0:

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -65,6 +65,7 @@ from pywinauto.timings import TimeoutError
 from pywinauto.timings import WaitUntil
 from pywinauto.timings import always_wait_until
 from pywinauto.timings import always_wait_until_passes
+from pywinauto.timings import timestamp  # noqa: E402
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.sysinfo import is_x64_OS
 from pywinauto.sysinfo import UIA_support
@@ -703,68 +704,68 @@ class WindowSpecificationTestCases(unittest.TestCase):
         # TODO: test a control that is not visible but exists
         #self.assertEquals(True, self.app.DefaultIME.Exists())
 
-        start = time.time()
+        start = timestamp()
         self.assertEquals(False, self.app.BlahBlah.Exists(timeout=.1))
-        self.assertEquals(True, time.time() - start < .3)
+        self.assertEquals(True, timestamp() - start < .3)
 
-        start = time.time()
+        start = timestamp()
         self.assertEquals(False, self.app.BlahBlah.exists(timeout=3))
-        self.assertEquals(True, 2.7 < time.time() - start < 3.3)
+        self.assertEquals(True, 2.7 < timestamp() - start < 3.3)
 
     def test_exists_timing(self):
         """test the timing of the exists method"""
         # try ones that should be found immediately
-        start = time.time()
+        start = timestamp()
         self.assertEquals(True, self.dlgspec.Exists())
-        self.assertEquals(True, time.time() - start < .3)
+        self.assertEquals(True, timestamp() - start < .3)
 
-        start = time.time()
+        start = timestamp()
         self.assertEquals(True, self.ctrlspec.Exists())
-        self.assertEquals(True, time.time() - start < .3)
+        self.assertEquals(True, timestamp() - start < .3)
 
         # try one that should not be found
-        start = time.time()
+        start = timestamp()
         self.assertEquals(True, self.dlgspec.Exists(.5))
-        timedif =  time.time() - start
+        timedif =  timestamp() - start
         self.assertEquals(True, .49 > timedif < .6)
 
     def test_wait(self):
         """test the functionality and timing of the wait method"""
         allowable_error = .2
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("enaBleD "))
-        time_taken = (time.time() - start)
+        time_taken = (timestamp() - start)
         if not 0 <= time_taken < (0 + 2 * allowable_error):
             self.assertEqual(.02,  time_taken)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("  ready"))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait(" exiSTS"))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait(" VISIBLE "))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait(" ready enabled"))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("visible exists "))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("exists "))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("actIve "))
-        self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+        self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         self.assertRaises(SyntaxError, self.dlgspec.Wait, "Invalid_criteria")
 
@@ -772,20 +773,20 @@ class WindowSpecificationTestCases(unittest.TestCase):
         """test timing of the wait method for non-existing element"""
         allowable_error = .2
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.app.BlahBlah.wait, 'exists')
         expected = Timings.window_find_timeout
-        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+        self.assertEqual(True, expected - allowable_error <= (timestamp() - start) < expected + allowable_error)
 
     def test_wait_invisible(self):
         """test timing of the wait method for non-existing element and existing invisible one"""
         # TODO: re-use an MFC sample for this test
         allowable_error = .2
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.app.BlahBlah.wait, 'visible')
         expected = Timings.window_find_timeout
-        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+        self.assertEqual(True, expected - allowable_error <= (timestamp() - start) < expected + allowable_error)
 
         # make sure Status Bar is not visible
         status_bar_menu = self.app.UntitledNotepad.menu().item('&View').sub_menu().item('&Status Bar')
@@ -796,13 +797,13 @@ class WindowSpecificationTestCases(unittest.TestCase):
         status_bar_spec = self.app.UntitledNotepad.child_window(class_name="msctls_statusbar32", visible_only=False)
         self.assertEqual('StatusBar', status_bar_spec.wait('exists').friendly_class_name())
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, status_bar_spec.wait, 'exists visible')
-        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+        self.assertEqual(True, expected - allowable_error <= (timestamp() - start) < expected + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, status_bar_spec.wait, 'visible exists')
-        self.assertEqual(True, expected - allowable_error <= (time.time() - start) < expected + allowable_error)
+        self.assertEqual(True, expected - allowable_error <= (timestamp() - start) < expected + allowable_error)
 
     def test_wait_not(self):
         """
@@ -813,39 +814,39 @@ class WindowSpecificationTestCases(unittest.TestCase):
         """
         allowable_error = .16
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "enaBleD ", .1, .05)
-        taken = time.time() - start
+        taken = timestamp() - start
         if .1 < (taken)  > .1 + allowable_error:
             self.assertEqual(.12, taken)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "  ready", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, " exiSTS", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, " VISIBLE ", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, " ready enabled", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "visible exists ", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "exists ", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        start = time.time()
+        start = timestamp()
         self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "actIve ", .1, .05)
-        self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+        self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         self.assertRaises(SyntaxError, self.dlgspec.WaitNot, "Invalid_criteria")
 
@@ -853,15 +854,15 @@ class WindowSpecificationTestCases(unittest.TestCase):
 #        """Make sure the friendly class is set correctly"""
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertEqual(self.dlgspec.ctrl_(), self.dlgspec.WaitReady(.1, .05))
 #
 #        # it it didn't finish in the allocated time then raise an error
 #        # we assertEqual to something that we know is not right - to get a
 #        # better error report
-#        if not 0 <= (time.time() - start) < 0 + allowable_error:
-#            self.assertEqual(0, time.time() - start)
-#        #self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+#        if not 0 <= (timestamp() - start) < 0 + allowable_error:
+#            self.assertEqual(0, timestamp() - start)
+#        #self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 #
 #
 #    def testWaitNotReady(self):
@@ -869,13 +870,13 @@ class WindowSpecificationTestCases(unittest.TestCase):
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertRaises(RuntimeError, self.dlgspec.WaitNotReady, .1, .05)
 #
-#        if not .1 <= (time.time() - start) < .1 + allowable_error:
-#            self.assertEqual(.1, time.time() - start)
+#        if not .1 <= (timestamp() - start) < .1 + allowable_error:
+#            self.assertEqual(.1, timestamp() - start)
 #
-#        #self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+#        #self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 #
 #
 #    def testWaitEnabled(self):
@@ -883,13 +884,13 @@ class WindowSpecificationTestCases(unittest.TestCase):
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertEqual(self.dlgspec.ctrl_(), self.dlgspec.WaitEnabled(.1, .05))
 #
-#        if not 0 <= (time.time() - start) < 0 + allowable_error:
-#            self.assertEqual(0, time.time() - start)
+#        if not 0 <= (timestamp() - start) < 0 + allowable_error:
+#            self.assertEqual(0, timestamp() - start)
 #
-#        #self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+#        #self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 #
 #
 #    def testWaitNotEnabled(self):
@@ -897,60 +898,60 @@ class WindowSpecificationTestCases(unittest.TestCase):
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertRaises(RuntimeError, self.dlgspec.WaitNotEnabled, .1, .05)
-#        if not .1 <= (time.time() - start) < .1 + allowable_error:
-#            self.assertEqual(.1, time.time() - start)
-#        #self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+#        if not .1 <= (timestamp() - start) < .1 + allowable_error:
+#            self.assertEqual(.1, timestamp() - start)
+#        #self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 #
 #    def testWaitVisible(self):
 #        "Make sure the friendly class is set correctly"
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertEqual(self.dlgspec.ctrl_(), self.dlgspec.WaitVisible(.1, .05))
-#        if not 0 <= (time.time() - start) < 0 + allowable_error:
-#            self.assertEqual(0, time.time() - start)
-#        #self.assertEqual(True, 0 <= (time.time() - start) < 0 + allowable_error)
+#        if not 0 <= (timestamp() - start) < 0 + allowable_error:
+#            self.assertEqual(0, timestamp() - start)
+#        #self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 #
 #    def testWaitNotVisible(self):
 #        "Make sure the friendly class is set correctly"
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertRaises(RuntimeError, self.dlgspec.WaitNotVisible, .1, .05)
 #        # it it didn't finish in the allocated time then raise an error
 #        # we assertEqual to something that we know is not right - to get a
 #        # better error report
-#        if not .1 <= (time.time() - start) < .1 + allowable_error:
-#            self.assertEqual(.1, time.time() - start)
+#        if not .1 <= (timestamp() - start) < .1 + allowable_error:
+#            self.assertEqual(.1, timestamp() - start)
 #
 #    def testWaitExists(self):
 #        "Make sure the friendly class is set correctly"
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertEqual(self.dlgspec.ctrl_(), self.dlgspec.WaitExists(.1, .05))
 #
 #        # it it didn't finish in the allocated time then raise an error
 #        # we assertEqual to something that we know is not right - to get a
 #        # better error report
-#        if not 0 <= (time.time() - start) < 0 + allowable_error:
-#            self.assertEqual(.1, time.time() - start)
+#        if not 0 <= (timestamp() - start) < 0 + allowable_error:
+#            self.assertEqual(.1, timestamp() - start)
 #
 #    def testWaitNotExists(self):
 #        "Make sure the friendly class is set correctly"
 #
 #        allowable_error = .02
 #
-#        start = time.time()
+#        start = timestamp()
 #        self.assertRaises(RuntimeError, self.dlgspec.WaitNotExists, .1, .05)
-#        if not .1 <= (time.time() - start) < .1 + allowable_error:
-#            self.assertEqual(.1, time.time() - start)
-#        #self.assertEqual(True, .1 <= (time.time() - start) < .1 + allowable_error)
+#        if not .1 <= (timestamp() - start) < .1 + allowable_error:
+#            self.assertEqual(.1, timestamp() - start)
+#        #self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
     def test_depth(self):
         """Test that descendants() with depth works correctly"""

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -604,7 +604,7 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         birds.Click(where='check')
         self.assertEqual(birds.IsChecked(), True)
         birds.click_input(where='check')
-        wait_until(3, 0.4, lambda: birds.IsChecked(), value=False)
+        wait_until(3, 0.4, birds.IsChecked, value=False)
 
     def testPrintItems(self):
         """Test TreeView method PrintItems()"""
@@ -744,11 +744,11 @@ class HeaderTestCases(unittest.TestCase):
 
         client_rects = self.ctrl.client_rects()
         self.assertEquals(len(test_rects), len(client_rects))
-        for i in range(len(test_rects)):
-            self.assertEquals(test_rects[i].left, client_rects[i].left)
-            self.assertEquals(test_rects[i].right, client_rects[i].right)
-            self.assertEquals(test_rects[i].top, client_rects[i].top)
-            self.failIf(abs(test_rects[i].bottom - client_rects[i].bottom) > 2)  # may be equal to 17 or 19
+        for i, r in enumerate(test_rects):
+            self.assertEquals(r.left, client_rects[i].left)
+            self.assertEquals(r.right, client_rects[i].right)
+            self.assertEquals(r.top, client_rects[i].top)
+            self.failIf(abs(r.bottom - client_rects[i].bottom) > 2)  # may be equal to 17 or 19
 
     def testGetColumnText(self):
         for i in range(0, 3):
@@ -841,8 +841,7 @@ class StatusBarTestCases(unittest.TestCase):
     def testClientRects(self):
         self.assertEquals(self.ctrl.ClientRect(), self.ctrl.ClientRects()[0])
         client_rects = self.ctrl.ClientRects()[1:]
-        for i in range(len(client_rects)):
-            client_rect = client_rects[i]
+        for i, client_rect in enumerate(client_rects):
             self.assertEquals(self.part_rects[i].left, client_rect.left)
             if i != len(client_rects) - 1:
                 self.assertEquals(self.part_rects[i].right, client_rect.right)

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -51,6 +51,7 @@ from pywinauto.sysinfo import is_x64_Python  # noqa: E402
 from pywinauto.remote_memory_block import RemoteMemoryBlock  # noqa: E402
 from pywinauto.actionlogger import ActionLogger  # noqa: E402
 from pywinauto.timings import Timings  # noqa: E402
+from pywinauto.timings import wait_until  # noqa: E402
 from pywinauto import mouse  # noqa: E402
 
 
@@ -601,9 +602,9 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         self.dlg.TVS_CHECKBOXES.check_by_click()
         birds = self.ctrl.GetItem(r'\Birds')
         birds.Click(where='check')
-        self.assertEquals(birds.IsChecked(), True)
+        self.assertEqual(birds.IsChecked(), True)
         birds.click_input(where='check')
-        self.assertEquals(birds.IsChecked(), False)
+        wait_until(3, 0.4, lambda: birds.IsChecked(), value=False)
 
     def testPrintItems(self):
         """Test TreeView method PrintItems()"""


### PR DESCRIPTION
Switch from time.time to time.clock on Py2 and time.perf_counter on Py3
PEP-8 fixes
Unit tests stabilization