### PR TITLE
add click() to baseWrapper

### DIFF
--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -615,6 +615,14 @@ class BaseWrapper(object):
         if not self.is_visible():
             raise ElementNotVisible()
 
+    # -----------------------------------------------------------
+    def click(self):
+        """Click the element by using Invoke pattern"""
+        self.invoke()
+
+        # Return itself so that action can be chained
+        return self
+
     #-----------------------------------------------------------
     def click_input(
         self,


### PR DESCRIPTION
UIAwrapper claims to have click() functionality, but it only has
click_input functionality. This adds click functionality similar to that
in uia_controls, by using Invoke pattern.