### PR TITLE
Fix GetWindowRect crash and type conversion for win32_hooks

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -63,7 +63,7 @@ if sys.platform == 'win32':
     def _get_com_threading_mode(module_sys):
         """Set up COM threading model
 
-        The ultimate goal is MTA, but the mode is adjusted
+        The ultimate goal is MTA, but the mode is adjusted
         if it was already defined prior to pywinauto import.
         """
         com_init_mode = 0  # COINIT_MULTITHREADED = 0x0

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -41,6 +41,7 @@ import win32process
 import win32api
 import win32con
 import win32gui
+import pywintypes
 
 from . import win32functions
 from . import win32defines
@@ -204,7 +205,10 @@ def clientrect(handle):
 def rectangle(handle):
     """Return the rectangle of the window"""
     # GetWindowRect returns 4-tuple
-    return win32structures.RECT(*win32gui.GetWindowRect(handle))
+    try:
+        return win32structures.RECT(*win32gui.GetWindowRect(handle))
+    except pywintypes.error:
+        return win32structures.RECT()
 
 
 #=========================================================================

--- a/pywinauto/win32_hooks.py
+++ b/pywinauto/win32_hooks.py
@@ -530,7 +530,7 @@ class Hook(object):
             self.keyboard_id = windll.user32.SetWindowsHookExW(
                 win32con.WH_KEYBOARD_LL,
                 _kbd_ll_cb,
-                windll.kernel32.GetModuleHandleA(None),
+                windll.kernel32.GetModuleHandleA(0),
                 0)
 
         if self.mouse_is_hook:
@@ -542,7 +542,7 @@ class Hook(object):
             self.mouse_id = windll.user32.SetWindowsHookExA(
                 win32con.WH_MOUSE_LL,
                 _mouse_ll_cb,
-                windll.kernel32.GetModuleHandleA(None),
+                windll.kernel32.GetModuleHandleA(0),
                 0)
 
         self.listen()

--- a/pywinauto/win32_hooks.py
+++ b/pywinauto/win32_hooks.py
@@ -61,7 +61,10 @@ from ctypes import pointer
 import atexit
 import sys
 import time
+
 import win32con
+import win32api
+
 from .win32defines import VK_PACKET
 from .actionlogger import ActionLogger
 from .win32structures import KBDLLHOOKSTRUCT
@@ -71,9 +74,11 @@ LRESULT = wintypes.LPARAM
 HOOKCB = CFUNCTYPE(LRESULT, c_int, wintypes.WPARAM, wintypes.LPARAM)
 
 windll.kernel32.GetModuleHandleA.restype = wintypes.HMODULE
-windll.kernel32.GetModuleHandleA.argtypes = [wintypes.LPCWSTR]
-windll.user32.SetWindowsHookExA.restype = c_int
+windll.kernel32.GetModuleHandleA.argtypes = [wintypes.LPCSTR]
+windll.user32.SetWindowsHookExA.restype = wintypes.HHOOK
 windll.user32.SetWindowsHookExA.argtypes = [c_int, HOOKCB, wintypes.HINSTANCE, wintypes.DWORD]
+windll.user32.SetWindowsHookExW.restype = wintypes.HHOOK
+windll.user32.SetWindowsHookExW.argtypes = [c_int, HOOKCB, wintypes.HINSTANCE, wintypes.DWORD]
 windll.user32.GetMessageW.argtypes = [POINTER(wintypes.MSG), wintypes.HWND, c_uint, c_uint]
 windll.user32.TranslateMessage.argtypes = [POINTER(wintypes.MSG)]
 windll.user32.DispatchMessageW.argtypes = [POINTER(wintypes.MSG)]
@@ -530,7 +535,7 @@ class Hook(object):
             self.keyboard_id = windll.user32.SetWindowsHookExW(
                 win32con.WH_KEYBOARD_LL,
                 _kbd_ll_cb,
-                windll.kernel32.GetModuleHandleA(0),
+                win32api.GetModuleHandle(None),
                 0)
 
         if self.mouse_is_hook:
@@ -542,7 +547,7 @@ class Hook(object):
             self.mouse_id = windll.user32.SetWindowsHookExA(
                 win32con.WH_MOUSE_LL,
                 _mouse_ll_cb,
-                windll.kernel32.GetModuleHandleA(0),
+                win32api.GetModuleHandle(None),
                 0)
 
         self.listen()


### PR DESCRIPTION
 * Fix #534 
 * Fix Python 3.7 `OverflowError`s: type conversion in `win32_hooks.py`
 * Remove strange Unicode symbol from the doc string