### PR TITLE
Fix empty pages on ReadTheDocs (fix #541)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -48,6 +48,7 @@ if sys.platform.startswith('linux'):
             "win32functions",
             "win32clipboard",
             'win32structures',
+            'win32_element_info',
             'comtypes',
             'comtypes.client',
             ]:


### PR DESCRIPTION
Fixed docs on the branch: http://pywinauto-fork.readthedocs.io/en/docs_fixes/code/code.html#main-user-modules

Currently I have no plans to publish docs for `HwndElementInfo` since it's pretty internal kitchen. It may be reconsidered in the future though.