### PR TITLE
Fix unit tests for Py3.3

### DIFF
--- a/pywinauto/unittests/test_actionlogger.py
+++ b/pywinauto/unittests/test_actionlogger.py
@@ -158,10 +158,10 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
         mockLogger = self.logger_patcher.start()
 
         actionlogger.disable()
-        mockLogger.disable.assert_called()
+        self.assertTrue(mockLogger.disable.called)
 
         actionlogger.reset_level()
-        mockLogger.reset_level.assert_called()
+        self.assertTrue(mockLogger.reset_level.called)
 
     def test_logger_enable_mapped_to_reset_level(self):
         """Test if the logger enable is mapped to reset_level"""
@@ -172,7 +172,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
         mockLogger = self.logger_patcher.start()
 
         actionlogger.enable()
-        mockLogger.reset_level.assert_called()
+        self.assertTrue(mockLogger.reset_level.called)
 
 
 if __name__ == "__main__":

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -629,20 +629,6 @@ class ApplicationTestCases(unittest.TestCase):
         app.wait_for_process_exit(timeout=10, retry_interval=1)
         self.assertFalse(app.is_process_running())
 
-    @mock.patch.object(win32api, 'OpenProcess')
-    def test_should_return_not_running_if_failed_to_open_process(self, func_open_process):
-        """Tests error handling wehn OpenProcess return 0 handle
-
-        Checks is_process_running and wait_for_process_exit works
-        even if OpenProcess returns 0 handle without exception
-        """
-        func_open_process.return_value = pywintypes.HANDLE(0)
-        app = Application()
-        app.start(_notepad_exe())
-        app.wait_for_process_exit(timeout=10, retry_interval=1)
-        self.assertFalse(app.is_process_running())
-        app.kill()
-
     class TestInheritedApp(Application):
 
         """Our inherited version of class"""

--- a/pywinauto/unittests/test_calendar.py
+++ b/pywinauto/unittests/test_calendar.py
@@ -5,15 +5,16 @@ import sys
 import unittest
 
 sys.path.append(".")
-from pywinauto import win32structures
-from pywinauto import win32defines
-from pywinauto.application import Application
-from pywinauto.sysinfo import is_x64_Python
+from pywinauto import win32structures  # noqa E402
+from pywinauto import win32defines  # noqa E402
+from pywinauto.application import Application  # noqa E402
+from pywinauto.sysinfo import is_x64_Python  # noqa E402
 
 mfc_samples_folder = os.path.join(
-   os.path.dirname(__file__), r"..\..\apps\MFC_samples")
+    os.path.dirname(__file__), r"..\..\apps\MFC_samples")
 if is_x64_Python():
     mfc_samples_folder = os.path.join(mfc_samples_folder, 'x64')
+
 
 class CalendarWrapperTests(unittest.TestCase):
 
@@ -41,11 +42,11 @@ class CalendarWrapperTests(unittest.TestCase):
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.type_keys("%{F4}")
+        self.app.kill()
 
     def test_can_get_current_date_from_calendar(self):
         date = self.calendar.get_current_date()
-        self.assert_actual_time_is_equal_to_expect_date_time(date,datetime.date.today())
+        self.assert_actual_time_is_equal_to_expect_date_time(date, datetime.date.today())
 
     def test_runtime_error_when_try_to_get_current_date_from_calendar_if_calendar_state_is_multiselect(self):
         self._set_calendar_state_into_multiselect()
@@ -54,8 +55,8 @@ class CalendarWrapperTests(unittest.TestCase):
     def test_can_set_current_date_in_calendar(self):
         self.calendar.set_current_date(2016, 4, 3, 13)
         self.assert_actual_time_is_equal_to_expect_date_time(
-                self.calendar.get_current_date(),
-                datetime.date(2016, 4, 13))
+            self.calendar.get_current_date(),
+            datetime.date(2016, 4, 13))
 
     def test_should_throw_runtime_error_when_try_to_set_invalid_date(self):
         self.assertRaises(RuntimeError, self.calendar.set_current_date, -2016, -4, -3, -13)
@@ -101,7 +102,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.set_day_states(month_states)
 
