### PR TITLE
Fix encode error

### DIFF
--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -170,7 +170,12 @@ class BaseWrapper(object):
         """
         repr_str = '<{0}, {1}>'.format(self.__str__(), self.__hash__())
         if six.PY2:
-            return repr_str.encode(sys.stdout.encoding, errors='backslashreplace')
+            if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None:
+                # some frameworks override sys.stdout without encoding attribute
+                # some users replace sys.stdout with file descriptor which can have None encoding
+                return repr_str.encode(sys.stdout.encoding, errors='backslashreplace')
+            else:
+                return repr_str.encode(locale.getpreferredencoding(), errors='backslashreplace')
         else:
             return repr_str
 

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -168,7 +168,11 @@ class BaseWrapper(object):
         a windows specification to access the control, while the unique ID is more for
         debugging purposes helping to distinguish between the runtime objects.
         """
-        return '<{0}, {1}>'.format(self.__str__(), self.__hash__())
+        repr_str = '<{0}, {1}>'.format(self.__str__(), self.__hash__())
+        if six.PY2:
+            return repr_str.encode(sys.stdout.encoding, errors='backslashreplace')
+        else:
+            return repr_str
 
     def __str__(self):
         """Pretty print representation of the wrapper object

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -155,6 +155,23 @@ class BaseWrapper(object):
         else:
             raise RuntimeError('NULL pointer was used to initialize BaseWrapper')
 
+    def __repr_texts(self):
+        """Internal common method to be called from __str__ and __repr__"""
+        module = self.__class__.__module__
+        module = module[module.rfind('.') + 1:]
+
+        type_name = module + "." + self.__class__.__name__
+        title = self.window_text()
+        class_name = self.friendly_class_name()
+        if six.PY2:
+            if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None:
+                # some frameworks override sys.stdout without encoding attribute (Tee Stream),
+                # some users replace sys.stdout with file descriptor which can have None encoding
+                title = title.encode(sys.stdout.encoding, errors='backslashreplace')
+            else:
+                title = title.encode(locale.getpreferredencoding(), errors='backslashreplace')
+        return type_name, title, class_name
+
     def __repr__(self):
         """Representation of the wrapper object
 
@@ -168,16 +185,11 @@ class BaseWrapper(object):
         a windows specification to access the control, while the unique ID is more for
         debugging purposes helping to distinguish between the runtime objects.
         """
-        repr_str = '<{0}, {1}>'.format(self.__str__(), self.__hash__())
+        type_name, title, class_name = self.__repr_texts()
         if six.PY2:
-            if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None:
-                # some frameworks override sys.stdout without encoding attribute (Tee Stream),
-                # some users replace sys.stdout with file descriptor which can have None encoding
-                return repr_str.encode(sys.stdout.encoding, errors='backslashreplace')
-            else:
-                return repr_str.encode(locale.getpreferredencoding(), errors='backslashreplace')
+            return b"<{0} - '{1}', {2}, {3}>".format(type_name, title, class_name, self.__hash__())
         else:
-            return repr_str
+            return "<{0} - '{1}', {2}, {3}>".format(type_name, title, class_name, self.__hash__())
 
     def __str__(self):
         """Pretty print representation of the wrapper object
@@ -188,20 +200,13 @@ class BaseWrapper(object):
         * friendly class name of the wrapped control
 
         Notice that the reported title and class name can be used as hints
