### PR TITLE
UIA stability

### DIFF
--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -649,7 +649,7 @@ class BaseWrapper(object):
             self.set_focus()
 
         if isinstance(coords, win32structures.RECT):
-            coords = [coords.left, coords.top]
+            coords = coords.mid_point()
         # allow points objects to be passed as the coords
         elif isinstance(coords, win32structures.POINT):
             coords = [coords.x, coords.y]
@@ -672,13 +672,13 @@ class BaseWrapper(object):
                 ctrl_text = six.text_type(ctrl_text)
             if button.lower() == 'move':
                 message = 'Moved mouse over ' + self.friendly_class_name() + \
-                          ' "' + ctrl_text + '" to screen point (x,y='
+                          ' "' + ctrl_text + '" to screen point ('
             else:
                 message = 'Clicked ' + self.friendly_class_name() + ' "' + ctrl_text + \
-                          '" by ' + str(button) + ' button mouse click (x,y='
+                          '" by ' + str(button) + ' button mouse click at '
                 if double:
                     message = 'Double-c' + message[1:]
-            message += ','.join([str(coord) for coord in coords]) + ')'
+            message += str(tuple(coords))
 
         _perform_click_input(button, coords, double, button_down, button_up,
                              wheel_dist=wheel_dist, pressed=pressed,

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -631,8 +631,8 @@ class BaseWrapper(object):
         """Click at the specified coordinates
 
         * **button** The mouse button to click. One of 'left', 'right',
-          'middle' or 'x' (Default: 'left')
-        * **coords** The coordinates to click at.(Default: center of control)
+          'middle' or 'x' (Default: 'left', 'move' is a special case)
+        * **coords** The coordinates to click at.(Default: the center of the control)
         * **double** Whether to perform a double click or not (Default: False)
         * **wheel_dist** The distance to move the mouse wheel (default: 0)
 
@@ -647,15 +647,14 @@ class BaseWrapper(object):
         """
         if self.is_dialog():
             self.set_focus()
-        ctrl_text = self.window_text()
+
         if isinstance(coords, win32structures.RECT):
             coords = [coords.left, coords.top]
-
         # allow points objects to be passed as the coords
-        if isinstance(coords, win32structures.POINT):
+        elif isinstance(coords, win32structures.POINT):
             coords = [coords.x, coords.y]
-        #else:
-        coords = list(coords)
+        else:
+            coords = list(coords)
 
         # set the default coordinates
         if coords[0] is None:
@@ -666,23 +665,27 @@ class BaseWrapper(object):
         if not absolute:
             coords = self.client_to_screen(coords)
 
+        message = None
         if use_log:
+            ctrl_text = self.window_text()
             if ctrl_text is None:
                 ctrl_text = six.text_type(ctrl_text)
-            message = 'Click ' + self.friendly_class_name() + ' "' + ctrl_text + \
-                      '" by ' + str(button) + ' button mouse click (x,y=' + \
-                      ','.join([str(coord) for coord in coords]) + ')'
-            if double:
-                message = 'Double-c' + message[1:]
             if button.lower() == 'move':
                 message = 'Moved mouse over ' + self.friendly_class_name() + \
-                          ' "' + ctrl_text + '" to screen point (x,y=' + \
-                          ','.join([str(coord) for coord in coords]) + ')'
-            ActionLogger().log(message)
+                          ' "' + ctrl_text + '" to screen point (x,y='
+            else:
+                message = 'Clicked ' + self.friendly_class_name() + ' "' + ctrl_text + \
+                          '" by ' + str(button) + ' button mouse click (x,y='
+                if double:
+                    message = 'Double-c' + message[1:]
+            message += ','.join([str(coord) for coord in coords]) + ')'
 
         _perform_click_input(button, coords, double, button_down, button_up,
                              wheel_dist=wheel_dist, pressed=pressed,
                              key_down=key_down, key_up=key_up)
+
+        if message:
+            self.actions.log(message)
 
     #-----------------------------------------------------------
     def double_click_input(self, button ="left", coords = (None, None)):

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -666,14 +666,10 @@ class BaseWrapper(object):
         if not absolute:
             coords = self.client_to_screen(coords)
 
-        _perform_click_input(button, coords, double, button_down, button_up,
-                             wheel_dist=wheel_dist, pressed=pressed,
-                             key_down=key_down, key_up=key_up)
-
         if use_log:
             if ctrl_text is None:
                 ctrl_text = six.text_type(ctrl_text)
-            message = 'Clicked ' + self.friendly_class_name() + ' "' + ctrl_text + \
+            message = 'Click ' + self.friendly_class_name() + ' "' + ctrl_text + \
                       '" by ' + str(button) + ' button mouse click (x,y=' + \
                       ','.join([str(coord) for coord in coords]) + ')'
             if double:
@@ -683,6 +679,10 @@ class BaseWrapper(object):
                           ' "' + ctrl_text + '" to screen point (x,y=' + \
                           ','.join([str(coord) for coord in coords]) + ')'
             ActionLogger().log(message)
+
+        _perform_click_input(button, coords, double, button_down, button_up,
+                             wheel_dist=wheel_dist, pressed=pressed,
+                             key_down=key_down, key_up=key_up)
 
     #-----------------------------------------------------------
     def double_click_input(self, button ="left", coords = (None, None)):

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1630,7 +1630,7 @@ def _perform_click(
     ctrl_friendly_class_name = ctrl.friendly_class_name()
 
     if isinstance(coords, win32structures.RECT):
-        coords = [coords.left, coords.top]
+        coords = coords.mid_point()
     # allow points objects to be passed as the coords
     elif isinstance(coords, win32structures.POINT):
         coords = [coords.x, coords.y]
@@ -1687,7 +1687,6 @@ def _perform_click(
     # figure out the flags and pack coordinates
     flags, click_point = _calc_flags_and_coords(pressed, coords)
 
-
     #control_thread = win32functions.GetWindowThreadProcessId(ctrl, 0)
     #win32functions.AttachThreadInput(win32functions.GetCurrentThreadId(), control_thread, win32defines.TRUE)
     # TODO: check return value of AttachThreadInput properly
@@ -1712,10 +1711,10 @@ def _perform_click(
 
     if button.lower() == 'move':
         message = 'Moved mouse over ' + ctrl_friendly_class_name + ' "' + ctrl_text + \
-                  '" to screen point (x,y=' + ','.join([str(coord) for coord in coords]) + ') by WM_MOUSEMOVE'
+                  '" to screen point ' + str(tuple(coords)) + ' by WM_MOUSEMOVE'
     else:
         message = 'Clicked ' + ctrl_friendly_class_name + ' "' + ctrl_text + \
-                  '" by ' + str(button) + ' button event (x,y=' + ','.join([str(coord) for coord in coords]) + ')'
+                  '" by ' + str(button) + ' button event ' + str(tuple(coords))
         if double:
             message = 'Double-c' + message[1:]
     ActionLogger().log(message)

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1624,20 +1624,24 @@ def _perform_click(
         ctrl = HwndWrapper(win32functions.GetDesktopWindow())
     ctrl.verify_actionable()
     ctrl_text = ctrl.window_text()
+    if ctrl_text is None:
+        ctrl_text = six.text_type(ctrl_text)
+
+    ctrl_friendly_class_name = ctrl.friendly_class_name()
 
     if isinstance(coords, win32structures.RECT):
         coords = [coords.left, coords.top]
     # allow points objects to be passed as the coords
-    if isinstance(coords, win32structures.POINT):
+    elif isinstance(coords, win32structures.POINT):
         coords = [coords.x, coords.y]
-    #else:
-    coords = list(coords)
+    else:
+        coords = list(coords)
 
     if absolute:
         coords = ctrl.client_to_screen(coords)
 
     # figure out the messages for click/press
-    msgs  = []
+    msgs = []
     if not double:
         if button.lower() == 'left':
             if button_down:
@@ -1706,16 +1710,15 @@ def _perform_click(
     # wait a certain(short) time after the click
     time.sleep(Timings.after_click_wait)
 
-    message = 'Clicked ' + ctrl.friendly_class_name() + ' "' + ctrl_text + \
-              '" by ' + str(button) + ' button event (x,y=' + ','.join([str(coord) for coord in coords]) + ')'
-    if double:
-        message = 'Double-c' + message[1:]
     if button.lower() == 'move':
-        message = 'Moved mouse over ' + ctrl.friendly_class_name() + ' "' + ctrl_text + \
-              '" to screen point (x,y=' + ','.join([str(coord) for coord in coords]) + ') by WM_MOUSEMOVE'
+        message = 'Moved mouse over ' + ctrl_friendly_class_name + ' "' + ctrl_text + \
+                  '" to screen point (x,y=' + ','.join([str(coord) for coord in coords]) + ') by WM_MOUSEMOVE'
+    else:
+        message = 'Clicked ' + ctrl_friendly_class_name + ' "' + ctrl_text + \
+                  '" by ' + str(button) + ' button event (x,y=' + ','.join([str(coord) for coord in coords]) + ')'
+        if double:
+            message = 'Double-c' + message[1:]
     ActionLogger().log(message)
-
-
 
 _mouse_flags = {
     "left": win32defines.MK_LBUTTON,

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -40,9 +40,10 @@ from .uia_defines import get_elem_interface
 from .handleprops import dumpwindow, controlid
 from .element_info import ElementInfo
 from .win32structures import RECT
+from .actionlogger import ActionLogger
 
 
-def elements_from_uia_array(ptrs, cache_enable = False):
+def elements_from_uia_array(ptrs, cache_enable=False):
     """Build a list of UIAElementInfo elements from IUIAutomationElementArray"""
     elements = []
     for n in range(ptrs.Length):
@@ -83,7 +84,7 @@ class UIAElementInfo(ElementInfo):
             return self._element.CurrentClassName
         except COMError:
             return None # probably element already doesn't exist
-    
+
     def _get_cached_class_name(self):
         """Return a cached class name of the element"""
         if self._cached_class_name is None:
@@ -256,10 +257,14 @@ class UIAElementInfo(ElementInfo):
         else:
             return None
 
-    def _get_elements(self, tree_scope, cond = IUIA().true_condition, cache_enable = False):
+    def _get_elements(self, tree_scope, cond=IUIA().true_condition, cache_enable=False):
         """Find all elements according to the given tree scope and conditions"""
-        ptrs_array = self._element.FindAll(tree_scope, cond)
-        return elements_from_uia_array(ptrs_array, cache_enable)
+        try:
+            ptrs_array = self._element.FindAll(tree_scope, cond)
+            return elements_from_uia_array(ptrs_array, cache_enable)
+        except(COMError, ValueError):
+            ActionLogger().log("COM error: can't get elements")
+            return []
 
     def children(self, **kwargs):
         """Return a list of only immediate children of the element

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -8,7 +8,6 @@ import sys
 import unittest
 import mock
 import six
-import comtypes
 
 sys.path.append(".")
 from pywinauto.application import Application, WindowSpecification  # noqa: E402
@@ -16,6 +15,7 @@ from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
 from pywinauto.timings import Timings  # noqa: E402
 from pywinauto.actionlogger import ActionLogger  # noqa: E402
 if UIA_support:
+    import comtypes
     import pywinauto.uia_defines as uia_defs
     import pywinauto.controls.uia_controls as uia_ctls
 

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -8,12 +8,13 @@ import sys
 import unittest
 import mock
 import six
+import comtypes
 
 sys.path.append(".")
 from pywinauto.application import Application, WindowSpecification  # noqa: E402
 from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
 from pywinauto.timings import Timings  # noqa: E402
-from pywinauto.actionlogger import ActionLogger
+from pywinauto.actionlogger import ActionLogger  # noqa: E402
 if UIA_support:
     import pywinauto.uia_defines as uia_defs
     import pywinauto.controls.uia_controls as uia_ctls
@@ -53,6 +54,18 @@ if UIA_support:
         def tearDown(self):
             """Close the application after tests"""
             self.app.kill_()
+
+        def test_issue_296(self):
+            """Test handling of disappered descendants"""
+            wrp = self.dlg.wrapper_object()
+            orig = wrp.element_info._element.FindAll
+            wrp.element_info._element.FindAll = mock.Mock(side_effect=ValueError("Mocked value error"),
+                                                          return_value=[])  # empty list
+            self.assertEqual([], wrp.descendants())
+            wrp.element_info._element.FindAll = mock.Mock(side_effect=comtypes.COMError("Mocked COM error", 0, 0),
+                                                          return_value=[])  # empty list
+            self.assertEqual([], wrp.descendants())
+            wrp.element_info._element = orig  # restore the original method
 
         def test_issue_278(self):
             """Test that statement menu = app.MainWindow.Menu works for 'uia' backend"""

--- a/pywinauto/unittests/test_win32functions.py
+++ b/pywinauto/unittests/test_win32functions.py
@@ -35,6 +35,7 @@ import unittest
 
 import sys
 sys.path.append(".")
+from pywinauto.win32structures import POINT
 from pywinauto.win32functions import MakeLong, HiWord, LoWord
 
 
@@ -81,7 +82,6 @@ class Win32FunctionsTestCases(unittest.TestCase):
         "Make sure MakeLong() function works with big numders in 2 words"
         self.assertEquals(0xffffffff, MakeLong(0xffff, 0xffff))
 
-
     def testLowWord_zero(self):
         self.assertEquals(0, LoWord(0))
 
@@ -93,7 +93,6 @@ class Win32FunctionsTestCases(unittest.TestCase):
 
     def testLowWord_vbig(self):
         self.assertEquals(0xffff, LoWord(MakeLong(0xffff, 0xffff)))
-
 
     def testHiWord_zero(self):
         self.assertEquals(0, HiWord(0))
@@ -109,6 +108,20 @@ class Win32FunctionsTestCases(unittest.TestCase):
 
     def testHiWord_vbig(self):
         self.assertEquals(0xffff, HiWord(MakeLong(0xffff, 0xffff)))
+
+    def testPOINTindexation(self):
+        p = POINT(1, 2)
+        self.assertEqual(p[0], p.x)
+        self.assertEqual(p[1], p.y)
+        self.assertEqual(p[-2], p.x)
+        self.assertEqual(p[-1], p.y)
+        self.assertRaises(IndexError, lambda: p[2])
+        self.assertRaises(IndexError, lambda: p[-3])
+
+    def testPOINTiteration(self):
+        p = POINT(1, 2)
+        self.assertEquals([1, 2], [i for i in p])
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -159,6 +159,21 @@ class POINT(Structure):
         ('x', LONG),
         ('y', LONG),
     ]
+
+    def __iter__(self):
+        """Allow iteration through coordinates"""
+        yield self.x
+        yield self.y
+
+    def __getitem__(self, key):
+        """Allow indexing of coordinates"""
+        if key == 0:
+            return self.x
+        elif key == 1:
+            return self.y
+        else:
+            raise IndexError("Illegal index")
+
 assert sizeof(POINT) == 8, sizeof(POINT)
 assert alignment(POINT) == 4, alignment(POINT)
 

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -167,9 +167,9 @@ class POINT(Structure):
 
     def __getitem__(self, key):
         """Allow indexing of coordinates"""
-        if key == 0:
+        if key == 0 or key == -2:
             return self.x
-        elif key == 1:
+        elif key == 1 or key == -1:
             return self.y
         else:
             raise IndexError("Illegal index")


### PR DESCRIPTION
BaseWrapper.click_input: print log before performing the click. Since the the clicked item can disapper after the click we try to retrieve the item's properties and build the log message prior to executing the click action.

Handle silently COMErrors in UIAElementInfo._get_elements(). This is an attempt to fix the issue #296 - return an empty list if COM error has been raised while retrieving the elements with FindAll() COM call

hwndwrapper._perform_click - cache control properties used by log before click