-        self.assertNotEquals(0, res)
+        self.assertNotEqual(0, res)
 
     def test_cant_set_day_state_passing_one_month_state(self):
         month_states = [self.NO_HOLIDAYS_IN_MONTH]
@@ -112,12 +113,12 @@ class CalendarWrapperTests(unittest.TestCase):
         expected_rect = self._get_expected_minimized_rectangle()
         rect = self.calendar.calc_min_rectangle(expected_rect.left + 100, expected_rect.top + 100,
                                                 expected_rect.right + 100, expected_rect.bottom + 100)
-        self.assertEquals(expected_rect, rect)
+        self.assertEqual(expected_rect, rect)
 
     def test_can_minimize_rectangle_handle_less_than_zero_values(self):
         expected_rect = self._get_expected_minimized_rectangle()
         rect = self.calendar.calc_min_rectangle(-1, -1, -1, -1)
-        self.assertEquals(expected_rect, rect)
+        self.assertEqual(expected_rect, rect)
 
     def test_can_determine_calendar_is_hit(self):
         x = int(self.width / self.CALENDARBK_WIDTH_COEFF)
@@ -125,7 +126,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDAR, res)
+        self.assertEqual(win32defines.MCHT_CALENDAR, res)
 
     def test_can_determine_calendar_background_is_hit(self):
         x = int(self.width / self.CALENDARBK_WIDTH_COEFF)
@@ -133,7 +134,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDARBK, res)
+        self.assertEqual(win32defines.MCHT_CALENDARBK, res)
 
     def test_can_determine_date_is_hit(self):
         x = int(self.width / 1.13)
@@ -141,7 +142,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDARDATE, res)
+        self.assertEqual(win32defines.MCHT_CALENDARDATE, res)
 
     def test_can_determine_next_month_date_is_hit(self):
         x = int(self.width / 1.14)
@@ -149,7 +150,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDARDATENEXT, res)
+        self.assertEqual(win32defines.MCHT_CALENDARDATENEXT, res)
 
     def test_can_determine_prev_month_date_is_hit(self):
         x = int(self.width / 16)
@@ -157,11 +158,11 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDARDATEPREV, res)
+        self.assertEqual(win32defines.MCHT_CALENDARDATEPREV, res)
 
     def test_can_determine_nothing_is_hit(self):
         res = self.calendar.hit_test(0, 0)
-        self.assertEquals(win32defines.MCHT_NOWHERE, res)
+        self.assertEqual(win32defines.MCHT_NOWHERE, res)
 
     def test_can_determine_top_left_title_corner_is_hit(self):
         x = int(self.width / 16)
@@ -169,7 +170,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_TITLEBTNPREV, res)
+        self.assertEqual(win32defines.MCHT_TITLEBTNPREV, res)
 
     def test_can_determine_title_is_hit(self):
         x = int(self.width / self.TITLEBK_WIDTH_COEFF)
@@ -177,7 +178,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_TITLE, res)
+        self.assertEqual(win32defines.MCHT_TITLE, res)
 
     def test_can_determine_title_background_is_hit(self):
         x = int(self.width / self.TITLEBK_WIDTH_COEFF)
@@ -185,7 +186,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_TITLEBK, res)
+        self.assertEqual(win32defines.MCHT_TITLEBK, res)
 
     def test_can_determine_top_right_title_corner_is_hit(self):
         x = int(self.width / 1.07)
@@ -193,7 +194,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_TITLEBTNNEXT, res)
+        self.assertEqual(win32defines.MCHT_TITLEBTNNEXT, res)
 
     # TODO: test_can_determine_today_link_is_hit fails in CI with strange res = 1048576.
     # There is no such value for MCHT_* defines.
@@ -203,7 +204,7 @@ class CalendarWrapperTests(unittest.TestCase):
     #
     #     res = self.calendar.test_hit(x, y)
     #
-    #     self.assertEquals(win32defines.MCHT_TODAYLINK, res)
+    #     self.assertEqual(win32defines.MCHT_TODAYLINK, res)
 
     def test_can_determine_day_abbreviation_is_hit(self):
         x = int(self.width / 5.33)
@@ -211,7 +212,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDARDAY, res)
+        self.assertEqual(win32defines.MCHT_CALENDARDAY, res)
 
     def test_can_determine_week_number_is_hit(self):
         self._set_calendar_state_to_display_week_numbers()
