### PR TITLE
MTA mode for COM client

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -34,9 +34,21 @@
 
 __version__ = "0.6.3"
 
-import sys
+import sys  # noqa: E402
 
 if sys.platform == 'win32':
+    # Set up COM client MTA mode as early as possible as it affects not only
+    # the optional comtypes package we use, but pywin32.pythoncom module as well.
+    sys.coinit_flags = 0   # COINIT_MULTITHREADED = 0x0
+
+    # Also try to un-initialze pythoncom if it's already been loaded.
+    # However, importing only pythoncom can fail with the errors like:
+    #     ImportError: No system module 'pywintypes' (pywintypes27.dll)
+    # So try to facilitate pywintypes*.dll loading with implicit import of win32api
+    import win32api  # noqa: E402
+    import pythoncom  # noqa: E402
+    pythoncom.CoUninitialize()
+
     from . import findwindows
     WindowAmbiguousError = findwindows.WindowAmbiguousError
     ElementNotFoundError = findwindows.ElementNotFoundError
@@ -51,7 +63,6 @@ if sys.platform == 'win32':
     MatchError = findbestmatch.MatchError
 
     from .application import Application, WindowSpecification
-
 
     class Desktop(object):
 

--- a/pywinauto/sysinfo.py
+++ b/pywinauto/sysinfo.py
@@ -31,10 +31,6 @@
 
 """Simple module for checking whether Python and Windows are 32-bit or 64-bit"""
 import sys
-if sys.platform == 'win32':
-    # Set up COM client MTA mode as early as possible as it affects not only
-    # an optional comtypes package but the standart pythoncom module as well.
-    sys.coinit_flags = 0   # COINIT_MULTITHREADED = 0x0
 import os  # noqa: E402
 import platform  # noqa: E402
 import ctypes  # noqa: E402

--- a/pywinauto/sysinfo.py
+++ b/pywinauto/sysinfo.py
@@ -30,17 +30,22 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 """Simple module for checking whether Python and Windows are 32-bit or 64-bit"""
-import os
 import sys
-import platform
-import ctypes
-import logging
+if sys.platform == 'win32':
+    # Set up COM client MTA mode as early as possible as it affects not only
+    # an optional comtypes package but the standart pythoncom module as well.
+    sys.coinit_flags = 0   # COINIT_MULTITHREADED = 0x0
+import os  # noqa: E402
+import platform  # noqa: E402
+import ctypes  # noqa: E402
+import logging  # noqa: E402
+
 
 try:
     # Disable 'INFO' logs from comtypes
     log = logging.getLogger('comtypes')
     log.setLevel('WARNING')
-    import comtypes
+    import comtypes  # noqa: E402
     UIA_support = True
 except ImportError:
     UIA_support = False

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -136,6 +136,11 @@ class ApplicationWarningTestCases(unittest.TestCase):
             return
 
         app = Application().start(self.sample_exe_inverted_bitness)
+        app.kill_()
+        if not app.is_process_running():
+            # Appveyor misteries...
+            app.actions.log("App process does not run (crashed ?). Try launch again.")
+            app = Application().start(self.sample_exe_inverted_bitness)
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -139,15 +139,13 @@ class ApplicationWarningTestCases(unittest.TestCase):
         # Appveyor misteries...
         self.assertEqual(app.is_process_running(), True)
 
-        # Make sure the filter is the first in the list
-        warnings.filterwarnings('always', category=UserWarning, append=False)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with mock.patch("warnings.warn") as mockWarn:
             Application().connect(process=app.process)
             app.kill_()
-            assert len(w) >= 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "64-bit" in str(w[-1].message)
+            args, kw = mockWarn.call_args
+            assert len(args) == 2
+            assert "64-bit" in args[0]
+            assert args[1].__name__ == 'UserWarning'
 
 
 class ApplicationTestCases(unittest.TestCase):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -135,12 +135,12 @@ class ApplicationWarningTestCases(unittest.TestCase):
             self.defaultTestResult()
             return
 
-        app = Application().start(self.sample_exe_inverted_bitness)
-        # Appveyor misteries...
-        self.assertEqual(app.is_process_running(), True)
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
+            app = Application().start(self.sample_exe_inverted_bitness)
+            # Appveyor misteries...
+            self.assertEqual(app.is_process_running(), True)
             Application().connect(process=app.process)
             app.kill_()
             assert len(w) >= 1

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -143,9 +143,9 @@ class ApplicationWarningTestCases(unittest.TestCase):
             self.assertEqual(app.is_process_running(), True)
             Application().connect(process=app.process)
             app.kill_()
