### PR TITLE
Fix set_focus() for UIA backend

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,6 +1,6 @@
 pywin32
 six
-Pillow==4.0.0
+Pillow==5.2.0
 coverage
 nose
 codecov

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,6 +2,34 @@
 Change Log
 ==========
 
+0.6.5 Handling Privileges, AutomationID for Win32 etc.
+--------------------------------------------------------------------
+27-July-2018
+
+Enhancements:
+ * Check admin privileges for both target app and Python process. This
+   allows detecting cases when window messages won't work.
+ * Add ``automation_id`` and ``control_type`` properties
+   for "win32" backend (the most useful for WinForms). Correct
+   child_window() keywords are ``auto_id`` and ``control_type``.
+ * Switch pypiwin32 dependency to pywin32 which became official again.
+ * New generators ``iter_children()`` and ``iter_descendants()``.
+ * Add method ``is_checked()`` to "win32" check box.
+
+Bug Fixes:
+ * Method ``Application().connect(...)`` works better with ``timeout``
+   argument.
+ * Fix ``.set_focus()`` for "uia" backend including minimized window case
+   (issue #443).
+ * ``maximize()/minimize()`` methods can be chained now.
+ * Fix passing keyword arguments to a function for decorators
+   ``@always_wait_until_passes`` and ``@always_wait_until``.
+ * Use correct types conversion for WaitGuiThreadIdle (issue #497).
+ * Fix reporting code coverage on Linux.
+ * Use .format() for logging BaseWrapper actions (issue #471).
+ * Print warning in case binary type is not determined (issue #387).
+
+
 0.6.4 NULL pointer access fix and enhancements
 --------------------------------------------------------------------
 21-January-2018

--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -4,7 +4,7 @@ Change Log
 
 0.6.5 Handling Privileges, AutomationID for Win32 etc.
 --------------------------------------------------------------------
-27-July-2018
+30-July-2018
 
 Enhancements:
  * Check admin privileges for both target app and Python process. This

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -39,6 +39,8 @@ import locale
 import re
 import time
 import win32process
+import win32gui
+import win32con
 import six
 
 try:
@@ -309,6 +311,15 @@ class BaseWrapper(object):
         visible and enabled.
         """
         return self.element_info.enabled #and self.top_level_parent().element_info.enabled
+
+    # -----------------------------------------------------------
+    def was_maximized(self):
+        """Indicate whether the window was maximized before minimizing or not"""
+        if self.handle:
+            (flags, _, _, _, _) = win32gui.GetWindowPlacement(self.handle)
+            return (flags & win32con.WPF_RESTORETOMAXIMIZED == win32con.WPF_RESTORETOMAXIMIZED)
+        else:
+            return None
 
     #------------------------------------------------------------
     def rectangle(self):

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1301,9 +1301,7 @@ class HwndWrapper(BaseWrapper):
         """
         # "steal the focus" if there is another active window
         # otherwise it is already into the foreground and no action required
-        cur_foreground = win32gui.GetForegroundWindow()
-
-        if self.handle != cur_foreground:
+        if not self.has_focus():
             # Notice that we need to move the mouse out of the screen
             # but we don't use the built-in methods of the class:
             # self.mouse_move doesn't do the job well even with absolute=True
@@ -1312,7 +1310,10 @@ class HwndWrapper(BaseWrapper):
 
             # change active window
             if self.is_minimized():
-                win32gui.ShowWindow(self.handle, win32con.SW_RESTORE)
+                if self.was_maximized():
+                    self.maximize()
+                else:
+                    self.restore()
             else:
                 win32gui.ShowWindow(self.handle, win32con.SW_SHOW)
             win32gui.SetForegroundWindow(self.handle)
@@ -1326,6 +1327,10 @@ class HwndWrapper(BaseWrapper):
         return self
     # Non PEP-8 alias
     SetFocus = set_focus
+
+    def has_focus(self):
+        """Check the window is in focus (foreground)"""
+        return self.handle == win32gui.GetForegroundWindow()
 
     def has_keyboard_focus(self):
         """Check the keyboard focus on this control."""

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -36,6 +36,7 @@ from __future__ import print_function
 
 import six
 import time
+import warnings
 import comtypes
 
 from .. import backend

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -35,8 +35,8 @@ from __future__ import unicode_literals
 from __future__ import print_function
 
 import six
-import comtypes
 import time
+import comtypes
 
 from .. import backend
 from ..timings import Timings
@@ -400,13 +400,20 @@ class UIAWrapper(BaseWrapper):
     # -----------------------------------------------------------
     def set_focus(self):
         """Set the focus to this element"""
-        if self.is_keyboard_focusable() and not self.has_keyboard_focus():
-            try:
-                self.element_info.element.SetFocus()
-            except comtypes.COMError:
-                pass  # TODO: add RuntimeWarning here
+        if self.is_minimized():
+            if self.was_maximized():
+                self.maximize()
+            else:
+                self.restore()
+        try:
+            self.element_info.element.SetFocus()
+        except comtypes.COMError as exc:
+            warnings.warn('The window has not been focused due to ' \
+                'COMError: {}'.format(exc), RuntimeWarning)
 
         return self
+
+    # TODO: figure out how to implement .has_focus() method (if no handle available)
 
     # -----------------------------------------------------------
     def close(self):

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -400,11 +400,14 @@ class UIAWrapper(BaseWrapper):
     # -----------------------------------------------------------
     def set_focus(self):
         """Set the focus to this element"""
-        if self.is_minimized():
-            if self.was_maximized():
-                self.maximize()
-            else:
-                self.restore()
+        try:
+            if self.is_minimized():
+                if self.was_maximized():
+                    self.maximize()
+                else:
+                    self.restore()
+        except uia_defs.NoPatternInterfaceError:
+            pass
         try:
             self.element_info.element.SetFocus()
         except comtypes.COMError as exc:

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -1591,7 +1591,7 @@ if UIA_support:
         def setUp(self):
             """Set some data and ensure the application is in the state we want"""
             _set_timings()
-            
+
             test_folder = os.path.join(os.path.dirname(os.path.dirname(
                 os.path.dirname(os.path.abspath(__file__)))), r"apps/MouseTester")
             self.qt5_app = os.path.join(test_folder, "mousebuttons.exe")

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -1584,6 +1584,54 @@ if UIA_support:
             self.assertEqual(itm.window_text(), 'Months')
 
 
+    class WindowWrapperTests(unittest.TestCase):
+
+        """Unit tests for the UIAWrapper class for Window elements"""
+
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            _set_timings()
+            
+            test_folder = os.path.join(os.path.dirname(os.path.dirname(
+                os.path.dirname(os.path.abspath(__file__)))), r"apps/MouseTester")
+            self.qt5_app = os.path.join(test_folder, "mousebuttons.exe")
+
+            # start the application
+            self.app = Application(backend='uia')
+            self.app = self.app.start(self.qt5_app)
+
+            self.dlg = self.app.MouseButtonTester.wrapper_object()
+            self.another_app = None
+
+        def tearDown(self):
+            """Close the application after tests"""
+            self.app.kill()
+            if self.another_app:
+                self.another_app.kill()
+                self.another_app = None
+
+        def test_issue_443(self):
+            """Test .set_focus() for window that is not keyboard focusable"""
+            self.dlg.minimize()
+            self.assertEqual(self.dlg.is_minimized(), True)
+            self.dlg.set_focus()
+            self.assertEqual(self.dlg.is_minimized(), False)
+            self.assertEqual(self.dlg.is_normal(), True)
+
+            # run another app instance (in focus now)
+            self.another_app = Application(backend="win32").start(self.qt5_app)
+            # eliminate clickable point at original app by maximizing second window
+            self.another_app.MouseButtonTester.maximize()
+            self.another_app.MouseButtonTester.set_focus()
+            self.assertEqual(self.another_app.MouseButtonTester.has_focus(), True)
+
+            self.dlg.set_focus()
+            # another app instance has lost focus
+            self.assertEqual(self.another_app.MouseButtonTester.has_focus(), False)
+            # our window has been brought to the focus (clickable point exists)
+            self.assertEqual(self.dlg.element_info.element.GetClickablePoint()[-1], 1)
+
+
 if __name__ == "__main__":
     if UIA_support:
         unittest.main()


### PR DESCRIPTION
 * It works for minimized window now (maximize or restore is correctly chosen).
 * Ignore window pattern if it's not a window.
 * Pillow is updated to support Py3.7 (though tests still failing due to some bug in Python 3.7.0).