### PR TITLE
Get AutomationID for Win32 backend

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,9 +55,9 @@ before_script:
   - cd $TRAVIS_BUILD_DIR
 
 script:
-  - coverage run -a --source=pywinauto/mouse.py pywinauto/unittests/test_mouse.py
-  - coverage run -a --source=pywinauto/linux/keyboard.py pywinauto/unittests/test_keyboard.py
-  - coverage run -a --source=pywinauto/linux/clipboard.py pywinauto/unittests/test_clipboard_linux.py
+  - coverage run -a --include=pywinauto/mouse.py pywinauto/unittests/test_mouse.py
+  - coverage run -a --include=pywinauto/linux/keyboard.py pywinauto/unittests/test_keyboard.py
+  - coverage run -a --include=pywinauto/linux/clipboard.py pywinauto/unittests/test_clipboard_linux.py
 
 after_success:
   - codecov

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,26 +31,6 @@ environment:
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "NO"
 
-    - PYTHON: "C:\\Python33"
-      PYTHON_VERSION: "3.3"
-      PYTHON_ARCH: "32"
-      UIA_SUPPORT: "YES"
-
-    - PYTHON: "C:\\Python33-x64"
-      PYTHON_VERSION: "3.3"
-      PYTHON_ARCH: "64"
-      UIA_SUPPORT: "NO"
-
-    - PYTHON: "C:\\Python34"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "32"
-      UIA_SUPPORT: "NO"
-
-    - PYTHON: "C:\\Python34-x64"
-      PYTHON_VERSION: "3.4"
-      PYTHON_ARCH: "64"
-      UIA_SUPPORT: "YES"
-
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
@@ -68,6 +48,16 @@ environment:
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
+      PYTHON_ARCH: "64"
+      UIA_SUPPORT: "YES"
+
+    - PYTHON: "C:\\Python37"
+      PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "32"
+      UIA_SUPPORT: "NO"
+
+    - PYTHON: "C:\\Python37-x64"
+      PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -5,6 +5,6 @@ coverage
 nose
 codecov
 rst2pdf
-Sphinx
+Sphinx==1.7.1
 mock==2.0.0
 codacy-coverage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,10 +1,10 @@
-pypiwin32
+pywin32
 six
 Pillow==4.0.0
 coverage
 nose
 codecov
 rst2pdf
-Sphinx==1.7.1
+Sphinx
 mock==2.0.0
 codacy-coverage

--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -32,7 +32,7 @@
 
 """Python package for automating GUI manipulation on Windows"""
 
-__version__ = "0.6.4"
+__version__ = "0.6.5"
 
 import sys  # noqa: E402
 import warnings  # noqa: E402

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -632,7 +632,10 @@ class WindowSpecification(object):
                     auto_id = ctrl.element_info.automation_id
                 if hasattr(ctrl.element_info, 'control_type'):
                     control_type = ctrl.element_info.control_type
-                    class_name = None  # no need for class_name if control_type exists
+                    if control_type:
+                        class_name = None  # no need for class_name if control_type exists
+                    else:
+                        control_type = None # if control_type is empty, still use class_name instead
                 criteria_texts = []
                 if title:
                     criteria_texts.append(u'title="{}"'.format(title))

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -262,20 +262,7 @@ class HwndWrapper(BaseWrapper):
     #------------------------------------------------------------
     def full_control_type(self):
         """Return the .NET type of the control (full, uncut)"""
-        textval = ''
-
-        length = 1024
-        remote_mem = RemoteMemoryBlock(self, size=length*2)
-
-        ret = win32gui.SendMessage(self.handle, self.element_info.wm_get_ctrl_type, length, remote_mem.mem_address)
-
-        if ret:
-            text = ctypes.create_unicode_buffer(length)
-            remote_mem.Read(text)
-            textval = text.value
-
-        del remote_mem
-        return textval
+        return self.element_info.full_control_type
 
     # -----------------------------------------------------------
     def user_data(self):

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -253,6 +253,11 @@ class HwndWrapper(BaseWrapper):
         """Return the .NET name of the control"""
         return self.element_info.automation_id
 