-            assert len(w) >= 2
-            assert issubclass(w[-1].category, UserWarning)
-            assert "64-bit" in str(w[-1].message)
+        assert len(w) >= 2
+        assert issubclass(w[-1].category, UserWarning)
+        assert "64-bit" in str(w[-1].message)
 
 
 class ApplicationTestCases(unittest.TestCase):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -143,7 +143,7 @@ class ApplicationWarningTestCases(unittest.TestCase):
             self.assertEqual(app.is_process_running(), True)
             Application().connect(process=app.process)
             app.kill_()
-            assert len(w) >= 1
+            assert len(w) >= 2
             assert issubclass(w[-1].category, UserWarning)
             assert "64-bit" in str(w[-1].message)
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -136,16 +136,12 @@ class ApplicationWarningTestCases(unittest.TestCase):
             return
 
         app = Application().start(self.sample_exe_inverted_bitness)
-        attempt = 0
-        while not app.is_process_running() and attempt < 4:
-            # Appveyor misteries...
-            app.actions.log("App process does not run (crashed ?). Try launch again.")
-            app = Application().start(self.sample_exe_inverted_bitness)
-            attempt += 1
+        # Appveyor misteries...
+        self.assertEqual(app.is_process_running(), True)
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            Application().connect(path=self.sample_exe_inverted_bitness)
+            Application().connect(process=app.process)
             app.kill_()
             assert len(w) >= 1
             assert issubclass(w[-1].category, UserWarning)

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -136,11 +136,12 @@ class ApplicationWarningTestCases(unittest.TestCase):
             return
 
         app = Application().start(self.sample_exe_inverted_bitness)
-        app.kill_()
-        if not app.is_process_running():
+        attempt = 0
+        while not app.is_process_running() and attempt < 4:
             # Appveyor misteries...
             app.actions.log("App process does not run (crashed ?). Try launch again.")
             app = Application().start(self.sample_exe_inverted_bitness)
+            attempt += 1
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -135,17 +135,19 @@ class ApplicationWarningTestCases(unittest.TestCase):
             self.defaultTestResult()
             return
 
-        warnings.filterwarnings('always', category=UserWarning, append=True)
+        app = Application().start(self.sample_exe_inverted_bitness)
+        # Appveyor misteries...
+        self.assertEqual(app.is_process_running(), True)
+
+        # Make sure the filter is the first in the list
+        warnings.filterwarnings('always', category=UserWarning, append=False)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            app = Application().start(self.sample_exe_inverted_bitness)
-            # Appveyor misteries...
-            self.assertEqual(app.is_process_running(), True)
             Application().connect(process=app.process)
             app.kill_()
-        assert len(w) >= 2
-        assert issubclass(w[-1].category, UserWarning)
-        assert "64-bit" in str(w[-1].message)
+            assert len(w) >= 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "64-bit" in str(w[-1].message)
 
 
 class ApplicationTestCases(unittest.TestCase):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -2,15 +2,20 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import time
-import os
 import sys
-import unittest
-import mock
-import six
-
 sys.path.append(".")
+# We want to import pywinauto as early as possible. This is
+# to apply identical settings on all affected modules.
+# The global var: sys.coinit_flags is customized in pywinauto.sysinfo
+# and affects the behavior of pythoncom and comtypes
 from pywinauto.application import Application, WindowSpecification  # noqa: E402
+
+import time  # noqa: E402
+import os  # noqa: E402
+import unittest  # noqa: E402
+import mock  # noqa: E402
+import six  # noqa: E402
+
 from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
 from pywinauto.timings import Timings  # noqa: E402
 from pywinauto.actionlogger import ActionLogger  # noqa: E402

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -2,20 +2,15 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
+import time
+import os
 import sys
+import unittest
+import mock
+import six
+
 sys.path.append(".")
-# We want to import pywinauto as early as possible. This is
-# to apply identical settings on all affected modules.
-# The global var: sys.coinit_flags is customized in pywinauto.sysinfo
-# and affects the behavior of pythoncom and comtypes
 from pywinauto.application import Application, WindowSpecification  # noqa: E402
-
-import time  # noqa: E402
-import os  # noqa: E402
-import unittest  # noqa: E402
-import mock  # noqa: E402
-import six  # noqa: E402
-
 from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
 from pywinauto.timings import Timings  # noqa: E402
 from pywinauto.actionlogger import ActionLogger  # noqa: E402


### PR DESCRIPTION
* Switch on COM client's MTA mode by default - this is to allow using 'UIA' backend from different threads. Fixes #394
* Stabilize ApplicationWarningTestCases.testConnectWarning3264: 
    - use PID to connect to the running app instead of path
    - mock warnings module to overcome Py3.3 constant failures

PS: this PR should be "squashed-and-merged" as there are too many commits with my attempts to fix testConnectWarning3264