@@ -220,7 +221,7 @@ class CalendarWrapperTests(unittest.TestCase):
 
         res = self.calendar.hit_test(x, y)
 
-        self.assertEquals(win32defines.MCHT_CALENDARWEEKNUM, res)
+        self.assertEqual(win32defines.MCHT_CALENDARWEEKNUM, res)
 
     def test_should_throw_runtime_error_when_try_to_set_invalid_type_of_calendar(self):
         self.assertRaises(ValueError, self.calendar.set_id, 'Aloha!')
@@ -254,23 +255,23 @@ class CalendarWrapperTests(unittest.TestCase):
         """Test setting up the control's today field"""
         self.calendar.set_today(2016, 5, 1)
         self.assert_actual_time_is_equal_to_expect_date_time(self.calendar.get_today(),
-                                                              datetime.date(2016, 5, 1))
+                                                             datetime.date(2016, 5, 1))
 
     def test_can_set_and_get_first_day_of_week(self):
         """Test can set and get first day of the week"""
         self.calendar.set_first_weekday(4)
-        self.assertEqual((True,4), self.calendar.get_first_weekday())
+        self.assertEqual((True, 4), self.calendar.get_first_weekday())
 
     def test_can_get_default_scroll_rate(self):
         actual_rate = 1
 
-        self.assertEquals(actual_rate, self.calendar.get_month_delta())
+        self.assertEqual(actual_rate, self.calendar.get_month_delta())
 
     def test_can_set_scroll_rate(self):
         actual_rate = 4
         self.calendar.set_month_delta(actual_rate)
 
-        self.assertEquals(actual_rate, self.calendar.get_month_delta())
+        self.assertEqual(actual_rate, self.calendar.get_month_delta())
 
     def test_should_throw_value_error_when_try_to_set_incorrect_scroll_rate(self):
         self.assertRaises(ValueError, self.calendar.set_month_delta, -1)
@@ -303,7 +304,7 @@ class CalendarWrapperTests(unittest.TestCase):
         start_month = datetime.date(2017, 4, 24)
         end_month = datetime.date(2017, 6, 4)
 
-        self.assertEquals(range_months, exp_range)
+        self.assertEqual(range_months, exp_range)
         self.assertEqual(system_time[0].wYear, start_month.year)
         self.assertEqual(system_time[0].wMonth, start_month.month)
         self.assertEqual(system_time[1].wYear, end_month.year)
@@ -316,7 +317,7 @@ class CalendarWrapperTests(unittest.TestCase):
         res = self.calendar.get_month_range(win32defines.GMR_VISIBLE)
         range_months, system_time = res[:2]
 
-        self.assertEquals(range_months, exp_range)
+        self.assertEqual(range_months, exp_range)
         self.assert_actual_time_is_equal_to_expect_date_time(system_time[0], start_month)
         self.assert_actual_time_is_equal_to_expect_date_time(system_time[1], end_month)
 
@@ -336,10 +337,8 @@ class CalendarWrapperTests(unittest.TestCase):
     def _set_calendar_state_to_display_day_states(self):
         self.app['Common Controls Sample']['MCS_DAYSTATE'].Click()
 
-
     def _set_calendar_state_to_display_week_numbers(self):
         self.app['Common Controls Sample']['MCS_WEEKNUMBERS'].Click()
-
 
     def _set_calendar_state_into_multiselect(self):
         self.app['Common Controls Sample']['MCS_MULTISELECT'].Click()


### PR DESCRIPTION
The recent commits started failing often on Py 3.3, so I reproduced several such problems on my local machine with Py3.3 x64. These are some fix:
 - remove ```ApplicationTestCases.test_should_return_not_running_if_failed_to_open_process``` as it confuses ```ApplicationWarningTests``` test suite running after. I didn't manage to re-write it in a way it will not harm "warnings" module globally.
- fix mock asserts for Py3.3 in ```ActionLoggerOnCustomLoggerTestCases.test_logger_disable_and_reset```
-  use more robust way to close test applications in ```CalendarWrapperTests```
- some PEP8 fixes in test_calendar