+    #------------------------------------------------------------
+    def control_type(self):
+        """Return the .NET name of the control"""
+        return self.element_info.control_type
+
     # -----------------------------------------------------------
     def user_data(self):
         """

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -65,6 +65,7 @@ from .. import timings
 from .. import handleprops
 from ..win32_element_info import HwndElementInfo
 from .. import backend
+from ..remote_memory_block import RemoteMemoryBlock
 
 # I leave this optional because PIL is a large dependency
 try:
@@ -257,6 +258,24 @@ class HwndWrapper(BaseWrapper):
     def control_type(self):
         """Return the .NET name of the control"""
         return self.element_info.control_type
+
+    #------------------------------------------------------------
+    def full_control_type(self):
+        """Return the .NET type of the control"""
+        textval = ''
+
+        length = 1024
+        remote_mem = RemoteMemoryBlock(self, size=length*2)
+
+        ret = win32gui.SendMessage(self.handle, self.element_info.wm_get_ctrl_type, length, remote_mem.mem_address)
+
+        if ret:
+            text = ctypes.create_unicode_buffer(length)
+            remote_mem.Read(text)
+            textval = text.value
+
+        del remote_mem
+        return textval
 
     # -----------------------------------------------------------
     def user_data(self):

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -256,12 +256,12 @@ class HwndWrapper(BaseWrapper):
 
     #------------------------------------------------------------
     def control_type(self):
-        """Return the .NET name of the control"""
+        """Return the .NET type of the control"""
         return self.element_info.control_type
 
     #------------------------------------------------------------
     def full_control_type(self):
-        """Return the .NET type of the control"""
+        """Return the .NET type of the control (full, uncut)"""
         textval = ''
 
         length = 1024

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -446,11 +446,11 @@ class HwndWrapper(BaseWrapper):
         """Send a message to the control and wait for it to return"""
         #return win32functions.SendMessage(self, message, wparam, lparam)
         wParamAddress = wparam
-        if hasattr(wparam, 'memAddress'):
-            wParamAddress = wparam.memAddress
+        if hasattr(wparam, 'mem_address'):
+            wParamAddress = wparam.mem_address
         lParamAddress = lparam
-        if hasattr(lparam, 'memAddress'):
-            lParamAddress = lparam.memAddress
+        if hasattr(lparam, 'mem_address'):
+            lParamAddress = lparam.mem_address
 
         CArgObject = type(ctypes.byref(ctypes.c_int(0)))
         if isinstance(wparam, CArgObject):

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -171,7 +171,6 @@ class HwndWrapper(BaseWrapper):
     C function - and it will get converted to a Long with the value of
     it's handle (see ctypes, _as_parameter_).
     """
-
     handle = None
 
     # -----------------------------------------------------------
@@ -215,6 +214,7 @@ class HwndWrapper(BaseWrapper):
                       'client_rects',
                       'is_unicode',
                       'menu_items',
+                      'automation_id',
                       ])
         return props
 
@@ -247,6 +247,11 @@ class HwndWrapper(BaseWrapper):
         return handleprops.exstyle(self)
     # Non PEP-8 alias
     ExStyle = exstyle
+
+    #------------------------------------------------------------
+    def automation_id(self):
+        """Return the .NET name of the control"""
+        return self.element_info.automation_id
 
     # -----------------------------------------------------------
     def user_data(self):

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -65,7 +65,6 @@ from .. import timings
 from .. import handleprops
 from ..win32_element_info import HwndElementInfo
 from .. import backend
-from ..remote_memory_block import RemoteMemoryBlock
 
 # I leave this optional because PIL is a large dependency
 try:

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -341,6 +341,7 @@ class UIAWrapper(BaseWrapper):
         props = super(UIAWrapper, self).writable_props
         props.extend(['is_keyboard_focusable',
                       'has_keyboard_focus',
+                      'automation_id',
                       ])
         return props
 
@@ -380,6 +381,11 @@ class UIAWrapper(BaseWrapper):
                 else:
                     self.friendlyclassname = _friendly_classes[ctrl_type]
         return self.friendlyclassname
