### PR TITLE
get_value() for EditWrapper

### DIFF
--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -250,6 +250,11 @@ class EditWrapper(uiawrapper.UIAWrapper):
             raise IndexError("There are only {0} lines but given index is {1}".format(self.line_count(), line_index))
 
     # -----------------------------------------------------------
+    def get_value(self):
+        """Return the current value of the element"""
+        return self.iface_value.CurrentValue
+
+    # -----------------------------------------------------------
     def texts(self):
         """Get the text of the edit control"""
         texts = [self.window_text(), ]

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -654,6 +654,13 @@ if UIA_support:
 
             self.assertEqual(self.edit.get_line(0), test_data)
 
+        def test_get_value(self):
+            """Test getting value of the edit control"""
+            test_data = "Some value"
+            self.edit.set_edit_text(test_data)
+
+            self.assertEqual(self.edit.get_value(), test_data)
+
         def test_text_block(self):
             """Test getting the text block of the edit control"""
             test_data = "Here is some text"


### PR DESCRIPTION
window text() or texts() doesn't always return text in the "edit" element, this is one more way to get it