### PR TITLE
pywinauto\controls\common_controls.py:776: DeprecationWarning

### DIFF
--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -773,7 +773,7 @@ class ListViewWrapper(hwndwrapper.HwndWrapper):
     def column_count(self):
         """Return the number of columns"""
         if self.get_header_control() is not None:
-            return self.get_header_control().ItemCount()
+            return self.get_header_control().item_count()
         return 0
     # Non PEP-8 alias
     ColumnCount = deprecated(column_count)


### PR DESCRIPTION
More messages being displayed when dumping "ListView":

pywinauto.application.Application().connect(handle=hwnd).window()['ListView'].dump_tree()

ItemCount() is deprecated, , use .item_count() instead