### PR TITLE
Updating Notepad Actions for Windows 10

### DIFF
--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -373,30 +373,64 @@ Please find below a sample run ::
 	(4)   >>> app.UntitledNotepad.draw_outline()
 	(5)   >>> app.UntitledNotepad.menu_select("Edit -> Replace")
 	(6)   >>> app.Replace.print_control_identifiers()
-	      Control Identifiers:
-	      Static - 'Fi&nd what:'   (L1018, T159, R1090, B172)
-	              'Fi&nd what:' 'Fi&nd what:Static' 'Static' 'Static0' 'Static1'
-	      Edit - ''   (L1093, T155, R1264, B175)
-	              'Edit' 'Edit0' 'Edit1' 'Fi&nd what:Edit'
-	      Static - 'Re&place with:'   (L1018, T186, R1090, B199)
-	              'Re&place with:' 'Re&place with:Static' 'Static2'
-	      Edit - ''   (L1093, T183, R1264, B203)
-	              'Edit2' 'Re&place with:Edit'
-	      Button - 'Match &case'   (L1020, T245, R1109, B265)
-	              'CheckBox2' 'Match &case' 'Match &caseCheckBox'
-	      Button - '&Find Next'   (L1273, T151, R1348, B174)
-	              '&Find Next' '&Find NextButton' 'Button' 'Button0' 'Button1'
-	      Button - '&Replace'   (L1273, T178, R1348, B201)
-	              '&Replace' '&ReplaceButton' 'Button2'
-	      Button - 'Replace &All'   (L1273, T206, R1348, B229)
-	              'Button3' 'Replace &All' 'Replace &AllButton'
-	      Button - 'Cancel'   (L1273, T233, R1348, B256)
-	              'Button4' 'Cancel' 'CancelButton'
+	        Control Identifiers:
+
+	   	Dialog - 'Replace'    (L179, T174, R657, B409)
+		['ReplaceDialog', 'Dialog', 'Replace']
+		child_window(title="Replace", class_name="#32770")
+ 		   |
+		   | Static - 'Fi&nd what:'    (L196, T230, R292, B246)
+		   | ['Fi&nd what:Static', 'Fi&nd what:', 'Static', 'Static0', 'Static1']
+		   | child_window(title="Fi&nd what:", class_name="Static")
+		   |
+		   | Edit - ''    (L296, T226, R524, B250)
+ 		   | ['Fi&nd what:Edit', 'Edit', 'Edit0', 'Edit1']
+		   | child_window(class_name="Edit")
+  	       	   |
+ 		   | Static - 'Re&place with:'    (L196, T264, R292, B280)
+  		   | ['Re&place with:', 'Re&place with:Static', 'Static2']
+  		   | child_window(title="Re&place with:", class_name="Static")
+ 		   |
+ 		   | Edit - ''    (L296, T260, R524, B284)
+  		   | ['Edit2', 'Re&place with:Edit']
+   		   | child_window(class_name="Edit")
+   		   |
+   		   | CheckBox - 'Match &whole word only'    (L198, T304, R406, B328)
+   		   | ['CheckBox', 'Match &whole word onlyCheckBox', 'Match &whole word only', 'CheckBox0', 'CheckBox1']
+   		   | child_window(title="Match &whole word only", class_name="Button")
+   		   |
+   		   | CheckBox - 'Match &case'    (L198, T336, R316, B360)
+   		   | ['CheckBox2', 'Match &case', 'Match &caseCheckBox']
+   		   | child_window(title="Match &case", class_name="Button")
+		   |
+		   | Button - '&Find Next'    (L536, T220, R636, B248)
+		   | ['&Find Next', '&Find NextButton', 'Button', 'Button0', 'Button1']
+		   | child_window(title="&Find Next", class_name="Button")
+		   |
+		   | Button - '&Replace'    (L536, T254, R636, B282)
+		   | ['&ReplaceButton', '&Replace', 'Button2']
+		   | child_window(title="&Replace", class_name="Button")
+		   |
+		   | Button - 'Replace &All'    (L536, T288, R636, B316)
+		   | ['Replace &AllButton', 'Replace &All', 'Button3']
+		   | child_window(title="Replace &All", class_name="Button")
+		   |
+		   | Button - 'Cancel'    (L536, T322, R636, B350)
+		   | ['CancelButton', 'Cancel', 'Button4']
+		   | child_window(title="Cancel", class_name="Button")
+		   |
+		   | Button - '&Help'    (L536, T362, R636, B390)
+		   | ['&Help', '&HelpButton', 'Button5']
+		   | child_window(title="&Help", class_name="Button")
+		   |
+		   | Static - ''    (L196, T364, R198, B366)
+		   | ['ReplaceStatic', 'Static3']
+		   | child_window(class_name="Static")
 	(7)   >>> app.Replace.Cancel.click()
 	(8)   >>> app.UntitledNotepad.Edit.type_keys("Hi from Python interactive prompt %s" % str(dir()), with_spaces = True)
 	      <pywinauto.controls.win32_controls.EditWrapper object at 0x00DDC2D0>
 	(9)   >>> app.UntitledNotepad.menu_select("File -> Exit")
-	(10)  >>> app.Notepad.No.click()
+	(10)  >>> app.Notepad.DontSave.click()
 	      >>>
 
 1. Import the pywinauto.application module (usually the only module you need


### PR DESCRIPTION
Replaced with "Don't Save" instead of "No"
In Windows 10 version of Notepad option "No" is not present.

So instead of `app.Notepad.No.click()` it's better to use `app.Notepad.DontSave.click()`