+
+    #------------------------------------------------------------
+    def automation_id(self):
+        """Return the Automation ID of the control"""
+        return self.element_info.automation_id
 
     # -----------------------------------------------------------
     def is_keyboard_focusable(self):

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -171,7 +171,6 @@ def find_elements(class_name=None,
     * **framework_id**   Elements with this framework id (for UIAutomation elements)
     * **backend**        Back-end name to use while searching (default=None means current active backend)
     """
-
     if backend is None:
         backend = registry.active_backend.name
     backend_obj = registry.backends[backend]
@@ -220,6 +219,10 @@ def find_elements(class_name=None,
 
     # early stop
     if not elements:
+        if found_index is not None:
+            if found_index > 0:
+                raise ElementNotFoundError("found_index is specified as {0}, but no windows found".format(
+                    found_index))
         return elements
 
     if framework_id is not None and elements:

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -104,7 +104,7 @@ def dotnetname(ctrl):
         remote_mem = RemoteMemoryBlock(ctrl, size=length)
 
         ret = win32functions.SendMessage(
-            ctrl.handle, wm_gcn, length, remote_mem)
+            ctrl.handle, wm_gcn, length, remote_mem.memAddress)
 
         if ret:
             text = ctypes.create_unicode_buffer(length)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -139,6 +139,10 @@ def control_type(ctrl):
     else:
         raise Exception("Cannot register WM_GETCONTROLTYPE")
 
+    # simplify control type for WinForms controls
+    if "PublicKeyToken" in textval:
+        textval = textval.split(", ")[0]
+
     return textval
 
 

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -40,13 +40,11 @@ import win32process
 import win32api
 import win32con
 import win32gui
-import six
 
 from . import win32functions
 from . import win32defines
 from . import win32structures
 from .actionlogger import ActionLogger
-from .remote_memory_block import RemoteMemoryBlock
 
 
 #=========================================================================
@@ -90,58 +88,6 @@ def text(handle):
 
         if ret:
             textval = buffer_.value
-
-    return textval
-
-
-#=========================================================================
-def automation_id(ctrl):
-    """Return the automation ID property of the control"""
-    textval = ''
-
-    wm_gcn = win32functions.RegisterWindowMessage(six.text_type('WM_GETCONTROLNAME'))
-    if wm_gcn > 0:
-        length = 1024
-        remote_mem = RemoteMemoryBlock(ctrl, size=length*2)
-
-        ret = win32gui.SendMessage(ctrl.handle, wm_gcn, length, remote_mem.mem_address)
-
-        if ret:
-            text = ctypes.create_unicode_buffer(length)
-            remote_mem.Read(text)
-            textval = text.value
-
-        del remote_mem
-    else:
-        raise Exception("Cannot register WM_GETCONTROLNAME")
-
-    return textval
-
-
-#=========================================================================
-def control_type(ctrl):
-    """Return the control type property of the control"""
-    textval = ''
-
-    wm_gcn = win32functions.RegisterWindowMessage(six.text_type('WM_GETCONTROLTYPE'))
-    if wm_gcn > 0:
-        length = 1024
-        remote_mem = RemoteMemoryBlock(ctrl, size=length*2)
-
-        ret = win32gui.SendMessage(ctrl.handle, wm_gcn, length, remote_mem.mem_address)
-
-        if ret:
-            text = ctypes.create_unicode_buffer(length)
-            remote_mem.Read(text)
-            textval = text.value
-
-        del remote_mem
-    else:
-        raise Exception("Cannot register WM_GETCONTROLTYPE")
-
-    # simplify control type for WinForms controls
-    if "PublicKeyToken" in textval:
-        textval = textval.split(", ")[0]
 
     return textval
 

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -39,7 +39,6 @@ import ctypes
 import win32process
 import win32api
 import win32con
-import win32gui
 
 from . import win32functions
 from . import win32defines

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -93,7 +93,7 @@ def text(handle):
 
 
 #=========================================================================
-def dotnetname(handle):
+def dotnetname(ctrl):
     """Return the .NET name of the control"""
     textval = ''
 
@@ -101,10 +101,10 @@ def dotnetname(handle):
     if wm_gcn > 0:
         length = 1024
 
-        remote_mem = RemoteMemoryBlock(handle, size=length)
+        remote_mem = RemoteMemoryBlock(ctrl, size=length)
 
         ret = win32functions.SendMessage(
-            handle, wm_gcn, length, remote_mem)
+            ctrl.handle, wm_gcn, length, remote_mem)
 
         if ret:
             text = ctypes.create_unicode_buffer(length)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -40,6 +40,7 @@ import win32process
 import win32api
 import win32con
 import win32gui
+import six
 
 from . import win32functions
 from . import win32defines
@@ -94,11 +95,11 @@ def text(handle):
 
 
 #=========================================================================
-def dotnetname(ctrl):
-    """Return the .NET name of the control"""
+def automation_id(ctrl):
+    """Return the automation ID property of the control"""
     textval = ''
 
-    wm_gcn = win32functions.RegisterWindowMessage('WM_GETCONTROLNAME')
+    wm_gcn = win32functions.RegisterWindowMessage(six.text_type('WM_GETCONTROLNAME'))
     if wm_gcn > 0:
         length = 1024
         remote_mem = RemoteMemoryBlock(ctrl, size=length*2)
@@ -111,6 +112,32 @@ def dotnetname(ctrl):
             textval = text.value
 
         del remote_mem
+    else:
+        raise Exception("Cannot register WM_GETCONTROLNAME")
+
+    return textval
+
+
+#=========================================================================
+def control_type(ctrl):
+    """Return the control type property of the control"""
+    textval = ''
+
+    wm_gcn = win32functions.RegisterWindowMessage(six.text_type('WM_GETCONTROLTYPE'))
+    if wm_gcn > 0:
+        length = 1024
+        remote_mem = RemoteMemoryBlock(ctrl, size=length*2)
+
+        ret = win32gui.SendMessage(ctrl.handle, wm_gcn, length, remote_mem.mem_address)
+
+        if ret:
+            text = ctypes.create_unicode_buffer(length)
+            remote_mem.Read(text)
+            textval = text.value
+
+        del remote_mem
+    else:
+        raise Exception("Cannot register WM_GETCONTROLTYPE")
 
     return textval
 

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -39,6 +39,7 @@ import ctypes
 import win32process
 import win32api
 import win32con
+import win32gui
 
 from . import win32functions
 from . import win32defines
@@ -100,11 +101,9 @@ def dotnetname(ctrl):
     wm_gcn = win32functions.RegisterWindowMessage('WM_GETCONTROLNAME')
     if wm_gcn > 0:
         length = 1024
+        remote_mem = RemoteMemoryBlock(ctrl, size=length*2)
 
-        remote_mem = RemoteMemoryBlock(ctrl, size=length)
-
-        ret = win32functions.SendMessage(
-            ctrl.handle, wm_gcn, length, remote_mem.memAddress)
+        ret = win32gui.SendMessage(ctrl.handle, wm_gcn, length, remote_mem.mem_address)
 
         if ret:
             text = ctypes.create_unicode_buffer(length)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -44,6 +44,7 @@ from . import win32functions
 from . import win32defines
 from . import win32structures
 from .actionlogger import ActionLogger
+from .remote_memory_block import RemoteMemoryBlock
 
 
 #=========================================================================
@@ -87,6 +88,30 @@ def text(handle):
 
         if ret:
             textval = buffer_.value
+
+    return textval
+
+
+#=========================================================================
+def dotnetname(handle):
+    """Return the .NET name of the control"""
+    textval = ''
+
+    wm_gcn = win32functions.RegisterWindowMessage('WM_GETCONTROLNAME')
+    if wm_gcn > 0:
+        length = 1024
+
+        remote_mem = RemoteMemoryBlock(handle, size=length)
+
+        ret = win32functions.SendMessage(
+            handle, wm_gcn, length, remote_mem)
+
+        if ret:
+            text = ctypes.create_unicode_buffer(length)
+            remote_mem.Read(text)
+            textval = text.value
+
+        del remote_mem
 
     return textval
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -1011,7 +1011,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
                 content = str(test_log_file.readlines())
                 self.assertTrue("'Untitled - NotepadEdit'" in content
                     and "'Edit'" in content)
-                self.assertTrue("child_window(class_name=\"msctls_statusbar32\")" in content)
+                self.assertTrue("child_window(class_name=\"msctls_statusbar32\"" in content)
             os.remove(output_filename)
         else:
             self.fail("print_control_identifiers can't create a file")

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -539,9 +539,15 @@ class ListViewWinFormTestCases32(unittest.TestCase):
     def test_win32_control_type(self):
         list_view = self.dlg.child_window(control_type="ListViewEx.ListViewEx").wait('visible')
         self.assertEqual(list_view.control_type(), "ListViewEx.ListViewEx")
+        self.assertEqual(list_view.full_control_type(),
+                         "ListViewEx.ListViewEx, ListViewEx, Version=1.0.6520.42612, " \
+                         "Culture=neutral, PublicKeyToken=null")
 
         check_box = self.dlg.child_window(control_type="System.Windows.Forms.CheckBox").wait('visible')
         self.assertEqual(check_box.control_type(), "System.Windows.Forms.CheckBox")
+        self.assertEqual(check_box.full_control_type(),
+                         "System.Windows.Forms.CheckBox, System.Windows.Forms, " \
+                         "Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089")
 
 if is_x64_Python():
 

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -527,13 +527,13 @@ class ListViewWinFormTestCases32(unittest.TestCase):
         self.assertTrue('In-place-edit control "Edit"' in str(context.exception))
 
     def test_automation_id_by_win32(self):
-        list_view = self.dlg.child_window(auto_id="listViewEx1").wait('visible', timeout=20)
+        list_view = self.dlg.child_window(auto_id="listViewEx1").wait('visible', timeout=50)
         self.assertEqual(list_view.automation_id(), "listViewEx1")
-        
-        check_box = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation").wait('visible', timeout=20)
+
+        check_box = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation").wait('visible', timeout=50)
         self.assertEqual(check_box.automation_id(), "checkBoxDoubleClickActivation")
-        
-        check_box = self.dlg.checkBoxDoubleClickActivation.wait('visible', timeout=20)
+
+        check_box = self.dlg.checkBoxDoubleClickActivation.wait('visible', timeout=50)
         self.assertEqual(check_box.automation_id(), "checkBoxDoubleClickActivation")
 
 if is_x64_Python():

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -527,14 +527,21 @@ class ListViewWinFormTestCases32(unittest.TestCase):
         self.assertTrue('In-place-edit control "Edit"' in str(context.exception))
 
     def test_automation_id_by_win32(self):
-        list_view = self.dlg.child_window(auto_id="listViewEx1").wait('visible', timeout=50)
+        list_view = self.dlg.child_window(auto_id="listViewEx1").wait('visible')
         self.assertEqual(list_view.automation_id(), "listViewEx1")
 
-        check_box = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation").wait('visible', timeout=50)
+        check_box = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation").wait('visible')
         self.assertEqual(check_box.automation_id(), "checkBoxDoubleClickActivation")
 
-        check_box = self.dlg.checkBoxDoubleClickActivation.wait('visible', timeout=50)
+        check_box = self.dlg.checkBoxDoubleClickActivation.wait('visible')
         self.assertEqual(check_box.automation_id(), "checkBoxDoubleClickActivation")
+
+    def test_win32_control_type(self):
+        list_view = self.dlg.child_window(control_type="ListViewEx.ListViewEx").wait('visible')
+        self.assertEqual(list_view.control_type(), "ListViewEx.ListViewEx")
+
+        check_box = self.dlg.child_window(control_type="System.Windows.Forms.CheckBox").wait('visible')
+        self.assertEqual(check_box.control_type(), "System.Windows.Forms.CheckBox")
 
 if is_x64_Python():
 
@@ -1288,7 +1295,7 @@ class RebarTestCases(unittest.TestCase):
         """Make sure we can click on Afx ToolBar button by index"""
         Timings.closeclick_dialog_close_wait = 2.
         self.dlg.StandardToolbar.Button(1).Click()
-        self.app.Window_(title='Open').Wait('ready')
+        self.app.Window_(title='Open').Wait('ready', timeout=30)
         self.app.Window_(title='Open').Cancel.CloseClick()
 
     def testMenuBarClickInput(self):

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -526,6 +526,16 @@ class ListViewWinFormTestCases32(unittest.TestCase):
             self.ctrl.get_item(1,1).inplace_control("Edit")
         self.assertTrue('In-place-edit control "Edit"' in str(context.exception))
 
+    def test_automation_id_by_win32(self):
+        list_view_spec = self.app.ListViewEx_Demo.child_window(auto_id="listViewEx1")
+        self.assertEqual(list_view_spec.automation_id(), "listViewEx1")
+        
+        check_box_spec = self.app.ListViewEx_Demo.child_window(auto_id="checkBoxDoubleClickActivation")
+        self.assertEqual(check_box_spec.automation_id(), "checkBoxDoubleClickActivation")
+        
+        check_box_spec = self.app.ListViewEx_Demo.checkBoxDoubleClickActivation
+        self.assertEqual(check_box_spec.automation_id(), "checkBoxDoubleClickActivation")
+
 if is_x64_Python():
 
     class ListViewWinFormTestCases64(ListViewWinFormTestCases32):

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -527,14 +527,14 @@ class ListViewWinFormTestCases32(unittest.TestCase):
         self.assertTrue('In-place-edit control "Edit"' in str(context.exception))
 
     def test_automation_id_by_win32(self):
-        list_view_spec = self.dlg.child_window(auto_id="listViewEx1")
-        self.assertEqual(list_view_spec.automation_id(), "listViewEx1")
+        list_view = self.dlg.child_window(auto_id="listViewEx1").wait('visible', timeout=20)
+        self.assertEqual(list_view.automation_id(), "listViewEx1")
         
-        check_box_spec = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation")
-        self.assertEqual(check_box_spec.automation_id(), "checkBoxDoubleClickActivation")
+        check_box = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation").wait('visible', timeout=20)
+        self.assertEqual(check_box.automation_id(), "checkBoxDoubleClickActivation")
         
-        check_box_spec = self.dlg.checkBoxDoubleClickActivation
-        self.assertEqual(check_box_spec.automation_id(), "checkBoxDoubleClickActivation")
+        check_box = self.dlg.checkBoxDoubleClickActivation.wait('visible', timeout=20)
+        self.assertEqual(check_box.automation_id(), "checkBoxDoubleClickActivation")
 
 if is_x64_Python():
 

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -527,13 +527,13 @@ class ListViewWinFormTestCases32(unittest.TestCase):
         self.assertTrue('In-place-edit control "Edit"' in str(context.exception))
 
     def test_automation_id_by_win32(self):
-        list_view_spec = self.app.ListViewEx_Demo.child_window(auto_id="listViewEx1")
+        list_view_spec = self.dlg.child_window(auto_id="listViewEx1")
         self.assertEqual(list_view_spec.automation_id(), "listViewEx1")
         
-        check_box_spec = self.app.ListViewEx_Demo.child_window(auto_id="checkBoxDoubleClickActivation")
+        check_box_spec = self.dlg.child_window(auto_id="checkBoxDoubleClickActivation")
         self.assertEqual(check_box_spec.automation_id(), "checkBoxDoubleClickActivation")
         
-        check_box_spec = self.app.ListViewEx_Demo.checkBoxDoubleClickActivation
+        check_box_spec = self.dlg.checkBoxDoubleClickActivation
         self.assertEqual(check_box_spec.automation_id(), "checkBoxDoubleClickActivation")
 
 if is_x64_Python():

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -118,6 +118,13 @@ if UIA_support:
                                      title="OK").wrapper_object()
             self.assertEqual(button.control_id(), None)
 
+        def test_automation_id(self):
+            """Test getting automation ID"""
+            alpha_toolbar = self.dlg.child_window(title="Alpha", control_type="ToolBar")
+            button = alpha_toolbar.child_window(control_type="Button",
+                                                auto_id="OverflowButton").wrapper_object()
+            self.assertEqual(button.automation_id(), "OverflowButton")
+
         def test_is_visible(self):
             """Test is_visible method of a control"""
             button = self.dlg.window(class_name="Button",

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -291,6 +291,7 @@ if UIA_support:
                              'is_keyboard_focusable',
                              'has_keyboard_focus',
                              'selection_indices',
+                             'automation_id',
                              ])
             edit = self.dlg.TestLabelEdit.wrapper_object()
             props = set(edit.get_properties().keys())

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -154,4 +154,9 @@ class HwndElementInfo(ElementInfo):
     @property
     def automation_id(self):
         """Return AutomationId of the element"""
-        return handleprops.dotnetname(self)
+        return handleprops.automation_id(self)
+
+    @property
+    def control_type(self):
+        """Return ControlType property of the element"""
+        return handleprops.control_type(self)

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -154,4 +154,4 @@ class HwndElementInfo(ElementInfo):
     @property
     def automation_id(self):
         """Return AutomationId of the element"""
-        return handleprops.dotnetname(self.handle)
+        return handleprops.dotnetname(self)

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -117,9 +117,9 @@ class HwndElementInfo(ElementInfo):
 
     def children(self, **kwargs):
         """Return a list of immediate children of the window"""
-        class_name = kwargs.get('class_name')
-        title = kwargs.get('title')
-        control_type = kwargs.get('control_type')
+        class_name = kwargs.get('class_name', None)
+        title = kwargs.get('title', None)
+        control_type = kwargs.get('control_type', None)
         # TODO: 'cache_enable' and 'depth' are ignored so far
         
         # this will be filled in the callback function
@@ -130,11 +130,11 @@ class HwndElementInfo(ElementInfo):
         def enum_window_proc(hwnd, lparam):
             """Called for each window - adds wrapped elements to a list"""
             element = HwndElementInfo(hwnd)
-            if class_name and class_name != element.class_name:
+            if class_name is not None and class_name != element.class_name:
                 return True
-            if title and title != element.rich_text:
+            if title is not None and title != element.rich_text:
                 return True
-            if control_type and control_type != element.control_type:
+            if control_type is not None and control_type != element.control_type:
                 return True
             child_elements.append(element)
             return True
@@ -157,11 +157,16 @@ class HwndElementInfo(ElementInfo):
 
     def descendants(self, **kwargs):
         """Return descendants of the window (all children from sub-tree)"""
-        child_elements = self.children(**kwargs)
+        if self == HwndElementInfo(): # root
+            top_elements = self.children()
+            child_elements = self.children(**kwargs)
+            for child in top_elements:
+                child_elements.extend(child.children(**kwargs))
+        else:
+            child_elements = self.children(**kwargs)
         depth = kwargs.pop('depth', None)
 
         child_elements = ElementInfo.filter_with_depth(child_elements, self, depth)
-
         return child_elements
 
     @property

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -121,7 +121,7 @@ class HwndElementInfo(ElementInfo):
         title = kwargs.get('title', None)
         control_type = kwargs.get('control_type', None)
         # TODO: 'cache_enable' and 'depth' are ignored so far
-        
+
         # this will be filled in the callback function
         child_elements = []
 

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -32,6 +32,7 @@
 """Implementation of the class to deal with a native element (window with a handle)"""
 
 import ctypes
+from ctypes import wintypes
 
 import six
 import win32gui
@@ -140,8 +141,7 @@ class HwndElementInfo(ElementInfo):
             return True
 
         # define the type of the child procedure
-        enum_win_proc_t = ctypes.WINFUNCTYPE(
-            ctypes.c_int, ctypes.c_long, ctypes.c_long)
+        enum_win_proc_t = ctypes.WINFUNCTYPE(wintypes.BOOL, wintypes.HWND, wintypes.LPARAM)
 
         # 'construct' the callback with our function
         proc = enum_win_proc_t(enum_window_proc)
@@ -202,9 +202,8 @@ class HwndElementInfo(ElementInfo):
         del remote_mem
         return textval
 
-    @property
-    def control_type(self):
-        """Return control type of the element"""
+    def __get_control_type(self, full=False):
+        """Internal parameterized method to distinguish control_type and full_control_type properties"""
         textval = ''
 
         length = 1024
@@ -220,6 +219,16 @@ class HwndElementInfo(ElementInfo):
         del remote_mem
 
         # simplify control type for WinForms controls
-        if "PublicKeyToken" in textval:
+        if (not full) and ("PublicKeyToken" in textval):
             textval = textval.split(", ")[0]
         return textval
+
+    @property
+    def control_type(self):
+        """Return control type of the element"""
+        return self.__get_control_type(full=False)
+
+    @property
+    def full_control_type(self):
+        """Return full string of control type of the element"""
+        return self.__get_control_type(full=True)

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -53,7 +53,7 @@ def _register_win_msg(msg_name):
 class HwndElementInfo(ElementInfo):
 
     """Wrapper for window handler"""
-    
+
     wm_get_ctrl_name = _register_win_msg('WM_GETCONTROLNAME')
     wm_get_ctrl_type = _register_win_msg('WM_GETCONTROLTYPE')
 

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -150,3 +150,8 @@ class HwndElementInfo(ElementInfo):
         if not isinstance(other, HwndElementInfo):
             return self.handle == other
         return self.handle == other.handle
+
+    @property
+    def automation_id(self):
+        """Return AutomationId of the element"""
+        return handleprops.dotnetname(self.handle)

--- a/pywinauto/win32_element_info.py
+++ b/pywinauto/win32_element_info.py
@@ -33,14 +33,29 @@
 
 import ctypes
 
+import six
+import win32gui
+
 from . import win32functions
 from . import handleprops
 from .element_info import ElementInfo
+from .remote_memory_block import RemoteMemoryBlock
+
+
+def _register_win_msg(msg_name):
+    msg_id = win32functions.RegisterWindowMessage(six.text_type(msg_name))
+    if msg_id > 0:
+        return msg_id
+    else:
+        raise Exception("Cannot register {}".format(msg_name))
 
 
 class HwndElementInfo(ElementInfo):
 
     """Wrapper for window handler"""
+    
+    wm_get_ctrl_name = _register_win_msg('WM_GETCONTROLNAME')
+    wm_get_ctrl_type = _register_win_msg('WM_GETCONTROLTYPE')
 
     def __init__(self, handle=None):
         """Create element by handle (default is root element)"""
@@ -102,39 +117,52 @@ class HwndElementInfo(ElementInfo):
 
     def children(self, **kwargs):
         """Return a list of immediate children of the window"""
-        if self == HwndElementInfo():  # self == root
-            child_handles = []
+        class_name = kwargs.get('class_name')
+        title = kwargs.get('title')
+        control_type = kwargs.get('control_type')
+        # TODO: 'cache_enable' and 'depth' are ignored so far
+        
+        # this will be filled in the callback function
+        child_elements = []
 
-            # The callback function that will be called for each HWND
-            # all we do is append the wrapped handle
-            def enum_window_proc(hwnd, lparam):
-                """Called for each window - adds handles to a list"""
-                child_handles.append(hwnd)
+        # The callback function that will be called for each HWND
+        # all we do is append the wrapped handle
+        def enum_window_proc(hwnd, lparam):
+            """Called for each window - adds wrapped elements to a list"""
+            element = HwndElementInfo(hwnd)
+            if class_name and class_name != element.class_name:
                 return True
+            if title and title != element.rich_text:
+                return True
+            if control_type and control_type != element.control_type:
+                return True
+            child_elements.append(element)
+            return True
 
-            # define the type of the child procedure
-            enum_win_proc_t = ctypes.WINFUNCTYPE(
-                ctypes.c_int, ctypes.c_long, ctypes.c_long)
+        # define the type of the child procedure
+        enum_win_proc_t = ctypes.WINFUNCTYPE(
+            ctypes.c_int, ctypes.c_long, ctypes.c_long)
 
-            # 'construct' the callback with our function
-            proc = enum_win_proc_t(enum_window_proc)
+        # 'construct' the callback with our function
+        proc = enum_win_proc_t(enum_window_proc)
 
+        if self == HwndElementInfo():  # self == root
             # loop over all the top level windows (callback called for each)
             win32functions.EnumWindows(proc, 0)
         else:
-            # TODO: this code returns the whole sub-tree, we need to re-write it
-            child_handles = handleprops.children(self._handle)
-        return [HwndElementInfo(ch) for ch in child_handles]
+            # loop over all the children (callback called for each)
+            win32functions.EnumChildWindows(self.handle, proc, 0)
+
+        return child_elements
 
     def descendants(self, **kwargs):
         """Return descendants of the window (all children from sub-tree)"""
-        child_handles = handleprops.children(self.handle)
-        child_handles = [HwndElementInfo(ch) for ch in child_handles]
+        child_elements = self.children(**kwargs)
         depth = kwargs.pop('depth', None)
 
-        child_handles = ElementInfo.filter_with_depth(child_handles, self, depth)
+        child_elements = ElementInfo.filter_with_depth(child_elements, self, depth)
 
-        return child_handles
+        return child_elements
 
     @property
     def rectangle(self):
@@ -154,9 +182,39 @@ class HwndElementInfo(ElementInfo):
     @property
     def automation_id(self):
         """Return AutomationId of the element"""
-        return handleprops.automation_id(self)
+        textval = ''
+
+        length = 1024
+        remote_mem = RemoteMemoryBlock(self, size=length*2)
+
+        ret = win32gui.SendMessage(self.handle, self.wm_get_ctrl_name, length, remote_mem.mem_address)
+
+        if ret:
+            text = ctypes.create_unicode_buffer(length)
+            remote_mem.Read(text)
+            textval = text.value
+
+        del remote_mem
+        return textval
 
     @property
     def control_type(self):
-        """Return ControlType property of the element"""
-        return handleprops.control_type(self)
+        """Return control type of the element"""
+        textval = ''
+
+        length = 1024
+        remote_mem = RemoteMemoryBlock(self, size=length*2)
+
+        ret = win32gui.SendMessage(self.handle, self.wm_get_ctrl_type, length, remote_mem.mem_address)
+
+        if ret:
+            text = ctypes.create_unicode_buffer(length)
+            remote_mem.Read(text)
+            textval = text.value
+
+        del remote_mem
+
+        # simplify control type for WinForms controls
+        if "PublicKeyToken" in textval:
+            textval = textval.split(", ")[0]
+        return textval

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -141,7 +141,7 @@ SendMessageTimeout  =   ctypes.windll.user32.SendMessageTimeoutW
 SendMessageA		=	ctypes.windll.user32.SendMessageA
 PostMessage			=	ctypes.windll.user32.PostMessageW
 GetMessage          =   ctypes.windll.user32.GetMessageW
-RegisterWindowMessage = ctypes.windll.user32.RegisterWindowMessageA
+RegisterWindowMessage = ctypes.windll.user32.RegisterWindowMessageW
 
 MoveWindow          =   ctypes.windll.user32.MoveWindow
 EnableWindow        =   ctypes.windll.user32.EnableWindow

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -141,6 +141,7 @@ SendMessageTimeout  =   ctypes.windll.user32.SendMessageTimeoutW
 SendMessageA		=	ctypes.windll.user32.SendMessageA
 PostMessage			=	ctypes.windll.user32.PostMessageW
 GetMessage          =   ctypes.windll.user32.GetMessageW
+RegisterWindowMessage = ctypes.windll.user32.RegisterWindowMessageA
 
 MoveWindow          =   ctypes.windll.user32.MoveWindow
 EnableWindow        =   ctypes.windll.user32.EnableWindow

--- a/setup.py
+++ b/setup.py
@@ -61,7 +61,7 @@ if sys.platform == 'win32':
     try:
         import win32api # check if it was already installed manually
     except ImportError:
-        install_requires.append('pypiwin32')
+        install_requires.append('pywin32')
 
     packages = ["pywinauto", "pywinauto.tests", "pywinauto.controls", "pywinauto.linux"]
 else:
@@ -69,7 +69,7 @@ else:
     packages = ["pywinauto", "pywinauto.linux"]
 
 setup(name='pywinauto',
-    version = '0.6.4',
+    version = '0.6.5',
     description = 'A set of Python modules to automate the Microsoft Windows GUI',
     keywords = "windows gui automation GuiAuto testing test desktop mouse keyboard",
     url = "http://pywinauto.github.io/",
@@ -99,12 +99,10 @@ Useful links
         'License :: OSI Approved :: BSD License',
         'Operating System :: Microsoft :: Windows',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 2.6',
         'Programming Language :: Python :: 2.7',
-        'Programming Language :: Python :: 3.3',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: Implementation :: CPython',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Testing',

--- a/setup.py
+++ b/setup.py
@@ -93,7 +93,7 @@ Useful links
 
     license = "BSD 3-clause",
     classifiers=[
-        'Development Status :: 4 - Beta',
+        'Development Status :: 5 - Production/Stable',
         'Environment :: Console',
         'Intended Audience :: Developers',
         'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
More changes:
 * Drop Python 3.3 & 3.4 tests (since pyWin32 and Sphinx don't support them as well).
 * Add Python 3.7 tests.
 * Switch dependencies to pyWin32 PyPI package which looks official again.
 * Fix code coverage reporting on Travis CI.
 * Bump version to prepare for 0.6.5.

[EDIT]
* Add `control_type` and `automation_id` properties for Win32 (mostly WinForms) apps.
* Support filtering by `class_name` etc in `children() / descendants()`.