### PR TITLE
 uia_element_info: on error return empty string for name and class_name

### DIFF
--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -474,12 +474,7 @@ def build_unique_dict(controls):
 
         # for each of the names
         for name in ctrl_names:
-            if name:
-                name_control_map[name] = ctrl
-            else:
-                from .actionlogger import ActionLogger
-                ActionLogger().log('Warning! Cannot get a name from: {0}'.format(ctrl_names))
-
+            name_control_map[name] = ctrl
     return name_control_map
 
 

--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -474,7 +474,12 @@ def build_unique_dict(controls):
 
         # for each of the names
         for name in ctrl_names:
-            name_control_map[name] = ctrl
+            if name:
+                name_control_map[name] = ctrl
+            else:
+                from .actionlogger import ActionLogger
+                ActionLogger().log('Warning! Cannot get a name from: {0}'.format(ctrl_names))
+
     return name_control_map
 
 

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -32,7 +32,7 @@
 """Implementation of the class to deal with an UI element (based on UI Automation API)"""
 
 from comtypes import COMError
-from six import integer_types
+from six import integer_types, text_type
 
 from .uia_defines import IUIA
 from .uia_defines import get_elem_interface
@@ -83,7 +83,7 @@ class UIAElementInfo(ElementInfo):
         try:
             return self._element.CurrentClassName
         except COMError:
-            return None # probably element already doesn't exist
+            return text_type('')  # probably element already doesn't exist
 
     def _get_cached_class_name(self):
         """Return a cached class name of the element"""
@@ -122,7 +122,7 @@ class UIAElementInfo(ElementInfo):
         try:
             return self._element.CurrentName
         except COMError:
-            return None # probably element already doesn't exist
+            return text_type('')  # probably element already doesn't exist
 
     def _get_cached_name(self):
         """Return a cached name of the element"""

--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -81,7 +81,8 @@ class UIAElementInfo(ElementInfo):
     def _get_current_class_name(self):
         """Return an actual class name of the element"""
         try:
-            return self._element.CurrentClassName
+            cn = self._element.CurrentClassName
+            return text_type('') if cn is None else cn
         except COMError:
             return text_type('')  # probably element already doesn't exist
 
@@ -120,7 +121,8 @@ class UIAElementInfo(ElementInfo):
     def _get_current_name(self):
         """Return an actual name of the element"""
         try:
-            return self._element.CurrentName
+            n = self._element.CurrentName
+            return text_type('') if n is None else n
         except COMError:
             return text_type('')  # probably element already doesn't exist
 


### PR DESCRIPTION
This is for consistency with ```win32_element_info``` returning strings on errors and to prevent building ```UniqueDict``` as ```{ None: ctrl }``` when dealing with disappearing controls, like in this example:
```
Traceback (most recent call last):
  File "c:\python27-x64\lib\unittest\case.py", line 358, in run
    self.tearDown()
  File "C:\projects\pywinauto\pywinauto\unittests\test_application.py", line 1123, in tearDown
    self.desktop.MFC_samplesDialog.wait_not('visible')
  File "C:\projects\pywinauto\pywinauto\application.py", line 538, in wait_not
    lambda: not self.__check_all_conditions(check_method_names, retry_interval))
  File "C:\projects\pywinauto\pywinauto\timings.py", line 349, in wait_until
    func_val = func(*args)
  File "C:\projects\pywinauto\pywinauto\application.py", line 538, in <lambda>
    lambda: not self.__check_all_conditions(check_method_names, retry_interval))
  File "C:\projects\pywinauto\pywinauto\application.py", line 453, in __check_all_conditions
    ctrls = self.__resolve_control(self.criteria, retry_interval, float(retry_interval) // 2)
  File "C:\projects\pywinauto\pywinauto\application.py", line 245, in __resolve_control
    criteria)
  File "C:\projects\pywinauto\pywinauto\timings.py", line 425, in wait_until_passes
    func_val = func(*args)
  File "C:\projects\pywinauto\pywinauto\application.py", line 190, in __get_ctrl
    dialog = self.backend.generic_wrapper_class(findwindows.find_element(**criteria[0]))
  File "C:\projects\pywinauto\pywinauto\findwindows.py", line 84, in find_element
    elements = find_elements(**kwargs)
  File "C:\projects\pywinauto\pywinauto\findwindows.py", line 300, in find_elements
    elements = findbestmatch.find_best_control_matches(best_match, wrapped_elems)
  File "C:\projects\pywinauto\pywinauto\findbestmatch.py", line 507, in find_best_control_matches
    best_ratio, best_texts = name_control_map.find_best_matches(search_text)
  File "C:\projects\pywinauto\pywinauto\findbestmatch.py", line 419, in find_best_matches
    ratio_calc.set_seq2(text)
  File "c:\python27-x64\lib\difflib.py", line 285, in set_seq2
    self.__chain_b()
  File "c:\python27-x64\lib\difflib.py", line 318, in __chain_b
    for i, elt in enumerate(b):
TypeError: 'NoneType' object is not iterable
```