### PR TITLE
Use 'utf8' encoding to write log file

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -71,6 +71,7 @@ import time
 import warnings
 import multiprocessing
 import locale
+import codecs
 
 import win32process
 import win32api
@@ -660,8 +661,8 @@ class WindowSpecification(object):
             print("Control Identifiers:")
             print_identifiers([this_ctrl, ])
         else:
-            log_file = open(filename, "w", encoding="utf8")
-
+            log_file = codecs.open(filename, "w", locale.getpreferredencoding())
+            
             def log_func(msg):
                 log_file.write(str(msg) + os.linesep)
             log_func("Control Identifiers:")

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -662,7 +662,7 @@ class WindowSpecification(object):
             print_identifiers([this_ctrl, ])
         else:
             log_file = codecs.open(filename, "w", locale.getpreferredencoding())
-            
+
             def log_func(msg):
                 log_file.write(str(msg) + os.linesep)
             log_func("Control Identifiers:")

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -660,7 +660,7 @@ class WindowSpecification(object):
             print("Control Identifiers:")
             print_identifiers([this_ctrl, ])
         else:
-            log_file = open(filename, "w")
+            log_file = open(filename, "w", encoding="utf8")
 
             def log_func(msg):
                 log_file.write(str(msg) + os.linesep)


### PR DESCRIPTION
It will throw encoding error when calling print_control_identifiers() function for some circumstance, add encoding to fix this issue.