### PR TITLE
Check admin privileges for both target and Python processes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,8 +89,8 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  # Build the compiled extension and run the project tests
-  - "powershell ./ci/runTestsuite.ps1"
+  # run the tests with restricted rights
+  - runas /trustlevel:0x20000 "powershell ./ci/runTestsuite.ps1"
 
 
 after_test:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -89,8 +89,8 @@ install:
 build: false  # Not a C# project, build stuff at the test step instead.
 
 test_script:
-  # run the tests with restricted rights
-  - runas /trustlevel:0x20000 "powershell ./ci/runTestsuite.ps1"
+  # run the tests
+  - "powershell ./ci/runTestsuite.ps1"
 
 
 after_test:

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -33,7 +33,7 @@ function run {
     $output = "transformed.xml"
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
-    Start-Process -FilePath psexec -ArgumentList "-accepteula -l -d nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests" -Wait -Passthru -WindowStyle Hidden
+    nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
     $success = $?
     Write-Host "result code of nosetests:" $success
 

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -33,7 +33,7 @@ function run {
     $output = "transformed.xml"
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
-    runas /trustlevel:0x20000 /NoProfile "nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests"
+    Start-Process -FilePath psexec -ArgumentList "-accepteula -l -d nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests" -Wait -Passthru -WindowStyle Hidden
     $success = $?
     Write-Host "result code of nosetests:" $success
 

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -33,7 +33,7 @@ function run {
     $output = "transformed.xml"
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
-    nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
+    psexec -l -d "nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests"
     $success = $?
     Write-Host "result code of nosetests:" $success
 

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -33,7 +33,7 @@ function run {
     $output = "transformed.xml"
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
-    psexec -l -d "nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests"
+    runas /trustlevel:0x20000 /NoProfile "nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests"
     $success = $?
     Write-Host "result code of nosetests:" $success
 

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -168,8 +168,8 @@ class WindowSpecification(object):
     def __call__(self, *args, **kwargs):
         """No __call__ so return a usefull error"""
         if "best_match" in self.criteria[-1]:
-            raise AttributeError(
-                "WindowSpecification class has no '{0}' method".
+            raise AttributeError("GUI element (wrapper) is not found " \
+                "or WindowSpecification has no '{0}' method (typo?)".
                 format(self.criteria[-1]['best_match']))
 
         message = (
@@ -956,6 +956,11 @@ class Application(object):
 
         if self.backend.name == 'win32':
             self.__warn_incorrect_bitness()
+
+            if not handleprops.has_enough_privileges(self.process):
+                warning_text = "Python process has no rights to make changes " \
+                    "in the target GUI (run the script as Administrator)"
+                warnings.warn(warning_text, UserWarning)
 
         return self
 

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -168,8 +168,8 @@ class WindowSpecification(object):
     def __call__(self, *args, **kwargs):
         """No __call__ so return a usefull error"""
         if "best_match" in self.criteria[-1]:
-            raise AttributeError("GUI element (wrapper) is not found " \
-                "or WindowSpecification has no '{0}' method (typo?)".
+            raise AttributeError("Neither GUI element (wrapper) " \
+                "nor wrapper method '{0}' were found (typo?)".
                 format(self.criteria[-1]['best_match']))
 
         message = (
@@ -918,7 +918,13 @@ class Application(object):
         connected = False
         if 'process' in kwargs:
             self.process = kwargs['process']
-            assert_valid_process(self.process)
+            try:
+                timings.wait_until_passes(
+                        timeout, retry_interval, assert_valid_process,
+                        ProcessNotFoundError, self.process
+                    )
+            except TimeoutError:
+                raise ProcessNotFoundError('Process with PID={} not found!'.format(self.process))
             connected = True
 
         elif 'handle' in kwargs:
@@ -944,15 +950,21 @@ class Application(object):
 
         elif kwargs:
             kwargs['backend'] = self.backend.name
-            self.process = findwindows.find_element(**kwargs).process_id
+            if 'timeout' in kwargs:
+                del kwargs['timeout']
+                self.process = timings.wait_until_passes(
+                        timeout, retry_interval, findwindows.find_element,
+                        exceptions=(findwindows.ElementNotFoundError, findbestmatch.MatchError,
+                                    controls.InvalidWindowHandle, controls.InvalidElement),
+                        *(), **kwargs
+                    ).process_id
+            else:
+                self.process = findwindows.find_element(**kwargs).process_id
             connected = True
 
         if not connected:
             raise RuntimeError(
-                "You must specify one of process, handle or path")
-        else:
-            if 'path' not in kwargs and 'timeout' in kwargs:
-                raise ValueError('Timeout could be specified with path param only')
+                "You must specify some of process, handle, path or window search criteria.")
 
         if self.backend.name == 'win32':
             self.__warn_incorrect_bitness()

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -669,6 +669,9 @@ class BaseWrapper(object):
         """
         if self.is_dialog():
             self.set_focus()
+        if self.backend.name == "win32":
+            self._ensure_enough_privileges('win32api.SetCursorPos(x, y)')
+        # TODO: check it in more general way for both backends
 
         if isinstance(coords, win32structures.RECT):
             coords = coords.mid_point()

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -3722,6 +3722,7 @@ class PagerWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def get_position(self):
         """Return the current position of the pager"""
+        self._ensure_enough_privileges('PGM_GETPOS')
         return self.send_message(win32defines.PGM_GETPOS)
     # Non PEP-8 alias
     GetPosition = get_position
@@ -3729,6 +3730,7 @@ class PagerWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def set_position(self, pos):
         """Set the current position of the pager"""
+        self._ensure_enough_privileges('PGM_SETPOS')
         return self.send_message(win32defines.PGM_SETPOS, pos)
     # Non PEP-8 alias
     SetPosition = set_position
@@ -3748,6 +3750,7 @@ class ProgressWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def get_position(self):
         """Return the current position of the progress bar"""
+        self._ensure_enough_privileges('PBM_GETPOS')
         return self.send_message(win32defines.PBM_GETPOS)
     # Non PEP-8 alias
     GetPosition = get_position
@@ -3755,6 +3758,7 @@ class ProgressWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def set_position(self, pos):
         """Set the current position of the progress bar"""
+        self._ensure_enough_privileges('PBM_SETPOS')
         return self.send_message(win32defines.PBM_SETPOS, pos)
     # Non PEP-8 alias
     SetPosition = set_position
@@ -3768,6 +3772,7 @@ class ProgressWrapper(hwndwrapper.HwndWrapper):
          * PBST_ERROR
          * PBST_PAUSED
         """
+        self._ensure_enough_privileges('PBM_GETSTATE')
         return self.send_message(win32defines.PBM_GETSTATE)
     # Non PEP-8 alias
     GetState = set_state
@@ -3775,6 +3780,7 @@ class ProgressWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def get_step(self):
         """Get the step size of the progress bar"""
+        self._ensure_enough_privileges('PBM_GETSTEP')
         return self.send_message(win32defines.PBM_GETSTEP)
     # Non PEP-8 alias
     GetStep = get_step
@@ -3782,6 +3788,7 @@ class ProgressWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def step_it(self):
         """Move the progress bar one step size forward"""
+        self._ensure_enough_privileges('PBM_STEPIT')
         return self.send_message(win32defines.PBM_STEPIT)
     # Non PEP-8 alias
     StepIt = step_it

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -456,7 +456,7 @@ class HwndWrapper(BaseWrapper):
         """Ensure the Python process has enough rights to send some window messages"""
         pid = handleprops.processid(self.handle)
         if not handleprops.has_enough_privileges(pid):
-            raise OSError('No enough rights to send {} message to target process ' \
+            raise RuntimeError('Not enough rights to use {} message/function for target process ' \
                 '(to resolve it run the script as Administrator)'.format(message_name))
 
     # -----------------------------------------------------------
@@ -745,6 +745,7 @@ class HwndWrapper(BaseWrapper):
         (i.e. it can be hidden beneath another window and it will still work).
         """
         self.verify_actionable()
+        self._ensure_enough_privileges('WM_*BUTTONDOWN/UP')
 
         _perform_click(self, button, pressed, coords, double, absolute=absolute)
         return self
@@ -1185,6 +1186,7 @@ class HwndWrapper(BaseWrapper):
         """Maximize the window"""
         win32functions.ShowWindow(self, win32defines.SW_MAXIMIZE)
         self.actions.log('Maximized window "{0}"'.format(self.window_text()))
+        return self
     # Non PEP-8 alias
     Maximize = maximize
 
@@ -1193,6 +1195,7 @@ class HwndWrapper(BaseWrapper):
         """Minimize the window"""
         win32functions.ShowWindow(self, win32defines.SW_MINIMIZE)
         self.actions.log('Minimized window "{0}"'.format(self.window_text()))
+        return self
     # Non PEP-8 alias
     Minimize = minimize
 
@@ -1201,6 +1204,7 @@ class HwndWrapper(BaseWrapper):
         """Restore the window to its previous state (normal or maximized)"""
         win32functions.ShowWindow(self, win32defines.SW_RESTORE)
         self.actions.log('Restored window "{0}"'.format(self.window_text()))
+        return self
     # Non PEP-8 alias
     Restore = restore
 
@@ -1344,7 +1348,6 @@ class HwndWrapper(BaseWrapper):
         win32functions.WaitGuiThreadIdle(self)
 
         time.sleep(Timings.after_setfocus_wait)
-
         return self
 
     # -----------------------------------------------------------

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -145,6 +145,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         BST_CHECKED = 1
         BST_INDETERMINATE = 2
         """
+        self._ensure_enough_privileges('BM_GETCHECK')
         return self.send_message(win32defines.BM_GETCHECK)
     # Non PEP-8 alias
     GetCheckState = get_check_state
@@ -152,6 +153,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def check(self):
         """Check a checkbox"""
+        self._ensure_enough_privileges('BM_SETCHECK')
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_CHECKED)
 
@@ -166,6 +168,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def uncheck(self):
         """Uncheck a checkbox"""
+        self._ensure_enough_privileges('BM_SETCHECK')
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_UNCHECKED)
 
@@ -180,6 +183,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def set_check_indeterminate(self):
         """Set the checkbox to indeterminate"""
+        self._ensure_enough_privileges('BM_SETCHECK')
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_INDETERMINATE)
 
@@ -311,6 +315,7 @@ class ComboBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def item_count(self):
         """Return the number of items in the combobox"""
+        self._ensure_enough_privileges('CB_GETCOUNT')
         return self.send_message(win32defines.CB_GETCOUNT)
     # Non PEP-8 alias
     ItemCount = item_count
@@ -318,6 +323,7 @@ class ComboBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def selected_index(self):
         """Return the selected index"""
+        self._ensure_enough_privileges('CB_GETCURSEL')
         return self.send_message(win32defines.CB_GETCURSEL)
     # Non PEP-8 alias
     SelectedIndex = selected_index
@@ -361,6 +367,7 @@ class ComboBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def item_texts(self):
         """Return the text of the items of the combobox"""
+        self._ensure_enough_privileges('CB_GETCOUNT')
         return _get_multiple_text_items(
             self,
             win32defines.CB_GETCOUNT,
@@ -462,6 +469,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def is_single_selection(self):
         """Check whether the listbox has single selection mode."""
+        self._ensure_enough_privileges('LB_GETSELCOUNT')
         num_selected = self.send_message(win32defines.LB_GETSELCOUNT)
 
         # if we got LB_ERR then it is a single selection list box
@@ -472,6 +480,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def selected_indices(self):
         """The currently selected indices of the listbox"""
+        self._ensure_enough_privileges('LB_GETSELCOUNT')
         num_selected = self.send_message(win32defines.LB_GETSELCOUNT)
 
         # if we got LB_ERR then it is a single selection list box
@@ -515,6 +524,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def item_count(self):
         """Return the number of items in the ListBox"""
+        self._ensure_enough_privileges('LB_GETCOUNT')
         return self.send_message(win32defines.LB_GETCOUNT)
     # Non PEP-8 alias
     ItemCount = item_count
@@ -530,6 +540,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def item_texts(self):
         """Return the text of the items of the listbox"""
+        self._ensure_enough_privileges('LB_GETCOUNT')
         return _get_multiple_text_items(
             self,
             win32defines.LB_GETCOUNT,
@@ -675,6 +686,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def line_count(self):
         """Return how many lines there are in the Edit"""
+        self._ensure_enough_privileges('EM_GETLINECOUNT')
         return  self.send_message(win32defines.EM_GETLINECOUNT)
     # Non PEP-8 alias
     LineCount = line_count
@@ -682,6 +694,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def line_length(self, line_index):
         """Return how many characters there are in the line"""
+        self._ensure_enough_privileges('EM_LINEINDEX')
         # need to first get a character index of that line
         char_index = self.send_message(win32defines.EM_LINEINDEX, line_index)
 
@@ -732,6 +745,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def selection_indices(self):
         """The start and end indices of the current selection"""
+        self._ensure_enough_privileges('EM_GETSEL')
         start = ctypes.c_int()
         end = ctypes.c_int()
         self.send_message(
@@ -755,6 +769,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def set_edit_text(self, text, pos_start = None, pos_end = None):
         """Set the text of the edit control"""
+        self._ensure_enough_privileges('EM_REPLACESEL')
         self.verify_actionable()
 
         # allow one or both of pos_start and pos_end to be None
@@ -819,6 +834,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
     #-----------------------------------------------------------
     def select(self, start = 0, end = None):
         """Set the edit selection of the edit control"""
+        self._ensure_enough_privileges('EM_SETSEL')
         self.verify_actionable()
         win32functions.SetFocus(self)
 

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -150,6 +150,16 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     # Non PEP-8 alias
     GetCheckState = get_check_state
 
+    __check_states = {
+        win32defines.BST_UNCHECKED: False,
+        win32defines.BST_CHECKED: True,
+        win32defines.BST_INDETERMINATE: None,
+        }
+    #-----------------------------------------------------------
+    def is_checked(self):
+        """Return True if checked, False if not checked, None if indeterminate"""
+        return self.__check_states[self.get_check_state()]
+
     #-----------------------------------------------------------
     def check(self):
         """Check a checkbox"""

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -39,6 +39,7 @@ import ctypes
 import win32process
 import win32api
 import win32con
+import win32gui
 
 from . import win32functions
 from . import win32defines
@@ -196,9 +197,8 @@ def clientrect(handle):
 #=========================================================================
 def rectangle(handle):
     """Return the rectangle of the window"""
-    rect = win32structures.RECT()
-    win32functions.GetWindowRect(handle, ctypes.byref(rect))
-    return rect
+    # GetWindowRect returns 4-tuple
+    return win32structures.RECT(*win32gui.GetWindowRect(handle))
 
 
 #=========================================================================
@@ -281,6 +281,20 @@ def processid(handle):
     """Return the ID of process that controls this window"""
     _, process_id = win32process.GetWindowThreadProcessId(int(handle))
     return process_id
+
+
+#=========================================================================
+def has_enough_privileges(process_id):
+    """Check if target process has enough rights to query GUI actions"""
+    try:
+        access_level = win32con.PROCESS_QUERY_INFORMATION | win32con.PROCESS_VM_READ
+        process_handle = win32api.OpenProcess(access_level, 0, process_id)
+        if process_handle:
+            win32api.CloseHandle(process_handle)
+            return True
+        return False
+    except win32gui.error:
+        return False
 
 
 #=========================================================================

--- a/pywinauto/timings.py
+++ b/pywinauto/timings.py
@@ -307,10 +307,10 @@ def always_wait_until(timeout,
     def wait_until_decorator(func):
         """Callable object that must be returned by the @always_wait_until decorator"""
         @wraps(func)
-        def wrapper(*args):
+        def wrapper(*args, **kwargs):
             """pre-callback, target function call and post-callback"""
             return wait_until(timeout, retry_interval,
-                              func, value, op, *args)
+                              func, value, op, *args, **kwargs)
         return wrapper
     return wait_until_decorator
 
@@ -321,9 +321,9 @@ def wait_until(timeout,
                func,
                value=True,
                op=operator.eq,
-               *args):
+               *args, **kwargs):
     r"""
-    Wait until ``op(function(*args), value)`` is True or until timeout expires
+    Wait until ``op(function(*args, **kwargs), value)`` is True or until timeout expires
 
     * **timeout**  how long the function will try the function
     * **retry_interval**  how long to wait between retries
@@ -331,6 +331,7 @@ def wait_until(timeout,
     * **value**  the value to be compared against (defaults to True)
     * **op** the comparison function (defaults to equality)\
     * **args** optional arguments to be passed to func when called
+    * **kwargs** optional keyword arguments to be passed to func when called
 
     Returns the return value of the function
     If the operation times out then the return value of the the function
@@ -348,7 +349,7 @@ def wait_until(timeout,
     """
     start = timestamp()
 
-    func_val = func(*args)
+    func_val = func(*args, **kwargs)
     # while the function hasn't returned what we are waiting for
     while not op(func_val, value):
 
@@ -360,7 +361,7 @@ def wait_until(timeout,
             # wait either the retry_interval or else the amount of
             # time until the timeout expires (whichever is less)
             time.sleep(min(retry_interval, time_left))
-            func_val = func(*args)
+            func_val = func(*args, **kwargs)
         else:
             err = TimeoutError("timed out")
             err.function_value = func_val
@@ -380,10 +381,10 @@ def always_wait_until_passes(timeout,
     def wait_until_passes_decorator(func):
         """Callable object that must be returned by the @always_wait_until_passes decorator"""
         @wraps(func)
-        def wrapper(*args):
+        def wrapper(*args, **kwargs):
             """pre-callback, target function call and post-callback"""
             return wait_until_passes(timeout, retry_interval,
-                                     func, exceptions, *args)
+                                     func, exceptions, *args, **kwargs)
         return wrapper
     return wait_until_passes_decorator
 
@@ -393,15 +394,16 @@ def wait_until_passes(timeout,
                       retry_interval,
                       func,
                       exceptions=(Exception),
-                      *args):
+                      *args, **kwargs):
     """
-    Wait until ``func(*args)`` does not raise one of the exceptions in exceptions
+    Wait until ``func(*args, **kwargs)`` does not raise one of the exceptions
 
     * **timeout**  how long the function will try the function
     * **retry_interval**  how long to wait between retries
     * **func** the function that will be executed
     * **exceptions**  list of exceptions to test against (default: Exception)
     * **args** optional arguments to be passed to func when called
+    * **kwargs** optional keyword arguments to be passed to func when called
 
     Returns the return value of the function
     If the operation times out then the original exception raised is in
@@ -424,7 +426,7 @@ def wait_until_passes(timeout,
     while True:
         try:
             # Call the function with any arguments
-            func_val = func(*args)
+            func_val = func(*args, **kwargs)
 
             # if no exception is raised then we are finished
             break

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -147,37 +147,37 @@ class ApplicationWarningTestCases(unittest.TestCase):
             assert args[1].__name__ == 'UserWarning'
 
 
-class AdminTestCases(ApplicationWarningTestCases):
+if ctypes.windll.shell32.IsUserAnAdmin() == 0:
+    class AdminTestCases(ApplicationWarningTestCases):
 
-    def setUp(self):
-        """Set some data and ensure the application is in the state we want"""
-        super(AdminTestCases, self).setUp()
-        cmd = 'powershell -Command "Start-Process {} -Verb RunAs"'.format(self.sample_exe)
-        self.app = Application().start(cmd, wait_for_idle=False)
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            super(AdminTestCases, self).setUp()
+            cmd = 'powershell -Command "Start-Process {} -Verb RunAs"'.format(self.sample_exe)
+            self.app = Application().start(cmd, wait_for_idle=False)
 
-    def tearDown(self):
-        """Close the application after tests"""
-        self.app.kill()
-        super(AdminTestCases, self).tearDown()
+        def tearDown(self):
+            """Close the application after tests"""
+            self.app.kill()
+            super(AdminTestCases, self).tearDown()
 
-    def test_non_admin_warning(self):
-        print('ctypes.windll.shell32.IsUserAnAdmin() = {}'.format(ctypes.windll.shell32.IsUserAnAdmin()))
-        warnings.filterwarnings('always', category=UserWarning, append=True)
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        def test_non_admin_warning(self):
+            warnings.filterwarnings('always', category=UserWarning, append=True)
+            with warnings.catch_warnings(record=True) as w:
+                warnings.simplefilter("always")
+                self.app = Application().connect(title="Common Controls Sample", timeout=20)
+                assert len(w) >= 1
+                assert issubclass(w[-1].category, UserWarning)
+                assert "process has no rights" in str(w[-1].message)
+
+        def test_non_admin_click(self):
             self.app = Application().connect(title="Common Controls Sample", timeout=20)
-            assert len(w) >= 1
-            assert issubclass(w[-1].category, UserWarning)
-            assert "process has no rights" in str(w[-1].message)
-
-    def test_non_admin_click(self):
-        self.app = Application().connect(title="Common Controls Sample", timeout=20)
-        with self.assertRaises(RuntimeError):
-            self.app.CommonControlsSample.OK.click()
-        with self.assertRaises(RuntimeError):
-            self.app.CommonControlsSample.OK.click_input()
-        with self.assertRaises(RuntimeError):
-            self.app.CommonControlsSample.TVS_HASBUTTON.check()
+            with self.assertRaises(RuntimeError):
+                self.app.CommonControlsSample.OK.click()
+            with self.assertRaises(RuntimeError):
+                self.app.CommonControlsSample.OK.click_input()
+            with self.assertRaises(RuntimeError):
+                self.app.CommonControlsSample.TVS_HASBUTTON.check()
 
 
 class NonAdminTestCases(ApplicationWarningTestCases):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -148,6 +148,64 @@ class ApplicationWarningTestCases(unittest.TestCase):
             assert args[1].__name__ == 'UserWarning'
 
 
+class AdminTestCases(ApplicationWarningTestCases):
+
+    def setUp(self):
+        """Set some data and ensure the application is in the state we want"""
+        super(AdminTestCases, self).setUp()
+        self.app = Application().start('powershell -Command "Start-Process {} -Verb RunAs"'.format(self.sample_exe), wait_for_idle=False)
+
+    def tearDown(self):
+        """Close the application after tests"""
+        self.app.kill()
+        super(AdminTestCases, self).tearDown()
+
+    def test_non_admin_warning(self):
+        warnings.filterwarnings('always', category=UserWarning, append=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            self.app = Application().connect(title="Common Controls Sample", timeout=5)
+            assert len(w) >= 1
+            assert issubclass(w[-1].category, UserWarning)
+            assert "process has no rights" in str(w[-1].message)
+
+    def test_non_admin_click(self):
+        self.app = Application().connect(title="Common Controls Sample", timeout=5)
+        with self.assertRaises(RuntimeError):
+            self.app.CommonControlsSample.OK.click()
+        with self.assertRaises(RuntimeError):
+            self.app.CommonControlsSample.OK.click_input()
+        with self.assertRaises(RuntimeError):
+            self.app.CommonControlsSample.TVS_HASBUTTON.check()
+
+
+class NonAdminTestCases(ApplicationWarningTestCases):
+
+    def setUp(self):
+        """Set some data and ensure the application is in the state we want"""
+        super(NonAdminTestCases, self).setUp()
+        self.app = Application().start(self.sample_exe)
+
+    def tearDown(self):
+        """Close the application after tests"""
+        self.app.kill()
+        super(NonAdminTestCases, self).tearDown()
+
+    def test_both_non_admin(self):
+        warnings.filterwarnings('always', category=UserWarning, append=True)
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            Application().connect(title="Common Controls Sample", timeout=5)
+            assert len(w) == 0
+
+    def test_both_non_admin_click(self):
+        self.app = Application().connect(title="Common Controls Sample", timeout=5)
+        self.app.CommonControlsSample.TVS_HASBUTTON.check()
+        self.assertEqual(self.app.CommonControlsSample.TVS_HASBUTTON.is_checked(), True)
+        self.app.CommonControlsSample.OK.click()
+        self.app.CommonControlsSample.wait_not('visible')
+
+
 class ApplicationTestCases(unittest.TestCase):
 
     """Unit tests for the application.Application class"""
@@ -302,7 +360,7 @@ class ApplicationTestCases(unittest.TestCase):
         """Test that connect_(process=...) raise error when set timeout"""
         app1 = Application()
         app1.start(_notepad_exe())
-        self.assertRaises(ValueError, Application().connect, process=app1.process, timeout=0.5)
+        self.assertRaises(ProcessNotFoundError, Application().connect, process=0, timeout=0.5)
         app1.UntitledNotepad.MenuSelect('File->Exit')
 
 #    def test_Connect(self):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -165,13 +165,13 @@ class AdminTestCases(ApplicationWarningTestCases):
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            self.app = Application().connect(title="Common Controls Sample", timeout=5)
+            self.app = Application().connect(title="Common Controls Sample", timeout=20)
             assert len(w) >= 1
             assert issubclass(w[-1].category, UserWarning)
             assert "process has no rights" in str(w[-1].message)
 
     def test_non_admin_click(self):
-        self.app = Application().connect(title="Common Controls Sample", timeout=5)
+        self.app = Application().connect(title="Common Controls Sample", timeout=20)
         with self.assertRaises(RuntimeError):
             self.app.CommonControlsSample.OK.click()
         with self.assertRaises(RuntimeError):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -43,8 +43,7 @@ import time
 #import pdb
 import warnings
 from threading import Thread
-import win32api
-import pywintypes
+import ctypes
 
 import mock
 
@@ -162,6 +161,7 @@ class AdminTestCases(ApplicationWarningTestCases):
         super(AdminTestCases, self).tearDown()
 
     def test_non_admin_warning(self):
+        print('ctypes.windll.shell32.IsUserAnAdmin() = {}'.format(ctypes.windll.shell32.IsUserAnAdmin()))
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -153,7 +153,8 @@ class AdminTestCases(ApplicationWarningTestCases):
     def setUp(self):
         """Set some data and ensure the application is in the state we want"""
         super(AdminTestCases, self).setUp()
-        self.app = Application().start('powershell -Command "Start-Process {} -Verb RunAs"'.format(self.sample_exe), wait_for_idle=False)
+        cmd = 'powershell -Command "Start-Process {} -Verb RunAs"'.format(self.sample_exe)
+        self.app = Application().start(cmd, wait_for_idle=False)
 
     def tearDown(self):
         """Close the application after tests"""
@@ -195,7 +196,7 @@ class NonAdminTestCases(ApplicationWarningTestCases):
         warnings.filterwarnings('always', category=UserWarning, append=True)
         with warnings.catch_warnings(record=True) as w:
             warnings.simplefilter("always")
-            Application().connect(title="Common Controls Sample", timeout=5)
+            self.app = Application().connect(title="Common Controls Sample", timeout=5)
             assert len(w) == 0
 
     def test_both_non_admin_click(self):

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -32,6 +32,7 @@
 """Defines Windows(tm) functions"""
 
 import ctypes
+from ctypes import wintypes
 from . import win32defines, win32structures
 from .actionlogger import ActionLogger
 from ctypes import c_uint, c_short, c_long
@@ -280,8 +281,8 @@ def LoWord(value):
 #====================================================================
 def WaitGuiThreadIdle(handle):
     """Wait until the thread of the specified handle is ready"""
-    process_id = ctypes.c_int()
-    GetWindowThreadProcessId(handle, ctypes.byref(process_id))
+    process_id = wintypes.DWORD(0)
+    GetWindowThreadProcessId(handle, ctypes.POINTER(wintypes.DWORD)(process_id))
 
     # ask the control if it has finished processing the message
     hprocess = OpenProcess(


### PR DESCRIPTION
Alternative implementation might be shorter if checking message in `def send_message` and allow permission for `WM_GETTEXT` only (seems like only this message always works). But it will require using string names for all window messages because there is no guarantee that int message ID is not equal to another attribute of `win32defines`. Example: `self.send_message("CB_GETCOUNT")`. Such changes are as global as current implementation. So don't see a reason to re-implement it.