-        to prepare a windows specification to access the control
+        to prepare a window specification to access the control
         """
-        module = self.__class__.__module__
-        module = module[module.rfind('.') + 1:]
-        type_name = module + "." + self.__class__.__name__
-
-        try:
-            title = self.texts()[0]
-        except IndexError:
-            title = ""
-
-        class_name = self.friendly_class_name()
-
-        return "{0} - '{1}', {2}".format(type_name, title, class_name)
+        type_name, title, class_name = self.__repr_texts()
+        if six.PY2:
+            return b"{0} - '{1}', {2}".format(type_name, title, class_name)
+        else:
+            return "{0} - '{1}', {2}".format(type_name, title, class_name)
 
     def __hash__(self):
         """Returns the hash value of the handle"""

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -171,7 +171,7 @@ class BaseWrapper(object):
         repr_str = '<{0}, {1}>'.format(self.__str__(), self.__hash__())
         if six.PY2:
             if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None:
-                # some frameworks override sys.stdout without encoding attribute
+                # some frameworks override sys.stdout without encoding attribute (Tee Stream),
                 # some users replace sys.stdout with file descriptor which can have None encoding
                 return repr_str.encode(sys.stdout.encoding, errors='backslashreplace')
             else:

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -2447,6 +2447,7 @@ class ToolbarWrapper(hwndwrapper.HwndWrapper):
     friendlyclassname = "Toolbar"
     windowclasses = [
         "ToolbarWindow32",
+        "TToolBar",
         r"WindowsForms\d*\.ToolbarWindow32\..*",
         "Afx:ToolBar:.*"]
 

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1679,7 +1679,7 @@ def _perform_click(
     else:
         coords = list(coords)
 
-    if not absolute:
+    if absolute:
         coords = ctrl.client_to_screen(coords)
 
     # figure out the messages for click/press

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1679,7 +1679,7 @@ def _perform_click(
     else:
         coords = list(coords)
 
-    if absolute:
+    if not absolute:
         coords = ctrl.client_to_screen(coords)
 
     # figure out the messages for click/press

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -432,7 +432,7 @@ if UIA_support:
             self.app.kill_()
 
         def test_pretty_print(self):
-            """Test __str__ method for UIA based controls"""
+            """Test __str__ and __repr__ methods for UIA based controls"""
             if six.PY3:
                 assert_regex = self.assertRegex
             else:
@@ -489,6 +489,12 @@ if UIA_support:
             assert_regex(wrp.element_info.__str__(), "^uia_element_info\.UIAElementInfo - 'None', Window$")
             assert_regex(wrp.element_info.__repr__(), "^<uia_element_info\.UIAElementInfo - 'None', Window, [0-9-]+>$")
             wrp.element_info._get_name = orig
+
+        def test_pretty_print_encode_error(self):
+            """Test __repr__ method for BaseWrapper with specific Unicode text (issue #594)"""
+            wrp = self.dlg.wrapper_object()
+            wrp.texts = mock.Mock(return_value=u'\xb7')
+            print(wrp)
 
         def test_friendly_class_names(self):
             """Test getting friendly class names of common controls"""

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -474,14 +474,14 @@ if UIA_support:
             assert_regex(wrp.element_info.__repr__(),
                          "^<uia_element_info.UIAElementInfo - 'WPF Sample Application', Window, [0-9-]+>$")
 
-            # mock a failure in texts() method
-            orig = wrp.texts
-            wrp.texts = mock.Mock(return_value=[])  # empty texts
+            # mock a failure in window_text() method
+            orig = wrp.window_text
+            wrp.window_text = mock.Mock(return_value="")  # empty text
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '', Dialog$")
             assert_regex(wrp.__repr__(), "^<uiawrapper\.UIAWrapper - '', Dialog, [0-9-]+>$")
-            wrp.texts.return_value = [u'\xd1\xc1\\\xa1\xb1\ua000']  # unicode string
+            wrp.window_text.return_value = u'\xd1\xc1\\\xa1\xb1\ua000'  # unicode string
             assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '.+', Dialog$")
-            wrp.texts = orig  # restore the original method
+            wrp.window_text = orig  # restore the original method
 
             # mock a failure in element_info.name property (it's based on _get_name())
             orig = wrp.element_info._get_name
@@ -493,8 +493,9 @@ if UIA_support:
         def test_pretty_print_encode_error(self):
             """Test __repr__ method for BaseWrapper with specific Unicode text (issue #594)"""
             wrp = self.dlg.wrapper_object()
-            wrp.texts = mock.Mock(return_value=u'\xb7')
+            wrp.window_text = mock.Mock(return_value=u'\xb7')
             print(wrp)
+            print(repr(wrp))
 
         def test_friendly_class_names(self):
             """Test getting friendly class names of common controls"""

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -453,8 +453,8 @@ if UIA_support:
             assert_regex(wrp.element_info.__repr__(), "^<uia_element_info.UIAElementInfo - '', TextBox, None>$")
 
             wrp = self.dlg.TabControl.wrapper_object()
-            assert_regex(wrp.__str__(), "^uia_controls\.TabControlWrapper - 'General', TabControl$")
-            assert_regex(wrp.__repr__(), "^<uia_controls\.TabControlWrapper - 'General', TabControl, [0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.TabControlWrapper - '', TabControl$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.TabControlWrapper - '', TabControl, [0-9-]+>$")
 
             wrp = self.dlg.MenuBar.wrapper_object()
             assert_regex(wrp.__str__(), "^uia_controls\.MenuWrapper - 'System', Menu$")


### PR DESCRIPTION
* Fixed `__str__` and `__repr__` methods for `BaseWrapper`, extended unit tests for them (fix #594).
* Added `"TToolBar"` for ToolbarWrapper detection list ([reported here](https://ru.stackoverflow.com/q/910285/179357)).

Attempt to fix #540 was reverted so far. Will do in separate PR.