### PR TITLE
Epic cleanup of deprecation warnings in unittests, split one

### DIFF
--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -919,7 +919,7 @@ class ListViewWrapper(hwndwrapper.HwndWrapper):
     def texts(self):
         """Get the texts for the ListView control"""
         texts = [self.window_text()]
-        texts.extend([item['text'] for item in self.items()])
+        texts.extend([item.text() for item in self.items()])
         return texts
 
     #-----------------------------------------------------------
@@ -1656,7 +1656,7 @@ class TreeViewWrapper(hwndwrapper.HwndWrapper):
     def is_selected(self, path):
         """Return True if the item is selected"""
         return win32defines.TVIS_SELECTED == (win32defines.TVIS_SELECTED &
-                                              self.get_item(path).State())
+                                              self.get_item(path).state())
     # Non PEP-8 alias
     IsSelected = deprecated(is_selected)
 
@@ -2775,11 +2775,11 @@ class ToolbarWrapper(hwndwrapper.HwndWrapper):
 
         current_toolbar = self
         for i, index in enumerate(indices):
-            windows_before = app.Windows_(visible_only=True)
+            windows_before = app.windows(visible_only=True)
             current_toolbar.button(index).click_input()
             if i < len(indices) - 1:
-                wait_until(5, 0.1, lambda: len(app.Windows_(visible_only=True)) > len(windows_before))
-                windows_after = app.Windows_(visible_only=True)
+                wait_until(5, 0.1, lambda: len(app.windows(visible_only=True)) > len(windows_before))
+                windows_after = app.windows(visible_only=True)
                 new_window = set(windows_after) - set(windows_before)
                 current_toolbar = list(new_window)[0].children()[0]
         self.actions.logSectionEnd()

--- a/pywinauto/unittests/test_actionlogger.py
+++ b/pywinauto/unittests/test_actionlogger.py
@@ -70,7 +70,7 @@ class ActionLoggerOnStadardLoggerTestCases(unittest.TestCase):
         """Close the application after tests"""
         self.logger.handlers[0].stream.close()
         self.logger.handlers[0].stream = self.out
-        self.app.kill_()
+        self.app.kill()
 
     def __lineCount(self):
         """hack to get line count from current logger stream"""
@@ -87,11 +87,11 @@ class ActionLoggerOnStadardLoggerTestCases(unittest.TestCase):
         self.assertEqual(self.__lineCount(), prev_line_count + 1)
 
         actionlogger.disable()
-        self.app.UntitledNotepad.MenuSelect('Help->About Notepad')
+        self.app.UntitledNotepad.menu_select('Help->About Notepad')
         self.assertEqual(self.__lineCount(), prev_line_count + 1)
 
         actionlogger.enable()
-        self.app.window(title='About Notepad').OK.Click()
+        self.app.window(title='About Notepad').OK.click()
         self.assertEqual(self.__lineCount(), prev_line_count + 2)
 
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -254,7 +254,7 @@ class ApplicationTestCases(unittest.TestCase):
         notepadpath = os.path.join(os.environ['systemroot'], self.notepad_subpath)
         self.assertEqual(str(process_module(app.process)).lower(), str(notepadpath).lower())
 
-        app.UntitledNotepad.MenuSelect("File->Exit")
+        app.UntitledNotepad.menu_select("File->Exit")
 
     def testStart_bug01(self):
         """On SourceForge forum AppStartError forgot to include %s for application name"""
@@ -265,7 +265,7 @@ class ApplicationTestCases(unittest.TestCase):
         try:
             app.start(app_name)
         except AppStartError as e:
-            self.assertEquals(app_name in str(e), True)
+            self.assertEqual(app_name in str(e), True)
 
 #    def testset_timing(self):
 #        """Test that set_timing sets the timing correctly"""
@@ -283,7 +283,7 @@ class ApplicationTestCases(unittest.TestCase):
 #        )
 #        set_timing(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
 #
-#        self.assertEquals(
+#        self.assertEqual(
 #            (
 #                application.window_find_timeout,
 #                application.window_retry_interval,
@@ -317,9 +317,9 @@ class ApplicationTestCases(unittest.TestCase):
 
         accessible_modules = process_get_modules()
         accessible_process_names = [os.path.basename(name.lower()) for process, name, cmdline in accessible_modules]
-        self.assertEquals('notepad.exe' in accessible_process_names, True)
+        self.assertEqual('notepad.exe' in accessible_process_names, True)
 
-        app_conn.UntitledNotepad.MenuSelect('File->Exit')
+        app_conn.UntitledNotepad.menu_select('File->Exit')
 
     def test_connect_path_timeout(self):
         """Test that connect_() works with a path with timeout"""
@@ -337,9 +337,9 @@ class ApplicationTestCases(unittest.TestCase):
 
         accessible_modules = process_get_modules()
         accessible_process_names = [os.path.basename(name.lower()) for process, name, cmdline in accessible_modules]
-        self.assertEquals('notepad.exe' in accessible_process_names, True)
+        self.assertEqual('notepad.exe' in accessible_process_names, True)
 
-        app1.UntitledNotepad.MenuSelect('File->Exit')
+        app1.UntitledNotepad.menu_select('File->Exit')
 
     def test_connect_path_timeout_problem(self):
         """Test that connect_() raise error when no process start"""
@@ -354,14 +354,14 @@ class ApplicationTestCases(unittest.TestCase):
 
         time.sleep(0.7)
 
-        app1.UntitledNotepad.MenuSelect('File->Exit')
+        app1.UntitledNotepad.menu_select('File->Exit')
 
     def test_connect_process_timeout_failed(self):
         """Test that connect_(process=...) raise error when set timeout"""
         app1 = Application()
         app1.start(_notepad_exe())
         self.assertRaises(ProcessNotFoundError, Application().connect, process=0, timeout=0.5)
-        app1.UntitledNotepad.MenuSelect('File->Exit')
+        app1.UntitledNotepad.menu_select('File->Exit')
 
 #    def test_Connect(self):
 #        """Test that connect_() works with a path"""
@@ -376,7 +376,7 @@ class ApplicationTestCases(unittest.TestCase):
 #        app_conn.connect_(path = r"c:\windows\system32\notepad.exe")
 #        self.assertEqual(app1.process, app_conn.process)
 #
-#        app_conn.UntitledNotepad.MenuSelect('File->Exit')
+#        app_conn.UntitledNotepad.menu_select('File->Exit')
 
     def test_connect_process(self):
         """Test that connect_() works with a process"""
@@ -387,7 +387,7 @@ class ApplicationTestCases(unittest.TestCase):
         app_conn.connect(process=app1.process)
         self.assertEqual(app1.process, app_conn.process)
 
-        app_conn.UntitledNotepad.MenuSelect('File->Exit')
+        app_conn.UntitledNotepad.menu_select('File->Exit')
 
 
     def test_connect_handle(self):
@@ -400,7 +400,7 @@ class ApplicationTestCases(unittest.TestCase):
         app_conn.connect(handle=handle)
         self.assertEqual(app1.process, app_conn.process)
 
-        app_conn.UntitledNotepad.MenuSelect('File->Exit')
+        app_conn.UntitledNotepad.menu_select('File->Exit')
 
     def test_connect_windowspec(self):
         """Test that connect_() works with a windowspec"""
@@ -421,7 +421,7 @@ class ApplicationTestCases(unittest.TestCase):
 
         self.assertEqual(app1.process, app_conn.process)
 
-        app_conn.UntitledNotepad.MenuSelect('File->Exit')
+        app_conn.UntitledNotepad.menu_select('File->Exit')
 
     def test_connect_raises(self):
         """Test that connect_() raises with invalid input"""
@@ -459,13 +459,13 @@ class ApplicationTestCases(unittest.TestCase):
 
         self.assertEqual(app.UntitledNotepad.handle, app.top_window_().handle)
 
-        app.UntitledNotepad.MenuSelect("Help->About Notepad")
+        app.UntitledNotepad.menu_select("Help->About Notepad")
 
         self.assertEqual(app.AboutNotepad.handle, app.top_window_().handle)
 
         app.AboutNotepad.Ok.Click()
-        app.UntitledNotepad.MenuSelect("File->Exit")
-        app.UntitledNotepad.WaitNot('exists')
+        app.UntitledNotepad.menu_select("File->Exit")
+        app.UntitledNotepad.wait_not('exists')
         self.assertRaises(RuntimeError, app.top_window_)
 
     def test_active_window(self):
@@ -474,10 +474,10 @@ class ApplicationTestCases(unittest.TestCase):
         self.assertRaises(AppNotConnected, app.active_)
         self.assertRaises(AppNotConnected, app.is64bit)
         app.start(_notepad_exe())
-        app.UntitledNotepad.Wait('ready')
+        app.UntitledNotepad.wait('ready')
         self.assertEqual(app.active_().handle, app.UntitledNotepad.handle)
-        app.UntitledNotepad.MenuSelect("File->Exit")
-        app.UntitledNotepad.WaitNot('exists')
+        app.UntitledNotepad.menu_select("File->Exit")
+        app.UntitledNotepad.wait_not('exists')
         self.assertRaises(RuntimeError, app.active_)
 
     def test_cpu_usage(self):
@@ -485,9 +485,9 @@ class ApplicationTestCases(unittest.TestCase):
         app = Application()
         self.assertRaises(AppNotConnected, app.cpu_usage)
         app.start(_notepad_exe())
-        self.assertEquals(0.0 <= app.cpu_usage() <= 100.0, True)
-        app.UntitledNotepad.MenuSelect("File->Exit")
-        app.UntitledNotepad.WaitNot('exists')
+        self.assertEqual(0.0 <= app.cpu_usage() <= 100.0, True)
+        app.UntitledNotepad.menu_select("File->Exit")
+        app.UntitledNotepad.wait_not('exists')
 
     def test_wait_cpu_usage_lower(self):
         """Test that wait_cpu_usage_lower() works correctly"""
@@ -559,17 +559,17 @@ class ApplicationTestCases(unittest.TestCase):
         self.assertRaises(ValueError, app.windows_, **{'backend' : 'uia'})
 
         notepad_handle = app.UntitledNotepad.handle
-        self.assertEquals(app.windows_(visible_only = True), [notepad_handle])
+        self.assertEqual(app.windows_(visible_only = True), [notepad_handle])
 
-        app.UntitledNotepad.MenuSelect("Help->About Notepad")
+        app.UntitledNotepad.menu_select("Help->About Notepad")
 
         aboutnotepad_handle = app.AboutNotepad.handle
-        self.assertEquals(
+        self.assertEqual(
             app.windows_(visible_only = True, enabled_only = False),
             [aboutnotepad_handle, notepad_handle])
 
         app.AboutNotepad.OK.Click()
-        app.UntitledNotepad.MenuSelect("File->Exit")
+        app.UntitledNotepad.menu_select("File->Exit")
 
     def test_window(self):
         """Test that window_() works correctly"""
@@ -597,7 +597,7 @@ class ApplicationTestCases(unittest.TestCase):
         self.assertEqual(title.handle, handle.handle)
         self.assertEqual(title.handle, bestmatch.handle)
 
-        app.UntitledNotepad.MenuSelect("File->Exit")
+        app.UntitledNotepad.menu_select("File->Exit")
 
     def test_getitem(self):
         """Test that __getitem__() works correctly"""
@@ -615,14 +615,14 @@ class ApplicationTestCases(unittest.TestCase):
             app[u'Unt\xeftledNotepad'].handle,
             app.window_(title = "Untitled - Notepad").handle)
 
-        app.UntitledNotepad.MenuSelect("Help->About Notepad")
+        app.UntitledNotepad.menu_select("Help->About Notepad")
 
         self.assertEqual(
             app['AboutNotepad'].handle,
             app.window_(title = "About Notepad").handle)
 
         app.AboutNotepad.Ok.Click()
-        app.UntitledNotepad.MenuSelect("File->Exit")
+        app.UntitledNotepad.menu_select("File->Exit")
 
     def test_getattribute(self):
         """Test that __getattribute__() works correctly"""
@@ -638,7 +638,7 @@ class ApplicationTestCases(unittest.TestCase):
             app.UntitledNotepad.handle,
             app.window_(title = "Untitled - Notepad").handle)
 
-        app.UntitledNotepad.MenuSelect("Help->About Notepad")
+        app.UntitledNotepad.menu_select("Help->About Notepad")
 
         # I think it's OK that this no longer raises a matcherror
         # just because the window is not enabled - doesn't mean you
@@ -651,21 +651,21 @@ class ApplicationTestCases(unittest.TestCase):
             app.window(title = "About Notepad").handle)
 
         app.AboutNotepad.Ok.Click()
-        app.UntitledNotepad.MenuSelect("File->Exit")
+        app.UntitledNotepad.menu_select("File->Exit")
 
-    def test_kill_(self):
+    def test_kill(self):
         """test killing the application"""
         app = Application()
         app.start(_notepad_exe())
 
         app.UntitledNotepad.Edit.type_keys("hello")
 
-        app.UntitledNotepad.MenuSelect("File->Print...")
+        app.UntitledNotepad.menu_select("File->Print...")
 
         #app.Print.FindPrinter.Click() # Vasily: (Win7 x64) "Find Printer" dialog is from splwow64.exe process
         #app.FindPrinters.Stop.Click()
 
-        app.kill_()
+        app.kill()
 
         self.assertRaises(AttributeError, app.UntitledNotepad.Edit)
 
@@ -717,8 +717,8 @@ class WindowSpecificationTestCases(unittest.TestCase):
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        #self.app.UntitledNotepad.MenuSelect("File->Exit")
-        self.app.kill_()
+        #self.app.UntitledNotepad.menu_select("File->Exit")
+        self.app.kill()
 
     def test__init__(self):
         """Test creating a new spec by hand"""
@@ -728,7 +728,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
                 process = self.app.process)
             )
 
-        self.assertEquals(
+        self.assertEqual(
             wspec.window_text(),
             u"Untitled - Notepad")
 
@@ -745,44 +745,44 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
     def test_wrapper_object(self):
         """Test that we can get a control"""
-        self.assertEquals(True, isinstance(self.dlgspec, WindowSpecification))
+        self.assertEqual(True, isinstance(self.dlgspec, WindowSpecification))
 
-        self.assertEquals(
+        self.assertEqual(
             True,
-            isinstance(self.dlgspec.WrapperObject(), hwndwrapper.HwndWrapper)
+            isinstance(self.dlgspec.wrapper_object(), hwndwrapper.HwndWrapper)
             )
 
     def test_window(self):
         """test specifying a sub window of an existing specification"""
-        sub_spec = self.dlgspec.ChildWindow(class_name = "Edit")
-        sub_spec_legacy = self.dlgspec.Window_(class_name = "Edit")
+        sub_spec = self.dlgspec.child_window(class_name = "Edit")
+        sub_spec_legacy = self.dlgspec.window(class_name = "Edit")
 
-        self.assertEquals(True, isinstance(sub_spec, WindowSpecification))
-        self.assertEquals(sub_spec.class_name(), "Edit")
-        self.assertEquals(sub_spec_legacy.class_name(), "Edit")
+        self.assertEqual(True, isinstance(sub_spec, WindowSpecification))
+        self.assertEqual(sub_spec.class_name(), "Edit")
+        self.assertEqual(sub_spec_legacy.class_name(), "Edit")
 
     def test__getitem__(self):
         """test item access of a windowspec"""
-        self.assertEquals(
+        self.assertEqual(
             True,
             isinstance(self.dlgspec['Edit'], WindowSpecification)
             )
 
-        self.assertEquals(self.dlgspec['Edit'].class_name(), "Edit")
+        self.assertEqual(self.dlgspec['Edit'].class_name(), "Edit")
 
         self.assertRaises(AttributeError, self.ctrlspec.__getitem__, 'edit')
 
     def test_getattr(self):
         """Test getting attributes works correctly"""
-        self.assertEquals(
+        self.assertEqual(
             True,
             isinstance(self.dlgspec.Edit, WindowSpecification)
             )
 
-        self.assertEquals(self.dlgspec.Edit.class_name(), "Edit")
+        self.assertEqual(self.dlgspec.Edit.class_name(), "Edit")
 
         # check that getting a dialog attribute works correctly
-        self.assertEquals(
+        self.assertEqual(
             "Notepad",
             self.dlgspec.class_name())
 
@@ -792,73 +792,73 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
     def test_exists(self):
         """Check that windows exist"""
-        self.assertEquals(True, self.dlgspec.Exists())
-        self.assertEquals(True, self.dlgspec.Exists(0))
-        self.assertEquals(True, self.ctrlspec.Exists())
+        self.assertEqual(True, self.dlgspec.exists())
+        self.assertEqual(True, self.dlgspec.exists(0))
+        self.assertEqual(True, self.ctrlspec.exists())
         # TODO: test a control that is not visible but exists
-        #self.assertEquals(True, self.app.DefaultIME.Exists())
+        #self.assertEqual(True, self.app.DefaultIME.exists())
 
         start = timestamp()
-        self.assertEquals(False, self.app.BlahBlah.Exists(timeout=.1))
-        self.assertEquals(True, timestamp() - start < .3)
+        self.assertEqual(False, self.app.BlahBlah.exists(timeout=.1))
+        self.assertEqual(True, timestamp() - start < .3)
 
         start = timestamp()
-        self.assertEquals(False, self.app.BlahBlah.exists(timeout=3))
-        self.assertEquals(True, 2.7 < timestamp() - start < 3.3)
+        self.assertEqual(False, self.app.BlahBlah.exists(timeout=3))
+        self.assertEqual(True, 2.7 < timestamp() - start < 3.3)
 
     def test_exists_timing(self):
         """test the timing of the exists method"""
         # try ones that should be found immediately
         start = timestamp()
-        self.assertEquals(True, self.dlgspec.Exists())
-        self.assertEquals(True, timestamp() - start < .3)
+        self.assertEqual(True, self.dlgspec.exists())
+        self.assertEqual(True, timestamp() - start < .3)
 
         start = timestamp()
-        self.assertEquals(True, self.ctrlspec.Exists())
-        self.assertEquals(True, timestamp() - start < .3)
+        self.assertEqual(True, self.ctrlspec.exists())
+        self.assertEqual(True, timestamp() - start < .3)
 
         # try one that should not be found
         start = timestamp()
-        self.assertEquals(True, self.dlgspec.Exists(.5))
+        self.assertEqual(True, self.dlgspec.exists(.5))
         timedif =  timestamp() - start
-        self.assertEquals(True, .49 > timedif < .6)
+        self.assertEqual(True, .49 > timedif < .6)
 
     def test_wait(self):
         """test the functionality and timing of the wait method"""
         allowable_error = .2
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("enaBleD "))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait("enaBleD "))
         time_taken = (timestamp() - start)
         if not 0 <= time_taken < (0 + 2 * allowable_error):
             self.assertEqual(.02,  time_taken)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("  ready"))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait("  ready"))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait(" exiSTS"))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait(" exiSTS"))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait(" VISIBLE "))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait(" VISIBLE "))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait(" ready enabled"))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait(" ready enabled"))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("visible exists "))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait("visible exists "))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("exists "))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait("exists "))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         start = timestamp()
-        self.assertEqual(self.dlgspec.WrapperObject(), self.dlgspec.Wait("actIve "))
+        self.assertEqual(self.dlgspec.wrapper_object(), self.dlgspec.wait("actIve "))
         self.assertEqual(True, 0 <= (timestamp() - start) < 0 + allowable_error)
 
         self.assertRaises(SyntaxError, self.dlgspec.Wait, "Invalid_criteria")
@@ -909,40 +909,40 @@ class WindowSpecificationTestCases(unittest.TestCase):
         allowable_error = .16
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "enaBleD ", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, "enaBleD ", .1, .05)
         taken = timestamp() - start
         if .1 < (taken)  > .1 + allowable_error:
             self.assertEqual(.12, taken)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "  ready", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, "  ready", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, " exiSTS", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, " exiSTS", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, " VISIBLE ", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, " VISIBLE ", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, " ready enabled", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, " ready enabled", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "visible exists ", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, "visible exists ", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "exists ", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, "exists ", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
         start = timestamp()
-        self.assertRaises(TimeoutError, self.dlgspec.WaitNot, "actIve ", .1, .05)
+        self.assertRaises(TimeoutError, self.dlgspec.wait_not, "actIve ", .1, .05)
         self.assertEqual(True, .1 <= (timestamp() - start) < .1 + allowable_error)
 
-        self.assertRaises(SyntaxError, self.dlgspec.WaitNot, "Invalid_criteria")
+        self.assertRaises(SyntaxError, self.dlgspec.wait_not, "Invalid_criteria")
 
 #    def test_wait_ready(self):
 #        """Make sure the friendly class is set correctly"""
@@ -1085,7 +1085,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
     def test_find_elements_re(self):
         """Test for bug #90: A crash in 'find_elements' when called with 'title_re' argument"""
-        self.dlgspec.Wait('visible')
+        self.dlgspec.wait('visible')
         windows = findwindows.find_elements(title_re = "Untitled - Notepad")
         self.assertTrue(len(windows) >= 1)
 

--- a/pywinauto/unittests/test_clipboard.py
+++ b/pywinauto/unittests/test_clipboard.py
@@ -36,10 +36,10 @@ import unittest
 import sys
 import time
 sys.path.append(".")
-from pywinauto.clipboard import GetClipboardFormats, GetData, GetFormatName, EmptyClipboard
-from pywinauto.application import Application
-from pywinauto.win32structures import RECT
-from pywinauto.timings import Timings
+from pywinauto.clipboard import GetClipboardFormats, GetData, GetFormatName, EmptyClipboard  # noqa E402
+from pywinauto.application import Application  # noqa E402
+from pywinauto.win32structures import RECT  # noqa E402
+from pywinauto.timings import Timings  # noqa E402
 
 
 class ClipboardTestCases(unittest.TestCase):
@@ -53,35 +53,33 @@ class ClipboardTestCases(unittest.TestCase):
         self.app1 = Application().start("notepad.exe")
         self.app2 = Application().start("notepad.exe")
 
-        self.app1.UntitledNotepad.MoveWindow(RECT(0, 0, 200, 200))
-        self.app2.UntitledNotepad.MoveWindow(RECT(0, 200, 200, 400))
-
+        self.app1.UntitledNotepad.move_window(RECT(0, 0, 200, 200))
+        self.app2.UntitledNotepad.move_window(RECT(0, 200, 200, 400))
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.app1.UntitledNotepad.MenuSelect('File -> Exit')
-        if self.app1.Notepad["Do&n't Save"].Exists():
-            self.app1.Notepad["Do&n't Save"].Click()
-        self.app1.kill_()
+        self.app1.UntitledNotepad.menu_select('File -> Exit')
+        if self.app1.Notepad["Do&n't Save"].exists():
+            self.app1.Notepad["Do&n't Save"].click()
+        self.app1.kill()
 
-        self.app2.UntitledNotepad.MenuSelect('File -> Exit')
-        if self.app2.Notepad["Do&n't Save"].Exists():
-            self.app2.Notepad["Do&n't Save"].Click()
-        self.app2.kill_()
-
+        self.app2.UntitledNotepad.menu_select('File -> Exit')
+        if self.app2.Notepad["Do&n't Save"].exists():
+            self.app2.Notepad["Do&n't Save"].click()
+        self.app2.kill()
 
     def testGetClipBoardFormats(self):
         typetext(self.app1, "here we are")
         copytext(self.app1)
 
-        self.assertEquals(GetClipboardFormats(), [13, 16, 1, 7])
+        self.assertEqual(GetClipboardFormats(), [13, 16, 1, 7])
 
     def testGetFormatName(self):
         typetext(self.app1, "here we are")
         copytext(self.app1)
 
-        self.assertEquals(
+        self.assertEqual(
             [GetFormatName(f) for f in GetClipboardFormats()],
             ['CF_UNICODETEXT', 'CF_LOCALE', 'CF_TEXT', 'CF_OEMTEXT']
         )
@@ -91,41 +89,42 @@ class ClipboardTestCases(unittest.TestCase):
 
         Where GetData was not closing the clipboard. FIXED.
         """
-        self.app1.UntitledNotepad.MenuSelect("Edit->Select All Ctrl+A")
+        self.app1.UntitledNotepad.menu_select("Edit->Select All Ctrl+A")
         typetext(self.app1, "some text")
         copytext(self.app1)
 
         # was not closing the clipboard!
         data = GetData()
-        self.assertEquals(data, "some text")
+        self.assertEqual(data, "some text")
 
-
-        self.assertEquals(gettext(self.app2), "")
+        self.assertEqual(gettext(self.app2), "")
         pastetext(self.app2)
-        self.assertEquals(gettext(self.app2), "some text")
-
+        self.assertEqual(gettext(self.app2), "some text")
 
 
 def gettext(app):
     return app.UntitledNotepad.Edit.texts()[1]
 
+
 def typetext(app, text):
-    app.UntitledNotepad.Edit.Wait('enabled')
-    app.UntitledNotepad.Edit.SetEditText(text)
+    app.UntitledNotepad.Edit.wait('enabled')
+    app.UntitledNotepad.Edit.set_edit_text(text)
     time.sleep(0.3)
 
 
 def copytext(app):
-    app.UntitledNotepad.Wait('enabled')
-    app.UntitledNotepad.MenuItem("Edit -> Select All").click_input()
+    app.UntitledNotepad.wait('enabled')
+    app.UntitledNotepad.menu_item("Edit -> Select All").click_input()
     time.sleep(0.7)
-    app.UntitledNotepad.Wait('enabled')
-    app.UntitledNotepad.MenuItem("Edit -> Copy").click_input()
+    app.UntitledNotepad.wait('enabled')
+    app.UntitledNotepad.menu_item("Edit -> Copy").click_input()
     time.sleep(1.0)
 
+
 def pastetext(app):
-    app.UntitledNotepad.Wait('enabled')
-    app.UntitledNotepad.MenuItem("Edit -> Paste").click_input()
+    app.UntitledNotepad.wait('enabled')
+    app.UntitledNotepad.menu_item("Edit -> Paste").click_input()
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -99,31 +99,31 @@ class ListViewTestCases32(unittest.TestCase):
 
         self.app = app
         self.dlg = app.RowListSampleApplication
-        self.ctrl = app.RowListSampleApplication.ListView.WrapperObject()
-        self.dlg.Toolbar.Button(0).Click()  # switch to icon view
-        self.dlg.Toolbar.Button(6).Click()  # switch off states
+        self.ctrl = app.RowListSampleApplication.ListView.wrapper_object()
+        self.dlg.Toolbar.button(0).click()  # switch to icon view
+        self.dlg.Toolbar.button(6).click()  # switch off states
 
     def tearDown(self):
         """Close the application after tests"""
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testFriendlyClass(self):
         """Make sure the ListView friendly class is set correctly"""
-        self.assertEquals(self.ctrl.friendly_class_name(), u"ListView")
+        self.assertEqual(self.ctrl.friendly_class_name(), u"ListView")
 
     def testColumnCount(self):
         """Test the ListView ColumnCount method"""
-        self.assertEquals(self.ctrl.ColumnCount(), 8)
+        self.assertEqual(self.ctrl.column_count(), 8)
 
     def testItemCount(self):
         """Test the ListView ItemCount method"""
-        self.assertEquals(self.ctrl.ItemCount(), 7)
+        self.assertEqual(self.ctrl.item_count(), 7)
 
     def testItemText(self):
         """Test the ListView item.Text property"""
-        item = self.ctrl.GetItem(1)
+        item = self.ctrl.get_item(1)
 
-        self.assertEquals(item['text'], u"Red")
+        self.assertEqual(item.text(), u"Red")
 
     def testItems(self):
         """Test the ListView Items method"""
@@ -131,10 +131,10 @@ class ListViewTestCases32(unittest.TestCase):
         for row in self.texts:
             flat_texts.extend(row)
 
-        items = self.ctrl.Items()
+        items = self.ctrl.items()
         for i, item in enumerate(items):
-            self.assertEquals(item['text'], flat_texts[i])
-        self.assertEquals(len(items), len(flat_texts))
+            self.assertEqual(item.text(), flat_texts[i])
+        self.assertEqual(len(items), len(flat_texts))
 
     def testTexts(self):
         """Test the ListView texts method"""
@@ -142,294 +142,294 @@ class ListViewTestCases32(unittest.TestCase):
         for row in self.texts:
             flat_texts.extend(row)
 
-        self.assertEquals(flat_texts, self.ctrl.texts()[1:])
+        self.assertEqual(flat_texts, self.ctrl.texts()[1:])
 
     def testGetItem(self):
-        """Test the ListView GetItem method"""
-        for row in range(self.ctrl.ItemCount()):
-            for col in range(self.ctrl.ColumnCount()):
-                self.assertEquals(
-                    self.ctrl.GetItem(row, col)['text'], self.texts[row][col])
+        """Test the ListView get_item method"""
+        for row in range(self.ctrl.item_count()):
+            for col in range(self.ctrl.column_count()):
+                self.assertEqual(
+                    self.ctrl.get_item(row, col).text(), self.texts[row][col])
 
     def testGetItemText(self):
-        """Test the ListView GetItem method - with text this time"""
+        """Test the ListView get_item method - with text this time"""
         for text in [row[0] for row in self.texts]:
-            self.assertEquals(
-                self.ctrl.GetItem(text)['text'], text)
+            self.assertEqual(
+                self.ctrl.get_item(text).text(), text)
 
-        self.assertRaises(ValueError, self.ctrl.GetItem, "Item not in this list")
+        self.assertRaises(ValueError, self.ctrl.get_item, "Item not in this list")
 
     def testColumn(self):
-        """Test the ListView Columns method"""
-        cols = self.ctrl.Columns()
-        self.assertEqual(len(cols), self.ctrl.ColumnCount())
+        """Test the ListView columns method"""
+        cols = self.ctrl.columns()
+        self.assertEqual(len(cols), self.ctrl.column_count())
 
         # TODO: add more checking of column values
         #for col in cols:
         #    print(col)
 
     def testGetSelectionCount(self):
-        """Test the ListView GetSelectedCount method"""
-        self.assertEquals(self.ctrl.GetSelectedCount(), 0)
+        """Test the ListView get_selected_count method"""
+        self.assertEqual(self.ctrl.get_selected_count(), 0)
 
-        self.ctrl.Select(1)
-        self.ctrl.Select(6)
+        self.ctrl.get_item(1).select()
+        self.ctrl.get_item(6).select()
 
-        self.assertEquals(self.ctrl.GetSelectedCount(), 2)
+        self.assertEqual(self.ctrl.get_selected_count(), 2)
 
 
 #    def testGetSelectionCount(self):
-#        "Test the ListView GetSelectedCount method"
+#        "Test the ListView get_selected_count method"
 #
-#        self.assertEquals(self.ctrl.GetSelectedCount(), 0)
+#        self.assertEqual(self.ctrl.get_selected_count(), 0)
 #
-#        self.ctrl.Select(1)
-#        self.ctrl.Select(7)
+#        self.ctrl.select(1)
+#        self.ctrl.select(7)
 #
-#        self.assertEquals(self.ctrl.GetSelectedCount(), 2)
+#        self.assertEqual(self.ctrl.get_selected_count(), 2)
 
     def testIsSelected(self):
         """Test ListView IsSelected for some items"""
         # ensure that the item is not selected
-        self.assertEquals(self.ctrl.IsSelected(1), False)
+        self.assertEqual(self.ctrl.get_item(1).is_selected(), False)
 
         # select an item
-        self.ctrl.Select(1)
+        self.ctrl.get_item(1).select()
 
         # now ensure that the item is selected
-        self.assertEquals(self.ctrl.IsSelected(1), True)
+        self.assertEqual(self.ctrl.get_item(1).is_selected(), True)
 
     def _testFocused(self):
         """Test checking the focus of some ListView items"""
         print("Select something quick!!")
         time.sleep(3)
-        #self.ctrl.Select(1)
+        #self.ctrl.select(1)
 
-        print(self.ctrl.IsFocused(0))
-        print(self.ctrl.IsFocused(1))
-        print(self.ctrl.IsFocused(2))
-        print(self.ctrl.IsFocused(3))
-        print(self.ctrl.IsFocused(4))
-        print(self.ctrl.IsFocused(5))
+        print(self.ctrl.is_focused(0))
+        print(self.ctrl.is_focused(1))
+        print(self.ctrl.is_focused(2))
+        print(self.ctrl.is_focused(3))
+        print(self.ctrl.is_focused(4))
+        print(self.ctrl.is_focused(5))
         #for col in cols:
         #    print(col)
 
     def testSelect(self):
         """Test ListView Selecting some items"""
-        self.ctrl.Select(1)
-        self.ctrl.Select(3)
-        self.ctrl.Select(4)
+        self.ctrl.get_item(1).select()
+        self.ctrl.get_item(3).select()
+        self.ctrl.get_item(4).select()
 
-        self.assertRaises(IndexError, self.ctrl.Deselect, 23)
+        self.assertRaises(IndexError, self.ctrl.get_item(23).select)
 
-        self.assertEquals(self.ctrl.GetSelectedCount(), 3)
+        self.assertEqual(self.ctrl.get_selected_count(), 3)
 
     def testSelectText(self):
         """Test ListView Selecting some items"""
-        self.ctrl.Select(u"Green")
-        self.ctrl.Select(u"Yellow")
-        self.ctrl.Select(u"Gray")
+        self.ctrl.get_item(u"Green").select()
+        self.ctrl.get_item(u"Yellow").select()
+        self.ctrl.get_item(u"Gray").select()
 
-        self.assertRaises(ValueError, self.ctrl.Deselect, u"Item not in list")
+        self.assertRaises(ValueError, self.ctrl.get_item, u"Item not in list")
 
-        self.assertEquals(self.ctrl.GetSelectedCount(), 3)
+        self.assertEqual(self.ctrl.get_selected_count(), 3)
 
     def testDeselect(self):
         """Test ListView Selecting some items"""
-        self.ctrl.Select(1)
-        self.ctrl.Select(4)
+        self.ctrl.get_item(1).select()
+        self.ctrl.get_item(4).select()
 
-        self.ctrl.Deselect(3)
-        self.ctrl.Deselect(4)
+        self.ctrl.get_item(3).deselect()
+        self.ctrl.get_item(4).deselect()
 
-        self.assertRaises(IndexError, self.ctrl.Deselect, 23)
+        self.assertRaises(IndexError, self.ctrl.get_item(23).deselect)
 
-        self.assertEquals(self.ctrl.GetSelectedCount(), 1)
+        self.assertEqual(self.ctrl.get_selected_count(), 1)
 
     def testGetProperties(self):
         """Test getting the properties for the listview control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             "ListView", props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props.keys():
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
-        self.assertEquals(props['column_count'], 8)
-        self.assertEquals(props['item_count'], 7)
+        self.assertEqual(props['column_count'], 8)
+        self.assertEqual(props['item_count'], 7)
 
     def testGetColumnTexts(self):
         """Test columns titles text"""
-        self.assertEquals(self.ctrl.GetColumn(0)['text'], u"Color")
-        self.assertEquals(self.ctrl.GetColumn(1)['text'], u"Red")
-        self.assertEquals(self.ctrl.GetColumn(2)['text'], u"Green")
-        self.assertEquals(self.ctrl.GetColumn(3)['text'], u"Blue")
+        self.assertEqual(self.ctrl.get_column(0)['text'], u"Color")
+        self.assertEqual(self.ctrl.get_column(1)['text'], u"Red")
+        self.assertEqual(self.ctrl.get_column(2)['text'], u"Green")
+        self.assertEqual(self.ctrl.get_column(3)['text'], u"Blue")
 
     def testItemRectangles(self):
         """Test getting item rectangles"""
-        yellow_rect = self.ctrl.GetItemRect('Yellow')
+        yellow_rect = self.ctrl.get_item_rect('Yellow')
         gold_rect = RECT(13, 0, 61, 53)
-        self.assertEquals(yellow_rect.left, gold_rect.left)
-        self.assertEquals(yellow_rect.top, gold_rect.top)
-        self.assertEquals(yellow_rect.right, gold_rect.right)
+        self.assertEqual(yellow_rect.left, gold_rect.left)
+        self.assertEqual(yellow_rect.top, gold_rect.top)
+        self.assertEqual(yellow_rect.right, gold_rect.right)
         if yellow_rect.bottom < 53 or yellow_rect.bottom > 55:
-            self.assertEquals(yellow_rect.bottom, gold_rect.bottom)
+            self.assertEqual(yellow_rect.bottom, gold_rect.bottom)
 
-        self.ctrl.GetItem('Green').Click(where='text')
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
+        self.ctrl.get_item('Green').click(where='text')
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), True)
 
-        self.ctrl.GetItem('Magenta').Click(where='icon')
-        self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), True)
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), False)
+        self.ctrl.get_item('Magenta').click(where='icon')
+        self.assertEqual(self.ctrl.get_item('Magenta').is_selected(), True)
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), False)
 
-        self.ctrl.GetItem('Green').Click(where='all')
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
-        self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), False)
+        self.ctrl.get_item('Green').click(where='all')
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), True)
+        self.assertEqual(self.ctrl.get_item('Magenta').is_selected(), False)
 
     def testItemCheck(self):
         """Test checking/unchecking item"""
-        if not self.dlg.Toolbar.Button(6).IsChecked():
-            self.dlg.Toolbar.Button(6).Click()
+        if not self.dlg.Toolbar.button(6).is_checked():
+            self.dlg.Toolbar.button(6).click()
 
-        yellow = self.ctrl.GetItem('Yellow')
-        yellow.Check()
-        self.assertEquals(yellow.IsChecked(), True)
+        yellow = self.ctrl.get_item('Yellow')
+        yellow.check()
+        self.assertEqual(yellow.is_checked(), True)
 
-        yellow.UnCheck()
-        self.assertEquals(yellow.IsChecked(), False)
+        yellow.uncheck()
+        self.assertEqual(yellow.is_checked(), False)
 
         # test legacy deprecated methods (TODO: remove later)
-        self.ctrl.Check('Yellow')
-        self.assertEquals(self.ctrl.IsChecked('Yellow'), True)
+        self.ctrl.get_item('Yellow').check()
+        self.assertEqual(self.ctrl.get_item('Yellow').is_checked(), True)
 
-        self.ctrl.UnCheck('Yellow')
-        self.assertEquals(self.ctrl.IsChecked('Yellow'), False)
+        self.ctrl.get_item('Yellow').uncheck()
+        self.assertEqual(self.ctrl.get_item('Yellow').is_checked(), False)
 
     def testItemClick(self):
-        """Test clicking item rectangles by Click() method"""
-        self.ctrl.GetItem('Green').Click(where='select')
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
+        """Test clicking item rectangles by click() method"""
+        self.ctrl.get_item('Green').click(where='select')
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), True)
 
-        self.ctrl.GetItem('Magenta').Click(where='select')
-        self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), True)
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), False)
-        self.assertEquals(self.ctrl.GetItem('Green').IsFocused(), False)
-        self.assertEquals(self.ctrl.GetItem('Green').State() & win32defines.LVIS_FOCUSED, 0)
+        self.ctrl.get_item('Magenta').click(where='select')
+        self.assertEqual(self.ctrl.get_item('Magenta').is_selected(), True)
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), False)
+        self.assertEqual(self.ctrl.get_item('Green').is_focused(), False)
+        self.assertEqual(self.ctrl.get_item('Green').state() & win32defines.LVIS_FOCUSED, 0)
 
-        self.ctrl.GetItem('Green').Click(where='select')
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
-        self.assertEquals(self.ctrl.IsSelected('Green'), True)  # TODO: deprecated method
-        self.assertEquals(self.ctrl.GetItem('Green').IsFocused(), True)
-        self.assertEquals(self.ctrl.IsFocused('Green'), True)  # TODO: deprecated method
-        self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), False)
+        self.ctrl.get_item('Green').click(where='select')
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), True)
+        self.assertEqual(self.ctrl.is_selected('Green'), True)  # TODO: deprecated method
+        self.assertEqual(self.ctrl.get_item('Green').is_focused(), True)
+        self.assertEqual(self.ctrl.is_focused('Green'), True)  # TODO: deprecated method
+        self.assertEqual(self.ctrl.get_item('Magenta').is_selected(), False)
 
         # Test click on checkboxes
-        if not self.dlg.Toolbar.Button(6).IsChecked():  # switch on states
-            self.dlg.Toolbar.Button(6).Click()
+        if not self.dlg.Toolbar.button(6).is_checked():  # switch on states
+            self.dlg.Toolbar.button(6).click()
 
         for i in range(1, 6):
-            self.dlg.Toolbar.Button(i - 1).Click()
+            self.dlg.Toolbar.button(i - 1).click()
 
-            self.ctrl.GetItem(i).Click(where='check')  # check item
+            self.ctrl.get_item(i).click(where='check')  # check item
             time.sleep(0.5)
-            self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
-            self.assertEquals(self.ctrl.GetItem(i - 1).IsChecked(), False)
+            self.assertEqual(self.ctrl.get_item(i).is_checked(), True)
+            self.assertEqual(self.ctrl.get_item(i - 1).is_checked(), False)
 
-            self.ctrl.GetItem(i).Click(where='check')  # uncheck item
+            self.ctrl.get_item(i).click(where='check')  # uncheck item
             time.sleep(0.5)
-            self.assertEquals(self.ctrl.GetItem(i).IsChecked(), False)
+            self.assertEqual(self.ctrl.get_item(i).is_checked(), False)
 
-            self.ctrl.GetItem(i).Click(where='check')  # recheck item
+            self.ctrl.get_item(i).click(where='check')  # recheck item
             time.sleep(0.5)
-            self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
+            self.assertEqual(self.ctrl.get_item(i).is_checked(), True)
 
-        self.dlg.Toolbar.Button(6).Click()  # switch off states
+        self.dlg.Toolbar.button(6).click()  # switch off states
 
-        self.assertRaises(RuntimeError, self.ctrl.GetItem(6).Click, where="check")
+        self.assertRaises(RuntimeError, self.ctrl.get_item(6).click, where="check")
 
     def testItemClickInput(self):
         """Test clicking item rectangles by click_input() method"""
         Timings.defaults()
 
-        self.ctrl.GetItem('Green').click_input(where='select')
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
+        self.ctrl.get_item('Green').click_input(where='select')
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), True)
 
-        self.ctrl.GetItem('Magenta').click_input(where='select')
-        self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), True)
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), False)
-        self.assertEquals(self.ctrl.GetItem('Green').IsFocused(), False)
-        self.assertEquals(self.ctrl.GetItem('Green').State() & win32defines.LVIS_FOCUSED, 0)
+        self.ctrl.get_item('Magenta').click_input(where='select')
+        self.assertEqual(self.ctrl.get_item('Magenta').is_selected(), True)
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), False)
+        self.assertEqual(self.ctrl.get_item('Green').is_focused(), False)
+        self.assertEqual(self.ctrl.get_item('Green').state() & win32defines.LVIS_FOCUSED, 0)
 
-        self.ctrl.GetItem('Green').click_input(where='select')
-        self.assertEquals(self.ctrl.GetItem('Green').IsSelected(), True)
-        self.assertEquals(self.ctrl.IsSelected('Green'), True)  # TODO: deprecated method
-        self.assertEquals(self.ctrl.GetItem('Green').IsFocused(), True)
-        self.assertEquals(self.ctrl.IsFocused('Green'), True)  # TODO: deprecated method
-        self.assertEquals(self.ctrl.GetItem('Magenta').IsSelected(), False)
+        self.ctrl.get_item('Green').click_input(where='select')
+        self.assertEqual(self.ctrl.get_item('Green').is_selected(), True)
+        self.assertEqual(self.ctrl.is_selected('Green'), True)  # TODO: deprecated method
+        self.assertEqual(self.ctrl.get_item('Green').is_focused(), True)
+        self.assertEqual(self.ctrl.is_focused('Green'), True)  # TODO: deprecated method
+        self.assertEqual(self.ctrl.get_item('Magenta').is_selected(), False)
 
         # Test click on checkboxes
-        if not self.dlg.Toolbar.Button(6).IsChecked():  # switch on states
-            self.dlg.Toolbar.Button(6).Click()
+        if not self.dlg.Toolbar.button(6).is_checked():  # switch on states
+            self.dlg.Toolbar.button(6).click()
 
         for i in range(1, 6):
-            self.dlg.Toolbar.Button(i - 1).Click()
+            self.dlg.Toolbar.button(i - 1).click()
 
-            self.ctrl.GetItem(i).click_input(where='check')  # check item
+            self.ctrl.get_item(i).click_input(where='check')  # check item
             time.sleep(0.5)
-            self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
-            self.assertEquals(self.ctrl.GetItem(i - 1).IsChecked(), False)
+            self.assertEqual(self.ctrl.get_item(i).is_checked(), True)
+            self.assertEqual(self.ctrl.get_item(i - 1).is_checked(), False)
 
-            self.ctrl.GetItem(i).click_input(where='check')  # uncheck item
+            self.ctrl.get_item(i).click_input(where='check')  # uncheck item
             time.sleep(0.5)
-            self.assertEquals(self.ctrl.GetItem(i).IsChecked(), False)
+            self.assertEqual(self.ctrl.get_item(i).is_checked(), False)
 
-            self.ctrl.GetItem(i).click_input(where='check')  # recheck item
+            self.ctrl.get_item(i).click_input(where='check')  # recheck item
             time.sleep(0.5)
-            self.assertEquals(self.ctrl.GetItem(i).IsChecked(), True)
+            self.assertEqual(self.ctrl.get_item(i).is_checked(), True)
 
-        self.dlg.Toolbar.Button(6).Click()  # switch off states
+        self.dlg.Toolbar.button(6).click()  # switch off states
 
-        self.assertRaises(RuntimeError, self.ctrl.GetItem(6).click_input, where="check")
+        self.assertRaises(RuntimeError, self.ctrl.get_item(6).click_input, where="check")
 
     def testItemMethods(self):
         """Test short item methods like Text(), State() etc"""
-        self.assertEquals(self.ctrl.GetItem('Green').Text(), 'Green')
-        self.assertEquals(self.ctrl.GetItem('Green').Image(), 2)
-        self.assertEquals(self.ctrl.GetItem('Green').Indent(), 0)
+        self.assertEqual(self.ctrl.get_item('Green').text(), 'Green')
+        self.assertEqual(self.ctrl.get_item('Green').image(), 2)
+        self.assertEqual(self.ctrl.get_item('Green').indent(), 0)
 
     def test_ensure_visible(self):
-        self.dlg.MoveWindow(width=300)
+        self.dlg.move_window(width=300)
 
         # Gray is selected by click because ensure_visible() is called inside
-        self.ctrl.GetItem('Gray').Click()
-        self.assertEquals(self.ctrl.GetItem('Gray').IsSelected(), True)
+        self.ctrl.get_item('Gray').click()
+        self.assertEqual(self.ctrl.get_item('Gray').is_selected(), True)
         self.dlg.set_focus()  # just in case
 
-        self.ctrl.GetItem('Green').EnsureVisible()
-        self.ctrl.GetItem('Red').Click()
-        self.assertEquals(self.ctrl.GetItem('Gray').IsSelected(), False)
-        self.assertEquals(self.ctrl.GetItem('Red').IsSelected(), True)
+        self.ctrl.get_item('Green').ensure_visible()
+        self.ctrl.get_item('Red').click()
+        self.assertEqual(self.ctrl.get_item('Gray').is_selected(), False)
+        self.assertEqual(self.ctrl.get_item('Red').is_selected(), True)
 
 #
 #    def testSubItems(self):
 #
-#        for row in range(self.ctrl.ItemCount())
+#        for row in range(self.ctrl.item_count())
 #
-#        for i in self.ctrl.Items():
+#        for i in self.ctrl.items():
 #
-#            #self.assertEquals(item.Text, texts[i])
+#            #self.assertEqual(item.Text, texts[i])
 
     def testEqualsItems(self):
         """
         Test __eq__ and __ne__ cases for _listview_item.
         """
-        item1 = self.ctrl.GetItem(0, 0)
-        item1_copy = self.ctrl.GetItem(0, 0)
-        item2 = self.ctrl.GetItem(1, 0)
+        item1 = self.ctrl.get_item(0, 0)
+        item1_copy = self.ctrl.get_item(0, 0)
+        item2 = self.ctrl.get_item(1, 0)
 
         self.assertEqual(item1, item1_copy)
         self.assertNotEqual(item1, "Not _listview_item")
@@ -437,8 +437,8 @@ class ListViewTestCases32(unittest.TestCase):
 
     def test_cells_rectangles(self):
         """Test the ListView get_item rectangle method for cells"""
-        if not self.dlg.Toolbar.Button(4).is_checked():
-            self.dlg.Toolbar.Button(4).click()
+        if not self.dlg.Toolbar.button(4).is_checked():
+            self.dlg.Toolbar.button(4).click()
 
         for row in range(self.ctrl.item_count() - 1):
             for col in range(self.ctrl.column_count() - 1):
@@ -584,73 +584,73 @@ class TreeViewTestCases32(unittest.TestCase):
         self.app = Application()
         self.app.start(self.path)
         self.dlg = self.app.MicrosoftControlSpy
-        self.ctrl = self.app.MicrosoftControlSpy.TreeView.WrapperObject()
+        self.ctrl = self.app.MicrosoftControlSpy.TreeView.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def test_friendly_class_name(self):
         """Make sure the friendly class name is set correctly (TreeView)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "TreeView")
+        self.assertEqual(self.ctrl.friendly_class_name(), "TreeView")
 
     def testItemCount(self):
         """Test the TreeView ItemCount method"""
-        self.assertEquals(self.ctrl.ItemCount(), 37)
+        self.assertEqual(self.ctrl.item_count(), 37)
 
     def testGetItem(self):
-        """Test the GetItem method"""
-        self.assertRaises(RuntimeError, self.ctrl.GetItem, "test\here\please")
+        """Test the get_item method"""
+        self.assertRaises(RuntimeError, self.ctrl.get_item, "test\here\please")
 
-        self.assertRaises(IndexError, self.ctrl.GetItem, r"\test\here\please")
+        self.assertRaises(IndexError, self.ctrl.get_item, r"\test\here\please")
 
-        self.assertEquals(
-            self.ctrl.GetItem((0, 1, 2)).Text(), self.texts[1][3] + " kg")
+        self.assertEqual(
+            self.ctrl.get_item((0, 1, 2)).text(), self.texts[1][3] + " kg")
 
-        self.assertEquals(
-            self.ctrl.GetItem(r"\The Planets\Venus\4.869e24 kg", exact=True).Text(), self.texts[1][3] + " kg")
+        self.assertEqual(
+            self.ctrl.get_item(r"\The Planets\Venus\4.869e24 kg", exact=True).text(), self.texts[1][3] + " kg")
 
-        self.assertEquals(
-            self.ctrl.GetItem(["The Planets", "Venus", "4.869"]).Text(),
+        self.assertEqual(
+            self.ctrl.get_item(["The Planets", "Venus", "4.869"]).text(),
             self.texts[1][3] + " kg"
         )
 
     def testItemText(self):
         """Test the TreeView item Text() method"""
-        self.assertEquals(self.ctrl.Root().Text(), self.root_text)
+        self.assertEqual(self.ctrl.tree_root().text(), self.root_text)
 
-        self.assertEquals(
-            self.ctrl.GetItem((0, 1, 2)).Text(), self.texts[1][3] + " kg")
+        self.assertEqual(
+            self.ctrl.get_item((0, 1, 2)).text(), self.texts[1][3] + " kg")
 
     def testSelect(self):
         """Test selecting an item"""
-        self.ctrl.Select((0, 1, 2))
+        self.ctrl.select((0, 1, 2))
 
-        self.ctrl.GetItem((0, 1, 2)).State()
+        self.ctrl.get_item((0, 1, 2)).state()
 
-        self.assertEquals(True, self.ctrl.IsSelected((0, 1, 2)))
+        self.assertEqual(True, self.ctrl.is_selected((0, 1, 2)))
 
     def testEnsureVisible(self):
         """make sure that the item is visible"""
         # TODO: note this is partially a fake test at the moment because
         # just by getting an item - we usually make it visible
-        self.ctrl.EnsureVisible((0, 8, 2))
+        self.ctrl.ensure_visible((0, 8, 2))
 
         # make sure that the item is not hidden
-        self.assertNotEqual(None, self.ctrl.GetItem((0, 8, 2)).client_rect())
+        self.assertNotEqual(None, self.ctrl.get_item((0, 8, 2)).client_rect())
 
     def testGetProperties(self):
         """Test getting the properties for the treeview control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             "TreeView", props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
     def testItemsClick(self):
         """Test clicking of items and sub-items in the treeview control"""
@@ -658,31 +658,31 @@ class TreeViewTestCases32(unittest.TestCase):
         mercury_diam_item_path = (0, 0, 1)
         mars_dist_item_path = (0, 3, 0)
 
-        itm = self.ctrl.GetItem(planets_item_path)
-        itm.EnsureVisible()
+        itm = self.ctrl.get_item(planets_item_path)
+        itm.ensure_visible()
         time.sleep(1)
-        itm.Click(button='left')
-        self.assertEquals(True, self.ctrl.IsSelected(planets_item_path))
+        itm.click(button='left')
+        self.assertEqual(True, self.ctrl.is_selected(planets_item_path))
 
-        itm = self.ctrl.GetItem(mars_dist_item_path)
-        itm.EnsureVisible()
+        itm = self.ctrl.get_item(mars_dist_item_path)
+        itm.ensure_visible()
         time.sleep(1)
-        itm.Click(button='left')
-        self.assertEquals(True, self.ctrl.IsSelected(mars_dist_item_path))
+        itm.click(button='left')
+        self.assertEqual(True, self.ctrl.is_selected(mars_dist_item_path))
 
-        itm = self.ctrl.GetItem(mercury_diam_item_path)
-        itm.EnsureVisible()
+        itm = self.ctrl.get_item(mercury_diam_item_path)
+        itm.ensure_visible()
         time.sleep(1)
-        itm.Click(button='left')
-        self.assertEquals(True, self.ctrl.IsSelected(mercury_diam_item_path))
-        self.assertEquals(False, self.ctrl.IsSelected(mars_dist_item_path))
+        itm.click(button='left')
+        self.assertEqual(True, self.ctrl.is_selected(mercury_diam_item_path))
+        self.assertEqual(False, self.ctrl.is_selected(mars_dist_item_path))
 
-        itm = self.ctrl.GetItem(planets_item_path)
-        itm.EnsureVisible()
+        itm = self.ctrl.get_item(planets_item_path)
+        itm.ensure_visible()
         time.sleep(1)
-        itm.Click(button='left')
-        self.assertEquals(True, self.ctrl.IsSelected(planets_item_path))
-        self.assertEquals(False, self.ctrl.IsSelected(mercury_diam_item_path))
+        itm.click(button='left')
+        self.assertEqual(True, self.ctrl.is_selected(planets_item_path))
+        self.assertEqual(False, self.ctrl.is_selected(mercury_diam_item_path))
 
 
 if is_x64_Python():
@@ -705,92 +705,92 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         self.app = Application().start(os.path.join(mfc_samples_folder, "CmnCtrl1.exe"))
 
         self.dlg = self.app.CommonControlsSample
-        self.ctrl = self.app.CommonControlsSample.TreeView.WrapperObject()
+        self.ctrl = self.app.CommonControlsSample.TreeView.wrapper_object()
         self.app.wait_cpu_usage_lower(threshold=1.5, timeout=30, usage_interval=1)
 
     def tearDown(self):
         """Close the application after tests"""
         self.dlg.send_message(win32defines.WM_CLOSE)
-        self.app.kill_()
+        self.app.kill()
 
     def testCheckBoxes(self):
-        """Make sure tree view item method IsChecked() works as expected"""
+        """Make sure tree view item method is_checked() works as expected"""
         self.dlg.set_focus()
         self.dlg.TVS_CHECKBOXES.check_by_click()
-        birds = self.ctrl.GetItem(r'\Birds')
-        birds.Click(where='check')
-        self.assertEqual(birds.IsChecked(), True)
+        birds = self.ctrl.get_item(r'\Birds')
+        birds.click(where='check')
+        self.assertEqual(birds.is_checked(), True)
         birds.click_input(where='check')
-        wait_until(3, 0.4, birds.IsChecked, value=False)
+        wait_until(3, 0.4, birds.is_checked, value=False)
 
     def testPrintItems(self):
-        """Test TreeView method PrintItems()"""
-        birds = self.ctrl.GetItem(r'\Birds')
-        birds.Expand()
-        items_str = self.ctrl.PrintItems()
-        self.assertEquals(items_str, "Treeview1\nBirds\n Eagle\n Hummingbird\n Pigeon\n" +
+        """Test TreeView method print_items()"""
+        birds = self.ctrl.get_item(r'\Birds')
+        birds.expand()
+        items_str = self.ctrl.print_items()
+        self.assertEqual(items_str, "Treeview1\nBirds\n Eagle\n Hummingbird\n Pigeon\n" +
                                      "Dogs\n Dalmatian\n German Shepherd\n Great Dane\n" +
                                      "Fish\n Salmon\n Snapper\n Sole\n")
 
     def testIsSelected(self):
         """Make sure tree view item method IsSelected() works as expected"""
-        birds = self.ctrl.GetItem(r'\Birds')
-        birds.Expand()
-        eagle = self.ctrl.GetItem(r'\Birds\Eagle')
-        eagle.Select()
-        self.assertEquals(eagle.IsSelected(), True)
+        birds = self.ctrl.get_item(r'\Birds')
+        birds.expand()
+        eagle = self.ctrl.get_item(r'\Birds\Eagle')
+        eagle.select()
+        self.assertEqual(eagle.is_selected(), True)
 
     def test_expand_collapse(self):
         """Make sure tree view item methods Expand() and Collapse() work as expected"""
-        birds = self.ctrl.GetItem(r'\Birds')
-        birds.Expand()
-        self.assertEquals(birds.IsExpanded(), True)
+        birds = self.ctrl.get_item(r'\Birds')
+        birds.expand()
+        self.assertEqual(birds.is_expanded(), True)
 
-        birds.Collapse()
-        self.assertEquals(birds.IsExpanded(), False)
+        birds.collapse()
+        self.assertEqual(birds.is_expanded(), False)
 
     def test_expand_collapse_buttons(self):
         """Make sure correct area is clicked"""
         self.dlg.TVS_HASBUTTONS.click_input()
         self.dlg.TVS_HASLINES.click_input()
         self.dlg.TVS_LINESATROOT.click_input()
-        birds = self.ctrl.GetItem(r'\Birds')
+        birds = self.ctrl.get_item(r'\Birds')
 
-        birds.Click(where='button')
-        self.assertEquals(birds.IsExpanded(), True)
-        birds.Click(double=True, where='icon')
-        self.assertEquals(birds.IsExpanded(), False)
+        birds.click(where='button')
+        self.assertEqual(birds.is_expanded(), True)
+        birds.click(double=True, where='icon')
+        self.assertEqual(birds.is_expanded(), False)
 
         birds.click_input(where='button')
-        self.assertEquals(birds.IsExpanded(), True)
+        self.assertEqual(birds.is_expanded(), True)
         birds.click_input(double=True, where='icon')
-        self.assertEquals(birds.IsExpanded(), False)
+        self.assertEqual(birds.is_expanded(), False)
 
     def testIncorrectAreas(self):
         """Make sure incorrect area raises an exception"""
-        birds = self.ctrl.GetItem(r'\Birds')
-        self.assertRaises(RuntimeError, birds.Click, where='radiob')
+        birds = self.ctrl.get_item(r'\Birds')
+        self.assertRaises(RuntimeError, birds.click, where='radiob')
         self.assertRaises(RuntimeError, birds.click_input, where='radiob')
 
     def testStartDraggingAndDrop(self):
-        """Make sure tree view item methods StartDragging() and Drop() work as expected"""
-        birds = self.ctrl.GetItem(r'\Birds')
-        birds.Expand()
+        """Make sure tree view item methods StartDragging() and drop() work as expected"""
+        birds = self.ctrl.get_item(r'\Birds')
+        birds.expand()
 
-        pigeon = self.ctrl.GetItem(r'\Birds\Pigeon')
-        pigeon.StartDragging()
+        pigeon = self.ctrl.get_item(r'\Birds\Pigeon')
+        pigeon.start_dragging()
 
-        eagle = self.ctrl.GetItem(r'\Birds\Eagle')
-        eagle.Drop()
+        eagle = self.ctrl.get_item(r'\Birds\Eagle')
+        eagle.drop()
 
-        self.assertRaises(IndexError, birds.GetChild, 'Pigeon')
-        self.assertRaises(IndexError, self.ctrl.GetItem, r'\Birds\Pigeon')
-        self.assertRaises(IndexError, self.ctrl.GetItem, [0, 2])
-        self.assertRaises(IndexError, self.ctrl.GetItem, r'\Bread', exact=True)
+        self.assertRaises(IndexError, birds.get_child, 'Pigeon')
+        self.assertRaises(IndexError, self.ctrl.get_item, r'\Birds\Pigeon')
+        self.assertRaises(IndexError, self.ctrl.get_item, [0, 2])
+        self.assertRaises(IndexError, self.ctrl.get_item, r'\Bread', exact=True)
 
-        new_pigeon = self.ctrl.GetItem(r'\Birds\Eagle\Pigeon')
-        self.assertEquals(len(birds.children()), 2)
-        self.assertEquals(new_pigeon.children(), [])
+        new_pigeon = self.ctrl.get_item(r'\Birds\Eagle\Pigeon')
+        self.assertEqual(len(birds.children()), 2)
+        self.assertEqual(new_pigeon.children(), [])
 
 
 class HeaderTestCases(unittest.TestCase):
@@ -817,61 +817,61 @@ class HeaderTestCases(unittest.TestCase):
 
         self.app = app
         self.dlg = app.RowListSampleApplication
-        self.ctrl = app.RowListSampleApplication.Header.WrapperObject()
+        self.ctrl = app.RowListSampleApplication.Header.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (Header)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "Header")
+        self.assertEqual(self.ctrl.friendly_class_name(), "Header")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals(self.ctrl.texts()[1:], self.texts)
+        self.assertEqual(self.ctrl.texts()[1:], self.texts)
 
     def testGetProperties(self):
         """Test getting the properties for the header control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
     def testItemCount(self):
-        self.assertEquals(8, self.ctrl.ItemCount())
+        self.assertEqual(8, self.ctrl.item_count())
 
     def testGetColumnRectangle(self):
         for i in range(0, 3):
-            self.assertEquals(self.item_rects[i].left, self.ctrl.GetColumnRectangle(i).left)
-            self.assertEquals(self.item_rects[i].right, self.ctrl.GetColumnRectangle(i).right)
-            self.assertEquals(self.item_rects[i].top, self.ctrl.GetColumnRectangle(i).top)
-            self.failIf(abs(self.item_rects[i].bottom - self.ctrl.GetColumnRectangle(i).bottom) > 2)
+            self.assertEqual(self.item_rects[i].left, self.ctrl.get_column_rectangle(i).left)
+            self.assertEqual(self.item_rects[i].right, self.ctrl.get_column_rectangle(i).right)
+            self.assertEqual(self.item_rects[i].top, self.ctrl.get_column_rectangle(i).top)
+            self.assertFalse(abs(self.item_rects[i].bottom - self.ctrl.get_column_rectangle(i).bottom) > 2)
 
     def testClientRects(self):
         test_rects = self.item_rects
         test_rects.insert(0, self.ctrl.client_rect())
 
         client_rects = self.ctrl.client_rects()
-        self.assertEquals(len(test_rects), len(client_rects))
+        self.assertEqual(len(test_rects), len(client_rects))
         for i, r in enumerate(test_rects):
-            self.assertEquals(r.left, client_rects[i].left)
-            self.assertEquals(r.right, client_rects[i].right)
-            self.assertEquals(r.top, client_rects[i].top)
-            self.failIf(abs(r.bottom - client_rects[i].bottom) > 2)  # may be equal to 17 or 19
+            self.assertEqual(r.left, client_rects[i].left)
+            self.assertEqual(r.right, client_rects[i].right)
+            self.assertEqual(r.top, client_rects[i].top)
+            self.assertFalse(abs(r.bottom - client_rects[i].bottom) > 2)  # may be equal to 17 or 19
 
     def testGetColumnText(self):
         for i in range(0, 3):
-            self.assertEquals(
+            self.assertEqual(
                 self.texts[i],
-                self.ctrl.GetColumnText(i))
+                self.ctrl.get_column_text(i))
 
 
 class StatusBarTestCases(unittest.TestCase):
@@ -892,37 +892,37 @@ class StatusBarTestCases(unittest.TestCase):
             RECT(92, 2, 261, 22)]
         self.app = app
         self.dlg = app.MicrosoftControlSpy
-        self.ctrl = app.MicrosoftControlSpy.StatusBar.WrapperObject()
+        self.ctrl = app.MicrosoftControlSpy.StatusBar.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def test_friendly_class_name(self):
         """Make sure the friendly class name is set correctly (StatusBar)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "StatusBar")
+        self.assertEqual(self.ctrl.friendly_class_name(), "StatusBar")
 
     def test_texts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals(self.ctrl.texts()[1:], self.texts)
+        self.assertEqual(self.ctrl.texts()[1:], self.texts)
 
     def testGetProperties(self):
         """Test getting the properties for the status bar control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
     def testBorderWidths(self):
         """Make sure the border widths are retrieved correctly"""
-        self.assertEquals(
-            self.ctrl.BorderWidths(),
+        self.assertEqual(
+            self.ctrl.border_widths(),
             dict(
                 Horizontal=0,
                 Vertical=2,
@@ -932,44 +932,44 @@ class StatusBarTestCases(unittest.TestCase):
 
     def testPartCount(self):
         "Make sure the number of parts is retrieved correctly"
-        self.assertEquals(self.ctrl.PartCount(), 3)
+        self.assertEqual(self.ctrl.part_count(), 3)
 
     def testPartRightEdges(self):
         "Make sure the part widths are retrieved correctly"
 
-        for i in range(0, self.ctrl.PartCount() - 1):
-            self.assertEquals(self.ctrl.PartRightEdges()[i], self.part_rects[i].right)
+        for i in range(0, self.ctrl.part_count() - 1):
+            self.assertEqual(self.ctrl.part_right_edges()[i], self.part_rects[i].right)
 
-        self.assertEquals(self.ctrl.PartRightEdges()[i + 1], -1)
+        self.assertEqual(self.ctrl.part_right_edges()[i + 1], -1)
 
     def testGetPartRect(self):
         "Make sure the part rectangles are retrieved correctly"
 
-        for i in range(0, self.ctrl.PartCount()):
-            part_rect = self.ctrl.GetPartRect(i)
-            self.assertEquals(part_rect.left, self.part_rects[i].left)
-            if i != self.ctrl.PartCount() - 1:
-                self.assertEquals(part_rect.right, self.part_rects[i].right)
-            self.assertEquals(part_rect.top, self.part_rects[i].top)
-            self.failIf(abs(part_rect.bottom - self.part_rects[i].bottom) > 2)
+        for i in range(0, self.ctrl.part_count()):
+            part_rect = self.ctrl.get_part_rect(i)
+            self.assertEqual(part_rect.left, self.part_rects[i].left)
+            if i != self.ctrl.part_count() - 1:
+                self.assertEqual(part_rect.right, self.part_rects[i].right)
+            self.assertEqual(part_rect.top, self.part_rects[i].top)
+            self.assertFalse(abs(part_rect.bottom - self.part_rects[i].bottom) > 2)
 
-        self.assertRaises(IndexError, self.ctrl.GetPartRect, 99)
+        self.assertRaises(IndexError, self.ctrl.get_part_rect, 99)
 
     def testClientRects(self):
-        self.assertEquals(self.ctrl.ClientRect(), self.ctrl.ClientRects()[0])
-        client_rects = self.ctrl.ClientRects()[1:]
+        self.assertEqual(self.ctrl.client_rect(), self.ctrl.client_rects()[0])
+        client_rects = self.ctrl.client_rects()[1:]
         for i, client_rect in enumerate(client_rects):
-            self.assertEquals(self.part_rects[i].left, client_rect.left)
+            self.assertEqual(self.part_rects[i].left, client_rect.left)
             if i != len(client_rects) - 1:
-                self.assertEquals(self.part_rects[i].right, client_rect.right)
-            self.assertEquals(self.part_rects[i].top, client_rect.top)
-            self.failIf(abs(self.part_rects[i].bottom - client_rect.bottom) > 2)
+                self.assertEqual(self.part_rects[i].right, client_rect.right)
+            self.assertEqual(self.part_rects[i].top, client_rect.top)
+            self.assertFalse(abs(self.part_rects[i].bottom - client_rect.bottom) > 2)
 
     def testGetPartText(self):
-        self.assertRaises(IndexError, self.ctrl.GetPartText, 99)
+        self.assertRaises(IndexError, self.ctrl.get_part_text, 99)
 
         for i, text in enumerate(self.texts):
-            self.assertEquals(text, self.ctrl.GetPartText(i))
+            self.assertEqual(text, self.ctrl.get_part_text(i))
 
 
 class TabControlTestCases(unittest.TestCase):
@@ -998,36 +998,36 @@ class TabControlTestCases(unittest.TestCase):
 
         self.app = app
         self.dlg = app.CommonControlsSample
-        self.ctrl = app.CommonControlsSample.TabControl.WrapperObject()
+        self.ctrl = app.CommonControlsSample.TabControl.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (TabControl)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "TabControl")
+        self.assertEqual(self.ctrl.friendly_class_name(), "TabControl")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals(self.ctrl.texts()[1:], self.texts)
+        self.assertEqual(self.ctrl.texts()[1:], self.texts)
 
     def testGetProperties(self):
         """Test getting the properties for the tabcontrol"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
     def testRowCount(self):
-        self.assertEquals(1, self.ctrl.RowCount())
+        self.assertEqual(1, self.ctrl.row_count())
 
         dlgClientRect = self.ctrl.parent().rectangle()  # use the parent as a reference
         prev_rect = self.ctrl.rectangle() - dlgClientRect
@@ -1036,7 +1036,7 @@ class TabControlTestCases(unittest.TestCase):
         new_rect = RECT(prev_rect)
         new_rect.right = int(new_rect.width() / 2)
 
-        self.ctrl.MoveWindow(
+        self.ctrl.move_window(
             new_rect.left,
             new_rect.top,
             new_rect.width(),
@@ -1045,29 +1045,29 @@ class TabControlTestCases(unittest.TestCase):
         time.sleep(0.1)
 
         # verify two tab rows
-        self.assertEquals(2, self.ctrl.RowCount())
+        self.assertEqual(2, self.ctrl.row_count())
 
         # restore back the original size of the control
-        self.ctrl.MoveWindow(prev_rect)
-        self.assertEquals(1, self.ctrl.RowCount())
+        self.ctrl.move_window(prev_rect)
+        self.assertEqual(1, self.ctrl.row_count())
 
     def testGetSelectedTab(self):
-        self.assertEquals(0, self.ctrl.GetSelectedTab())
-        self.ctrl.Select(1)
-        self.assertEquals(1, self.ctrl.GetSelectedTab())
-        self.ctrl.Select(u"CMonthCalCtrl")
-        self.assertEquals(4, self.ctrl.GetSelectedTab())
+        self.assertEqual(0, self.ctrl.get_selected_tab())
+        self.ctrl.select(1)
+        self.assertEqual(1, self.ctrl.get_selected_tab())
+        self.ctrl.select(u"CMonthCalCtrl")
+        self.assertEqual(4, self.ctrl.get_selected_tab())
 
     def testTabCount(self):
         """Make sure the number of parts is retrieved correctly"""
-        self.assertEquals(self.ctrl.TabCount(), 5)
+        self.assertEqual(self.ctrl.tab_count(), 5)
 
     def testGetTabRect(self):
         """Make sure the part rectangles are retrieved correctly"""
         for i, _ in enumerate(self.rects):
-            self.assertEquals(self.ctrl.GetTabRect(i), self.rects[i])
+            self.assertEqual(self.ctrl.get_tab_rect(i), self.rects[i])
 
-        self.assertRaises(IndexError, self.ctrl.GetTabRect, 99)
+        self.assertRaises(IndexError, self.ctrl.get_tab_rect, 99)
 
 #    def testGetTabState(self):
 #        self.assertRaises(IndexError, self.ctrl.GetTabState, 99)
@@ -1080,7 +1080,7 @@ class TabControlTestCases(unittest.TestCase):
 #        time.sleep(2)
 #        print("==\n",self.ctrl.TabStates())
 #
-#        self.assertEquals(self.ctrl.GetTabState(1), 1)
+#        self.assertEqual(self.ctrl.GetTabState(1), 1)
 #
 #    def testTabStates(self):
 #        print(self.ctrl.TabStates())
@@ -1088,23 +1088,23 @@ class TabControlTestCases(unittest.TestCase):
 
     def testGetTabText(self):
         for i, text in enumerate(self.texts):
-            self.assertEquals(text, self.ctrl.GetTabText(i))
+            self.assertEqual(text, self.ctrl.get_tab_text(i))
 
-        self.assertRaises(IndexError, self.ctrl.GetTabText, 99)
+        self.assertRaises(IndexError, self.ctrl.get_tab_text, 99)
 
     def testClientRects(self):
-        self.assertEquals(self.ctrl.client_rect(), self.ctrl.client_rects()[0])
-        self.assertEquals(self.rects, self.ctrl.client_rects()[1:])
+        self.assertEqual(self.ctrl.client_rect(), self.ctrl.client_rects()[0])
+        self.assertEqual(self.rects, self.ctrl.client_rects()[1:])
 
     def testSelect(self):
-        self.assertEquals(0, self.ctrl.GetSelectedTab())
+        self.assertEqual(0, self.ctrl.get_selected_tab())
 
-        self.ctrl.Select(1)
-        self.assertEquals(1, self.ctrl.GetSelectedTab())
-        self.ctrl.Select(u"CToolBarCtrl")
-        self.assertEquals(2, self.ctrl.GetSelectedTab())
+        self.ctrl.select(1)
+        self.assertEqual(1, self.ctrl.get_selected_tab())
+        self.ctrl.select(u"CToolBarCtrl")
+        self.assertEqual(2, self.ctrl.get_selected_tab())
 
-        self.assertRaises(IndexError, self.ctrl.Select, 99)
+        self.assertRaises(IndexError, self.ctrl.select, 99)
 
 
 class ToolbarTestCases(unittest.TestCase):
@@ -1122,7 +1122,7 @@ class ToolbarTestCases(unittest.TestCase):
         self.dlg = app.CommonControlsSample
 
         # select a tab with toolbar controls
-        self.dlg.SysTabControl.Select(u"CToolBarCtrl")
+        self.dlg.SysTabControl.select(u"CToolBarCtrl")
 
         # see identifiers available at that tab
         #self.dlg.PrintControlIdentifiers()
@@ -1130,115 +1130,115 @@ class ToolbarTestCases(unittest.TestCase):
         # The sample app has two toolbars. The first toolbar can be
         # addressed as Toolbar, Toolbar0 and Toolbar1.
         # The second control goes as Toolbar2
-        self.ctrl = app.CommonControlsSample.ToolbarNew.WrapperObject()
-        self.ctrl2 = app.CommonControlsSample.ToolbarErase.WrapperObject()
+        self.ctrl = app.CommonControlsSample.ToolbarNew.wrapper_object()
+        self.ctrl2 = app.CommonControlsSample.ToolbarErase.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (Toolbar)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "Toolbar")
+        self.assertEqual(self.ctrl.friendly_class_name(), "Toolbar")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
         for txt in self.ctrl.texts():
-            self.assertEquals(isinstance(txt, six.string_types), True)
+            self.assertEqual(isinstance(txt, six.string_types), True)
 
     def testGetProperties(self):
         """Test getting the properties for the toolbar control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
-        self.assertEquals(
-            self.ctrl.ButtonCount(), props['button_count'])
+        self.assertEqual(
+            self.ctrl.button_count(), props['button_count'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
     def testButtonCount(self):
         """Test the button count method of the toolbar"""
         # TODO: for a some reason the first toolbar returns button count = 12
         # The same as in the second toolbar, even though their handles are different.
         # Maybe the test app itself has to be fixed too.
-        #self.assertEquals(self.ctrl.ButtonCount(), 9)
+        #self.assertEqual(self.ctrl.button_count(), 9)
 
-        self.assertEquals(self.ctrl2.ButtonCount(), 12)
+        self.assertEqual(self.ctrl2.button_count(), 12)
 
     def testGetButton(self):
-        self.assertRaises(IndexError, self.ctrl.GetButton, 29)
+        self.assertRaises(IndexError, self.ctrl.get_button, 29)
 
     def testGetButtonRect(self):
-        rect_ctrl = self.ctrl.GetButtonRect(0)
-        self.assertEquals((rect_ctrl.left, rect_ctrl.top), (0, 0))
-        self.failIf((rect_ctrl.right - rect_ctrl.left) > 40)
-        self.failIf((rect_ctrl.right - rect_ctrl.left) < 36)
-        self.failIf((rect_ctrl.bottom - rect_ctrl.top) > 38)
-        self.failIf((rect_ctrl.bottom - rect_ctrl.top) < 36)
-        #self.assertEquals(rect_ctrl, RECT(0, 0, 40, 38))
+        rect_ctrl = self.ctrl.get_button_rect(0)
+        self.assertEqual((rect_ctrl.left, rect_ctrl.top), (0, 0))
+        self.assertFalse((rect_ctrl.right - rect_ctrl.left) > 40)
+        self.assertFalse((rect_ctrl.right - rect_ctrl.left) < 36)
+        self.assertFalse((rect_ctrl.bottom - rect_ctrl.top) > 38)
+        self.assertFalse((rect_ctrl.bottom - rect_ctrl.top) < 36)
+        #self.assertEqual(rect_ctrl, RECT(0, 0, 40, 38))
 
-        rect_ctrl2 = self.ctrl2.GetButtonRect(0)
-        self.assertEquals((rect_ctrl2.left, rect_ctrl2.top), (0, 0))
-        self.failIf((rect_ctrl2.right - rect_ctrl2.left) > 70)
-        self.failIf((rect_ctrl2.right - rect_ctrl2.left) < 64)
-        self.failIf((rect_ctrl2.bottom - rect_ctrl2.top) > 38)
-        self.failIf((rect_ctrl2.bottom - rect_ctrl2.top) < 36)
-        #self.assertEquals(rect_ctrl2, RECT(0, 0, 70, 38))
+        rect_ctrl2 = self.ctrl2.get_button_rect(0)
+        self.assertEqual((rect_ctrl2.left, rect_ctrl2.top), (0, 0))
+        self.assertFalse((rect_ctrl2.right - rect_ctrl2.left) > 70)
+        self.assertFalse((rect_ctrl2.right - rect_ctrl2.left) < 64)
+        self.assertFalse((rect_ctrl2.bottom - rect_ctrl2.top) > 38)
+        self.assertFalse((rect_ctrl2.bottom - rect_ctrl2.top) < 36)
+        #self.assertEqual(rect_ctrl2, RECT(0, 0, 70, 38))
 
     def testGetToolTipsControls(self):
-        tips = self.ctrl.GetToolTipsControl()
+        tips = self.ctrl.get_tool_tips_control()
         tt = tips.texts()
-        self.assertEquals(u"New" in tt, True)
-        self.assertEquals(u"About" in tt, True)
+        self.assertEqual(u"New" in tt, True)
+        self.assertEqual(u"About" in tt, True)
 
-        tips = self.ctrl2.GetToolTipsControl()
+        tips = self.ctrl2.get_tool_tips_control()
         tt = tips.texts()
-        self.assertEquals(u"Pencil" in tt, True)
-        self.assertEquals(u"Ellipse" in tt, True)
+        self.assertEqual(u"Pencil" in tt, True)
+        self.assertEqual(u"Ellipse" in tt, True)
 
     def testPressButton(self):
 
-        self.ctrl.PressButton(0)
+        self.ctrl.press_button(0)
 
         #print(self.ctrl.texts())
         self.assertRaises(
             findbestmatch.MatchError,
-            self.ctrl.PressButton,
+            self.ctrl.press_button,
             "asdfdasfasdf")
 
         # todo more tests for pressbutton
-        self.ctrl.PressButton(u"Open")
+        self.ctrl.press_button(u"Open")
 
     def testCheckButton(self):
-        self.ctrl2.CheckButton('Erase', True)
-        self.assertEquals(self.ctrl2.Button('Erase').IsChecked(), True)
+        self.ctrl2.check_button('Erase', True)
+        self.assertEqual(self.ctrl2.button('Erase').is_checked(), True)
 
-        self.ctrl2.CheckButton('Pencil', True)
-        self.assertEquals(self.ctrl2.Button('Erase').IsChecked(), False)
+        self.ctrl2.check_button('Pencil', True)
+        self.assertEqual(self.ctrl2.button('Erase').is_checked(), False)
 
-        self.ctrl2.CheckButton('Erase', False)
-        self.assertEquals(self.ctrl2.Button('Erase').IsChecked(), False)
+        self.ctrl2.check_button('Erase', False)
+        self.assertEqual(self.ctrl2.button('Erase').is_checked(), False)
 
         # try to check separator
-        self.assertRaises(RuntimeError, self.ctrl.CheckButton, 3, True)
+        self.assertRaises(RuntimeError, self.ctrl.check_button, 3, True)
 
     def testIsCheckable(self):
-        self.assertNotEqual(self.ctrl2.Button('Erase').IsCheckable(), False)
-        self.assertEquals(self.ctrl.Button('New').IsCheckable(), False)
+        self.assertNotEqual(self.ctrl2.button('Erase').is_checkable(), False)
+        self.assertEqual(self.ctrl.button('New').is_checkable(), False)
 
     def testIsPressable(self):
-        self.assertEquals(self.ctrl.Button('New').IsPressable(), True)
+        self.assertEqual(self.ctrl.button('New').is_pressable(), True)
 
     def testButtonByTooltip(self):
-        self.assertEquals(self.ctrl.Button('New', by_tooltip=True).Text(), 'New')
-        self.assertEquals(self.ctrl.Button('About', exact=False, by_tooltip=True).Text(), 'About')
+        self.assertEqual(self.ctrl.button('New', by_tooltip=True).text(), 'New')
+        self.assertEqual(self.ctrl.button('About', exact=False, by_tooltip=True).text(), 'About')
 
 
 class RebarTestCases(unittest.TestCase):
@@ -1260,8 +1260,8 @@ class RebarTestCases(unittest.TestCase):
         mouse.move((-500, 200))  # remove the mouse from the screen to avoid side effects
         self.app = app
         self.dlg = app.RebarTest_RebarTest
-        self.dlg.Wait('ready', 20)
-        self.ctrl = app.RebarTest_RebarTest.Rebar.WrapperObject()
+        self.dlg.wait('ready', 20)
+        self.ctrl = app.RebarTest_RebarTest.Rebar.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
@@ -1270,51 +1270,51 @@ class RebarTestCases(unittest.TestCase):
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (ReBar)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "ReBar")
+        self.assertEqual(self.ctrl.friendly_class_name(), "ReBar")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
         for txt in self.ctrl.texts():
-            self.assertEquals(isinstance(txt, six.string_types), True)
+            self.assertEqual(isinstance(txt, six.string_types), True)
 
     def testBandCount(self):
-        """Make sure BandCount() returns 2"""
-        self.assertEquals(self.ctrl.BandCount(), 2)
+        """Make sure band_count() returns 2"""
+        self.assertEqual(self.ctrl.band_count(), 2)
 
     def testGetBand(self):
-        """Check that GetBand() is working corectly"""
-        self.assertRaises(IndexError, self.ctrl.GetBand, 99)
-        self.assertRaises(IndexError, self.ctrl.GetBand, 2)
+        """Check that get_band() is working corectly"""
+        self.assertRaises(IndexError, self.ctrl.get_band, 99)
+        self.assertRaises(IndexError, self.ctrl.get_band, 2)
 
-        band = self.ctrl.GetBand(0)
+        band = self.ctrl.get_band(0)
 
-        self.assertEquals(band.hwndChild, self.dlg.MenuBar.handle)
+        self.assertEqual(band.hwndChild, self.dlg.MenuBar.handle)
 
-        self.assertEquals(self.ctrl.GetBand(1).text, u"Tools band:")
-        self.assertEquals(self.ctrl.GetBand(0).text, u"Menus band:")
+        self.assertEqual(self.ctrl.get_band(1).text, u"Tools band:")
+        self.assertEqual(self.ctrl.get_band(0).text, u"Menus band:")
 
     def testGetToolTipsControl(self):
         """Make sure GetToolTipsControl() returns None"""
-        self.assertEquals(self.ctrl.GetToolTipsControl(), None)
+        self.assertEqual(self.ctrl.get_tool_tips_control(), None)
 
     def testAfxToolBarButtons(self):
         """Make sure we can click on Afx ToolBar button by index"""
         Timings.closeclick_dialog_close_wait = 2.
-        self.dlg.StandardToolbar.Button(1).Click()
-        self.app.Window_(title='Open').Wait('ready', timeout=30)
-        self.app.Window_(title='Open').Cancel.CloseClick()
+        self.dlg.StandardToolbar.button(1).click()
+        self.app.window(title='Open').wait('ready', timeout=30)
+        self.app.window(title='Open').Cancel.close_click()
 
     def testMenuBarClickInput(self):
         """Make sure we can click on Menu Bar items by indexed path"""
-        self.assertRaises(TypeError, self.dlg.MenuBar.MenuBarClickInput, '#one->#0', self.app)
+        self.assertRaises(TypeError, self.dlg.MenuBar.menu_bar_click_input, '#one->#0', self.app)
 
-        self.dlg.MenuBar.MenuBarClickInput('#1->#0->#0', self.app)
-        self.app.Customize.CloseButton.Click()
-        self.app.Customize.WaitNot('visible')
+        self.dlg.MenuBar.menu_bar_click_input('#1->#0->#0', self.app)
+        self.app.Customize.CloseButton.click()
+        self.app.Customize.wait_not('visible')
 
-        self.dlg.MenuBar.MenuBarClickInput([2, 0], self.app)
-        self.app.Window_(title='About RebarTest').OK.Click()
-        self.app.Window_(title='About RebarTest').WaitNot('visible')
+        self.dlg.MenuBar.menu_bar_click_input([2, 0], self.app)
+        self.app.window(title='About RebarTest').OK.click()
+        self.app.window(title='About RebarTest').wait_not('visible')
 
 
 class DatetimeTestCases(unittest.TestCase):
@@ -1329,15 +1329,15 @@ class DatetimeTestCases(unittest.TestCase):
 
         self.app = app
         self.dlg = app.CommonControlsSample
-        self.dlg.Wait('ready', 20)
-        tab = app.CommonControlsSample.TabControl.WrapperObject()
-        tab.Select(3)
+        self.dlg.wait('ready', 20)
+        tab = app.CommonControlsSample.TabControl.wrapper_object()
+        tab.select(3)
         self.ctrl = self.dlg.DateTimePicker
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (DateTimePicker)"""
@@ -1348,7 +1348,7 @@ class DatetimeTestCases(unittest.TestCase):
 
         # No check for seconds and milliseconds as it can slip
         # These values are verified in the next 'testSetTime'
-        test_date_time = self.ctrl.GetTime()
+        test_date_time = self.ctrl.get_time()
         date_time_now = datetime.now()
         self.assertEqual(test_date_time.wYear, date_time_now.year)
         self.assertEqual(test_date_time.wMonth, date_time_now.month)
@@ -1366,7 +1366,7 @@ class DatetimeTestCases(unittest.TestCase):
         minute = 2
         second = 3
         milliseconds = 781
-        self.ctrl.SetTime(
+        self.ctrl.set_time(
             year=year,
             month=month,
             day_of_week=day_of_week,
@@ -1378,7 +1378,7 @@ class DatetimeTestCases(unittest.TestCase):
         )
 
         # Retrive back the values we set
-        test_date_time = self.ctrl.GetTime()
+        test_date_time = self.ctrl.get_time()
         self.assertEqual(test_date_time.wYear, year)
         self.assertEqual(test_date_time.wMonth, month)
         self.assertEqual(test_date_time.wDay, day)
@@ -1409,53 +1409,53 @@ class ToolTipsTestCases(unittest.TestCase):
         # so it won't generate an unexpected tooltip
         self.dlg.move_mouse_input(coords=(-100, -100), absolute=True)
 
-        self.dlg.TabControl.Select(u'CToolBarCtrl')
+        self.dlg.TabControl.select(u'CToolBarCtrl')
 
-        self.ctrl = self.dlg.Toolbar.GetToolTipsControl()
+        self.ctrl = self.dlg.Toolbar.get_tool_tips_control()
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.app.kill_()
+        self.app.kill()
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (ToolTips)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "ToolTips")
+        self.assertEqual(self.ctrl.friendly_class_name(), "ToolTips")
 
     def testGetProperties(self):
         """Test getting the properties for the tooltips control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
-    def testGetTip(self):
-        """Test that GetTip() returns correct ToolTip object"""
-        self.assertRaises(IndexError, self.ctrl.GetTip, 99)
-        tip = self.ctrl.GetTip(1)
-        self.assertEquals(tip.text, self.texts[1])
+    def test_get_tip(self):
+        """Test that get_tip() returns correct ToolTip object"""
+        self.assertRaises(IndexError, self.ctrl.get_tip, 99)
+        tip = self.ctrl.get_tip(1)
+        self.assertEqual(tip.text, self.texts[1])
 
-    def testToolCount(self):
-        """Test that ToolCount() returns correct value"""
-        self.assertEquals(10, self.ctrl.ToolCount())
+    def test_tool_count(self):
+        """Test that tool_count() returns correct value"""
+        self.assertEqual(10, self.ctrl.tool_count())
 
-    def testGetTipText(self):
-        """Test that GetTipText() returns correct text"""
-        self.assertEquals(self.texts[1], self.ctrl.GetTipText(1))
+    def test_get_tip_text(self):
+        """Test that get_tip_text() returns correct text"""
+        self.assertEqual(self.texts[1], self.ctrl.get_tip_text(1))
 
-    def testTexts(self):
+    def test_texts(self):
         """Make sure the texts are set correctly"""
         # just to make sure a tooltip is not shown
         self.dlg.move_mouse_input(coords=(0, 0), absolute=False)
         ActionLogger().log('ToolTips texts = ' + ';'.join(self.ctrl.texts()))
-        self.assertEquals(self.ctrl.texts()[0], '')
-        self.assertEquals(self.ctrl.texts()[1:], self.texts)
+        self.assertEqual(self.ctrl.texts()[0], '')
+        self.assertEqual(self.ctrl.texts()[1:], self.texts)
 
 
 class UpDownTestCases(unittest.TestCase):
@@ -1470,82 +1470,82 @@ class UpDownTestCases(unittest.TestCase):
 
         self.app = app
         self.dlg = app.MicrosoftControlSpy
-        self.ctrl = app.MicrosoftControlSpy.UpDown2.WrapperObject()
+        self.ctrl = app.MicrosoftControlSpy.UpDown2.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
         # close the application
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (UpDown)"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "UpDown")
+        self.assertEqual(self.ctrl.friendly_class_name(), "UpDown")
 
     def testTexts(self):
         """Make sure the texts are set correctly"""
-        self.assertEquals(self.ctrl.texts()[1:], [])
+        self.assertEqual(self.ctrl.texts()[1:], [])
 
     def testGetProperties(self):
         """Test getting the properties for the updown control"""
-        props = self.ctrl.GetProperties()
+        props = self.ctrl.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.ctrl, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.ctrl, prop_name)(), props[prop_name])
 
     def testGetValue(self):
         """Test getting up-down position"""
-        self.assertEquals(self.ctrl.GetValue(), 0)
+        self.assertEqual(self.ctrl.get_value(), 0)
 
-        self.ctrl.SetValue(23)
-        self.assertEquals(self.ctrl.GetValue(), 23)
+        self.ctrl.set_value(23)
+        self.assertEqual(self.ctrl.get_value(), 23)
 
     def testSetValue(self):
         """Test setting up-down position"""
-        self.assertEquals(self.ctrl.GetValue(), 0)
+        self.assertEqual(self.ctrl.get_value(), 0)
 
-        self.ctrl.SetValue(23)
-        self.assertEquals(self.ctrl.GetValue(), 23)
-        self.assertEquals(
-            int(self.ctrl.GetBuddyControl().texts()[1]),
+        self.ctrl.set_value(23)
+        self.assertEqual(self.ctrl.get_value(), 23)
+        self.assertEqual(
+            int(self.ctrl.get_buddy_control().texts()[1]),
             23)
 
     def testGetBase(self):
         """Test getting the base of the up-down control"""
-        self.assertEquals(self.ctrl.GetBase(), 10)
+        self.assertEqual(self.ctrl.get_base(), 10)
         #self.dlg.StatementEdit.SetEditText ("MSG (UDM_SETBASE, 16, 0)")
 
         # use CloseClick to allow the control time to respond to the message
         #self.dlg.Send.click_input()
-        self.ctrl.SetBase(16)
+        self.ctrl.set_base(16)
 
-        self.assertEquals(self.ctrl.GetBase(), 16)
+        self.assertEqual(self.ctrl.get_base(), 16)
 
     def testGetRange(self):
         """Test getting the range of the up-down control"""
-        self.assertEquals((0, 9999), self.ctrl.GetRange())
+        self.assertEqual((0, 9999), self.ctrl.get_range())
 
     def testGetBuddy(self):
         """Test getting the buddy control"""
-        self.assertEquals(self.ctrl.GetBuddyControl().handle, self.dlg.Edit6.handle)
+        self.assertEqual(self.ctrl.get_buddy_control().handle, self.dlg.Edit6.handle)
 
     def testIncrement(self):
         """Test incremementing up-down position"""
         Timings.defaults()
-        self.ctrl.Increment()
-        self.assertEquals(self.ctrl.GetValue(), 1)
+        self.ctrl.increment()
+        self.assertEqual(self.ctrl.get_value(), 1)
 
     def testDecrement(self):
         """Test decrementing up-down position"""
         Timings.defaults()
-        self.ctrl.SetValue(23)
-        self.ctrl.Decrement()
-        self.assertEquals(self.ctrl.GetValue(), 22)
+        self.ctrl.set_value(23)
+        self.ctrl.decrement()
+        self.assertEqual(self.ctrl.get_value(), 22)
 
 
 class TrackbarWrapperTestCases(unittest.TestCase):
@@ -1555,9 +1555,9 @@ class TrackbarWrapperTestCases(unittest.TestCase):
         app = Application()
         app.start(os.path.join(mfc_samples_folder, u"CmnCtrl2.exe"))
         dlg = app.top_window()
-        dlg.TabControl.Select(1)
+        dlg.TabControl.select(1)
 
-        ctrl = dlg.Trackbar.WrapperObject()
+        ctrl = dlg.Trackbar.wrapper_object()
         self.app = app
         self.dlg = dlg
         self.ctrl = ctrl
@@ -1569,17 +1569,17 @@ class TrackbarWrapperTestCases(unittest.TestCase):
 
     def test_friendly_class(self):
         """Make sure the Trackbar friendly class is set correctly"""
-        self.assertEquals(self.ctrl.friendly_class_name(), u"Trackbar")
+        self.assertEqual(self.ctrl.friendly_class_name(), u"Trackbar")
 
     def test_get_range_max(self):
         """Test the get_range_max method"""
         self.ctrl.set_range_max(100)
-        self.assertEquals(self.ctrl.get_range_max(), 100)
+        self.assertEqual(self.ctrl.get_range_max(), 100)
 
     def test_get_range_min(self):
         """Test the get_range_min method"""
         self.ctrl.set_range_min(25)
-        self.assertEquals(self.ctrl.get_range_min(), 25)
+        self.assertEqual(self.ctrl.get_range_min(), 25)
 
     def test_set_range_min_more_then_range_max(self):
         """Test the set_range_min method with error"""
@@ -1620,12 +1620,12 @@ class TrackbarWrapperTestCases(unittest.TestCase):
     def test_get_line_size(self):
         """Test the get_line_size method"""
         self.ctrl.set_line_size(10)
-        self.assertEquals(self.ctrl.get_line_size(), 10)
+        self.assertEqual(self.ctrl.get_line_size(), 10)
 
     def test_get_page_size(self):
         """Test the set_page_size method"""
         self.ctrl.set_page_size(14)
-        self.assertEquals(self.ctrl.get_page_size(), 14)
+        self.assertEqual(self.ctrl.get_page_size(), 14)
 
     def test_get_tool_tips_control(self):
         """Test the get_tooltips_control method"""

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -51,7 +51,7 @@ import mock
 from pywinauto.application import Application  # noqa E402
 from pywinauto.controls.hwndwrapper import HwndWrapper  # noqa E402
 from pywinauto.controls.hwndwrapper import InvalidWindowHandle  # noqa E402
-from pywinauto.controls.hwndwrapper import GetDialogPropsFromHandle  # noqa E402
+from pywinauto.controls.hwndwrapper import get_dialog_props_from_handle  # noqa E402
 from pywinauto import win32structures  # noqa E402
 from pywinauto import win32defines  # noqa E402
 from pywinauto.findwindows import ElementNotFoundError  # noqa E402
@@ -90,22 +90,22 @@ class HwndWrapperTests(unittest.TestCase):
         self.app = Application().start(os.path.join(mfc_samples_folder, u"CmnCtrl3.exe"))
 
         self.dlg = self.app.Common_Controls_Sample
-        self.dlg.TabControl.Select('CButton (Command Link)')
+        self.dlg.TabControl.select('CButton (Command Link)')
         self.ctrl = HwndWrapper(self.dlg.Command_button_here.handle)
 
         #self.dlg = self.app.Calculator
-        #self.dlg.MenuSelect('View->Scientific\tAlt+2')
+        #self.dlg.menu_select('View->Scientific\tAlt+2')
         #self.ctrl = HwndWrapper(self.dlg.Button2.handle) # Backspace
 
     def tearDown(self):
         """Close the application after tests"""
         #self.dlg.type_keys("%{F4}")
-        #self.dlg.Close()
-        self.app.kill_()
+        #self.dlg.close()
+        self.app.kill()
 
     def test_scroll(self):
         """Test control scrolling"""
-        self.dlg.TabControl.Select('CNetworkAddressCtrl')
+        self.dlg.TabControl.select('CNetworkAddressCtrl')
         ctrl = HwndWrapper(self.dlg.TypeListBox.handle)
 
         # Check exceptions on wrong arguments
@@ -122,33 +122,33 @@ class HwndWrapperTests(unittest.TestCase):
 
     def testFriendlyClassName(self):
         """Test getting the friendly classname of the control"""
-        self.assertEquals(self.ctrl.friendly_class_name(), "Button")
+        self.assertEqual(self.ctrl.friendly_class_name(), "Button")
 
     def testClass(self):
         """Test getting the classname of the control"""
-        self.assertEquals(self.ctrl.class_name(), "Button")
+        self.assertEqual(self.ctrl.class_name(), "Button")
 
     def testWindowText(self):
         """Test getting the window Text of the control"""
-        self.assertEquals(
+        self.assertEqual(
             HwndWrapper(self.dlg.Set.handle).window_text(), u'Set')
 
     def testStyle(self):
-        self.dlg.Style()
-        self.assertEquals(self.ctrl.Style(),
+        self.dlg.style()
+        self.assertEqual(self.ctrl.style(),
                           win32defines.WS_CHILD |
                           win32defines.WS_VISIBLE |
                           win32defines.WS_TABSTOP |
                           win32defines.BS_COMMANDLINK)
 
     def testExStyle(self):
-        self.assertEquals(self.ctrl.ExStyle(),
+        self.assertEqual(self.ctrl.exstyle(),
                           win32defines.WS_EX_NOPARENTNOTIFY |
                           win32defines.WS_EX_LEFT |
                           win32defines.WS_EX_LTRREADING |
                           win32defines.WS_EX_RIGHTSCROLLBAR)
 
-        #self.assertEquals(self.dlg.ExStyle(),
+        #self.assertEqual(self.dlg.exstyle(),
         #    win32defines.WS_EX_WINDOWEDGE |
         #    win32defines.WS_EX_LEFT |
         #    win32defines.WS_EX_LTRREADING |
@@ -157,24 +157,24 @@ class HwndWrapperTests(unittest.TestCase):
         #    win32defines.WS_EX_APPWINDOW)
 
     def testControlID(self):
-        self.assertEquals(self.ctrl.control_id(), 1037)
+        self.assertEqual(self.ctrl.control_id(), 1037)
         self.dlg.control_id()
 
     def testUserData(self):
-        self.ctrl.UserData()
-        self.dlg.UserData()
+        self.ctrl.user_data()
+        self.dlg.user_data()
 
     def testContextHelpID(self):
-        self.ctrl.ContextHelpID()
-        self.dlg.ContextHelpID()
+        self.ctrl.context_help_id()
+        self.dlg.context_help_id()
 
     def testIsVisible(self):
         self.assertEqual(self.ctrl.is_visible(), True)
         self.assertEqual(self.dlg.is_visible(), True)
 
     def testIsUnicode(self):
-        self.assertEqual(self.ctrl.IsUnicode(), True)
-        self.assertEqual(self.dlg.IsUnicode(), True)
+        self.assertEqual(self.ctrl.is_unicode(), True)
+        self.assertEqual(self.dlg.is_unicode(), True)
 
     def testIsEnabled(self):
         self.assertEqual(self.ctrl.is_enabled(), True)
@@ -197,7 +197,7 @@ class HwndWrapperTests(unittest.TestCase):
 
     def testClientRect(self):
         rect = self.dlg.rectangle()
-        cli = self.dlg.ClientRect()
+        cli = self.dlg.client_rect()
 
         self.assertEqual(cli.left, 0)
         self.assertEqual(cli.top, 0)
@@ -206,25 +206,25 @@ class HwndWrapperTests(unittest.TestCase):
         assert(cli.height() < rect.height())
 
     def testFont(self):
-        self.assertNotEqual(self.dlg.Font(), self.ctrl.Font())
+        self.assertNotEqual(self.dlg.font(), self.ctrl.font())
 
     def testProcessID(self):
         self.assertEqual(self.ctrl.process_id(), self.dlg.process_id())
         self.assertNotEqual(self.ctrl.process_id(), 0)
 
     def testHasStyle(self):
-        self.assertEqual(self.ctrl.HasStyle(win32defines.WS_CHILD), True)
-        self.assertEqual(self.dlg.HasStyle(win32defines.WS_CHILD), False)
+        self.assertEqual(self.ctrl.has_style(win32defines.WS_CHILD), True)
+        self.assertEqual(self.dlg.has_style(win32defines.WS_CHILD), False)
 
-        self.assertEqual(self.ctrl.HasStyle(win32defines.WS_SYSMENU), False)
-        self.assertEqual(self.dlg.HasStyle(win32defines.WS_SYSMENU), True)
+        self.assertEqual(self.ctrl.has_style(win32defines.WS_SYSMENU), False)
+        self.assertEqual(self.dlg.has_style(win32defines.WS_SYSMENU), True)
 
     def testHasExStyle(self):
-        self.assertEqual(self.ctrl.HasExStyle(win32defines.WS_EX_NOPARENTNOTIFY), True)
-        self.assertEqual(self.dlg.HasExStyle(win32defines.WS_EX_NOPARENTNOTIFY), False)
+        self.assertEqual(self.ctrl.has_exstyle(win32defines.WS_EX_NOPARENTNOTIFY), True)
+        self.assertEqual(self.dlg.has_exstyle(win32defines.WS_EX_NOPARENTNOTIFY), False)
 
-        self.assertEqual(self.ctrl.HasExStyle(win32defines.WS_EX_APPWINDOW), False)
-        #self.assertEqual(self.dlg.HasExStyle(win32defines.WS_EX_APPWINDOW), True)
+        self.assertEqual(self.ctrl.has_exstyle(win32defines.WS_EX_APPWINDOW), False)
+        #self.assertEqual(self.dlg.has_exstyle(win32defines.WS_EX_APPWINDOW), True)
 
     def testIsDialog(self):
         self.assertEqual(self.ctrl.is_dialog(), False)
@@ -240,14 +240,14 @@ class HwndWrapperTests(unittest.TestCase):
     def testTexts(self):
         self.assertEqual(self.dlg.texts(), ['Common Controls Sample'])
         self.assertEqual(HwndWrapper(self.dlg.Show.handle).texts(), [u'Show'])
-        self.assertEqual(self.dlg.ChildWindow(class_name='Button', found_index=2).texts(), [u'Elevation Icon'])
+        self.assertEqual(self.dlg.child_window(class_name='Button', found_index=2).texts(), [u'Elevation Icon'])
 
     def testFoundIndex(self):
         """Test an access to a control by found_index"""
 
-        ctl = self.dlg.ChildWindow(class_name='Button', found_index=3)
+        ctl = self.dlg.child_window(class_name='Button', found_index=3)
         self.assertEqual(ctl.texts(), [u'Show'])
-        ctl.DrawOutline('blue')  # visualize
+        ctl.draw_outline('blue')  # visualize
 
         # Test an out-of-range access
         # Notice:
@@ -255,7 +255,7 @@ class HwndWrapperTests(unittest.TestCase):
         # The exception is raised later when we try to find the window.
         # For this reason we can't use an assertRaises statement here because
         # the exception is raised before actual call to DrawOutline
-        ctl = self.dlg.ChildWindow(class_name='Button', found_index=3333)
+        ctl = self.dlg.child_window(class_name='Button', found_index=3333)
         self.assertRaises(ElementNotFoundError, ctl.WrapperObject)
 
     def testSearchWithPredicateFunc(self):
@@ -271,31 +271,31 @@ class HwndWrapperTests(unittest.TestCase):
                     res = True
             return res
 
-        ctl = self.dlg.ChildWindow(predicate_func=is_checkbox)
+        ctl = self.dlg.child_window(predicate_func=is_checkbox)
         self.assertEqual(ctl.texts(), [u'Show'])
-        ctl.DrawOutline('red')  # visualize
+        ctl.draw_outline('red')  # visualize
 
     def testClientRects(self):
-        self.assertEqual(self.ctrl.ClientRects()[0], self.ctrl.ClientRect())
-        self.assertEqual(self.dlg.ClientRects()[0], self.dlg.ClientRect())
+        self.assertEqual(self.ctrl.client_rects()[0], self.ctrl.client_rect())
+        self.assertEqual(self.dlg.client_rects()[0], self.dlg.client_rect())
 
     def testFonts(self):
-        self.assertEqual(self.ctrl.Fonts()[0], self.ctrl.Font())
-        self.assertEqual(self.dlg.Fonts()[0], self.dlg.Font())
+        self.assertEqual(self.ctrl.fonts()[0], self.ctrl.font())
+        self.assertEqual(self.dlg.fonts()[0], self.dlg.font())
 
     def testChildren(self):
         self.assertEqual(self.ctrl.children(), [])
         self.assertNotEqual(self.dlg.children(), [])
 
     def testIsChild(self):
-        self.assertEqual(self.ctrl.is_child(self.dlg.WrapperObject()), True)
+        self.assertEqual(self.ctrl.is_child(self.dlg.wrapper_object()), True)
         self.assertEqual(self.dlg.is_child(self.ctrl), False)
 
     def testSendMessage(self):
-        vk = self.dlg.SendMessage(win32defines.WM_GETDLGCODE)
+        vk = self.dlg.send_message(win32defines.WM_GETDLGCODE)
         self.assertEqual(0, vk)
 
-        code = self.dlg.Edit.SendMessage(win32defines.WM_GETDLGCODE)
+        code = self.dlg.Edit.send_message(win32defines.WM_GETDLGCODE)
         # The expected return code is: "Edit" ? # "Button" = 0x2000 and "Radio" = 0x40
         expected = 0x89  # 0x2000 + 0x40
         self.assertEqual(expected, code)
@@ -303,10 +303,10 @@ class HwndWrapperTests(unittest.TestCase):
     def test_send_chars(self):
         testString = "Hello World"
 
-        self.dlg.Minimize()
+        self.dlg.minimize()
         self.dlg.Edit.send_chars(testString)
 
-        actual = self.dlg.Edit.Texts()[0]
+        actual = self.dlg.Edit.texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
@@ -314,16 +314,16 @@ class HwndWrapperTests(unittest.TestCase):
         with self.assertRaises(keyboard.KeySequenceError):
             testString = "Hello{LEFT 2}{DEL 2}"
 
-            self.dlg.Minimize()
+            self.dlg.minimize()
             self.dlg.Edit.send_chars(testString)
 
     def test_send_keystrokes_multikey_characters(self):
         testString = "Hawaii#{%}@$"
 
-        self.dlg.Minimize()
+        self.dlg.minimize()
         self.dlg.Edit.send_keystrokes(testString)
 
-        actual = self.dlg.Edit.Texts()[0]
+        actual = self.dlg.Edit.texts()[0]
         expected = "Hawaii#%@$"
         self.assertEqual(expected, actual)
 
@@ -331,56 +331,56 @@ class HwndWrapperTests(unittest.TestCase):
         with self.assertRaises(findbestmatch.MatchError):
             testString = "{ENTER}"
 
-            self.dlg.Minimize()
+            self.dlg.minimize()
             self.dlg.Edit.send_keystrokes(testString)
 
-            self.dlg.Restore()
+            self.dlg.restore()
 
     def test_send_keystrokes_virtual_keys_left_del_back(self):
         testString = "+hello123{LEFT 2}{DEL 2}{BACKSPACE} +world"
 
-        self.dlg.Minimize()
+        self.dlg.minimize()
         self.dlg.Edit.send_keystrokes(testString)
 
-        actual = self.dlg.Edit.Texts()[0]
+        actual = self.dlg.Edit.texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
     def test_send_keystrokes_virtual_keys_shift(self):
         testString = "+hello +world"
 
-        self.dlg.Minimize()
+        self.dlg.minimize()
         self.dlg.Edit.send_keystrokes(testString)
 
-        actual = self.dlg.Edit.Texts()[0]
+        actual = self.dlg.Edit.texts()[0]
         expected = "Hello World"
         self.assertEqual(expected, actual)
 
     def test_send_keystrokes_virtual_keys_ctrl(self):
         testString = "^a^c{RIGHT}^v"
 
-        self.dlg.Minimize()
+        self.dlg.minimize()
         self.dlg.Edit.send_keystrokes(testString)
 
-        actual = self.dlg.Edit.Texts()[0]
+        actual = self.dlg.Edit.texts()[0]
         expected = "and the note goes here ...and the note goes here ..."
         self.assertEqual(expected, actual)
 
     def testSendMessageTimeout(self):
         default_timeout = Timings.sendmessagetimeout_timeout
         Timings.sendmessagetimeout_timeout = 0.1
-        vk = self.dlg.SendMessageTimeout(win32defines.WM_GETDLGCODE)
+        vk = self.dlg.send_message_timeout(win32defines.WM_GETDLGCODE)
         self.assertEqual(0, vk)
 
-        code = self.dlg.Show.SendMessageTimeout(win32defines.WM_GETDLGCODE)
+        code = self.dlg.Show.send_message_timeout(win32defines.WM_GETDLGCODE)
         # The expected return code is: "Button" = 0x2000 # and "Radio" = 0x40
         expected = 0x2000  # + 0x40
         Timings.sendmessagetimeout_timeout = default_timeout
         self.assertEqual(expected, code)
 
     def testPostMessage(self):
-        self.assertNotEquals(0, self.dlg.PostMessage(win32defines.WM_PAINT))
-        self.assertNotEquals(0, self.dlg.Show.PostMessage(win32defines.WM_PAINT))
+        self.assertNotEqual(0, self.dlg.post_message(win32defines.WM_PAINT))
+        self.assertNotEqual(0, self.dlg.Show.post_message(win32defines.WM_PAINT))
 
 #    def testNotifyMenuSelect(self):
 #        "Call NotifyMenuSelect to ensure it does not raise"
@@ -388,22 +388,22 @@ class HwndWrapperTests(unittest.TestCase):
 #        self.dlg.NotifyMenuSelect(1234)
 
     def testNotifyParent(self):
-        """Call NotifyParent to ensure it does not raise"""
-        self.ctrl.NotifyParent(1234)
-        #self.dlg.NotifyParent(1234)
+        """Call notify_parent to ensure it does not raise"""
+        self.ctrl.notify_parent(1234)
+        #self.dlg.notify_parent(1234)
 
     def testGetProperties(self):
         """Test getting the properties for the HwndWrapped control"""
-        props = self.dlg.GetProperties()
+        props = self.dlg.get_properties()
 
-        self.assertEquals(
+        self.assertEqual(
             self.dlg.friendly_class_name(), props['friendly_class_name'])
 
-        self.assertEquals(
+        self.assertEqual(
             self.dlg.texts(), props['texts'])
 
         for prop_name in props:
-            self.assertEquals(getattr(self.dlg, prop_name)(), props[prop_name])
+            self.assertEqual(getattr(self.dlg, prop_name)(), props[prop_name])
 
     def test_capture_as_image_multi_monitor(self):
         with mock.patch('win32api.EnumDisplayMonitors') as mon_device:
@@ -416,8 +416,8 @@ class HwndWrapperTests(unittest.TestCase):
     # def testDrawOutline(self):
     #     """Test the outline was drawn."""
     #     # make sure window is ready
-    #     self.dlg.Wait('active')
-    #     self.dlg.Show.Click()
+    #     self.dlg.wait('active')
+    #     self.dlg.Show.click()
     #
     #     # not sure why, but this extra call makes the test stable
     #     self.dlg.draw_outline()
@@ -443,8 +443,8 @@ class HwndWrapperTests(unittest.TestCase):
     def testMoveWindow_same(self):
         """Test calling movewindow without any parameters"""
         prevRect = self.dlg.rectangle()
-        self.dlg.MoveWindow()
-        self.assertEquals(prevRect, self.dlg.rectangle())
+        self.dlg.move_window()
+        self.assertEqual(prevRect, self.dlg.rectangle())
 
     def testMoveWindow(self):
         """Test moving the window"""
@@ -459,7 +459,7 @@ class HwndWrapperTests(unittest.TestCase):
         new_rect.right += 2
         new_rect.bottom += 2
 
-        self.ctrl.MoveWindow(
+        self.ctrl.move_window(
             new_rect.left,
             new_rect.top,
             new_rect.width(),
@@ -471,42 +471,42 @@ class HwndWrapperTests(unittest.TestCase):
         print('new_rect = ', new_rect)
         print('dlgClientRect = ', dlgClientRect)
         print('self.ctrl.rectangle() = ', self.ctrl.rectangle())
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.rectangle(),
             new_rect + dlgClientRect)
 
-        self.ctrl.MoveWindow(prev_rect)
+        self.ctrl.move_window(prev_rect)
 
-        self.assertEquals(
+        self.assertEqual(
             self.ctrl.rectangle(),
             prev_rect + dlgClientRect)
 
     def testMaximize(self):
-        self.dlg.Maximize()
+        self.dlg.maximize()
 
-        self.assertEquals(self.dlg.GetShowState(), win32defines.SW_SHOWMAXIMIZED)
-        self.dlg.Restore()
+        self.assertEqual(self.dlg.get_show_state(), win32defines.SW_SHOWMAXIMIZED)
+        self.dlg.restore()
 
     def testMinimize(self):
-        self.dlg.Minimize()
-        self.assertEquals(self.dlg.GetShowState(), win32defines.SW_SHOWMINIMIZED)
-        self.dlg.Restore()
+        self.dlg.minimize()
+        self.assertEqual(self.dlg.get_show_state(), win32defines.SW_SHOWMINIMIZED)
+        self.dlg.restore()
 
     def testRestore(self):
-        self.dlg.Maximize()
-        self.dlg.Restore()
-        self.assertEquals(self.dlg.GetShowState(), win32defines.SW_SHOWNORMAL)
+        self.dlg.maximize()
+        self.dlg.restore()
+        self.assertEqual(self.dlg.get_show_state(), win32defines.SW_SHOWNORMAL)
 
-        self.dlg.Minimize()
-        self.dlg.Restore()
-        self.assertEquals(self.dlg.GetShowState(), win32defines.SW_SHOWNORMAL)
+        self.dlg.minimize()
+        self.dlg.restore()
+        self.assertEqual(self.dlg.get_show_state(), win32defines.SW_SHOWNORMAL)
 
     def testGetFocus(self):
-        self.assertNotEqual(self.dlg.GetFocus(), None)
-        self.assertEqual(self.dlg.GetFocus(), self.ctrl.GetFocus())
+        self.assertNotEqual(self.dlg.get_focus(), None)
+        self.assertEqual(self.dlg.get_focus(), self.ctrl.get_focus())
 
         self.dlg.Set.set_focus()
-        self.assertEqual(self.dlg.GetFocus(), self.dlg.Set.handle)
+        self.assertEqual(self.dlg.get_focus(), self.dlg.Set.handle)
 
     def test_issue_318(self):
         self.dlg.restore()
@@ -523,9 +523,9 @@ class HwndWrapperTests(unittest.TestCase):
         self.dlg.restore()
 
     def testSetFocus(self):
-        self.assertNotEqual(self.dlg.GetFocus(), self.dlg.Set.handle)
+        self.assertNotEqual(self.dlg.get_focus(), self.dlg.Set.handle)
         self.dlg.Set.set_focus()
-        self.assertEqual(self.dlg.GetFocus(), self.dlg.Set.handle)
+        self.assertEqual(self.dlg.get_focus(), self.dlg.Set.handle)
 
     def testHasKeyboardFocus(self):
         self.assertFalse(self.dlg.set.has_keyboard_focus())
@@ -573,72 +573,72 @@ class HwndWrapperMenuTests(unittest.TestCase):
         self.app = Application().start(os.path.join(mfc_samples_folder, u"RowList.exe"))
 
         self.dlg = self.app.RowListSampleApplication
-        self.ctrl = self.app.RowListSampleApplication.ListView.WrapperObject()
+        self.ctrl = self.app.RowListSampleApplication.ListView.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
-        self.dlg.SendMessage(win32defines.WM_CLOSE)
+        self.dlg.send_message(win32defines.WM_CLOSE)
 
     def testMenuItems(self):
         """Test getting menu items"""
-        self.assertEqual(self.ctrl.MenuItems(), [])
-        self.assertEqual(self.dlg.MenuItems()[1]['text'], '&View')
+        self.assertEqual(self.ctrl.menu_items(), [])
+        self.assertEqual(self.dlg.menu_items()[1]['text'], '&View')
 
     def testMenuSelect(self):
         """Test selecting a menu item"""
 
-        if self.dlg.MenuItem("View -> Toolbar").IsChecked():
-            self.dlg.MenuSelect("View -> Toolbar")
-        self.assertEquals(self.dlg.MenuItem("View -> Toolbar").IsChecked(), False)
+        if self.dlg.menu_item("View -> Toolbar").is_checked():
+            self.dlg.menu_select("View -> Toolbar")
+        self.assertEqual(self.dlg.menu_item("View -> Toolbar").is_checked(), False)
 
-        self.dlg.MenuSelect("View -> Toolbar")
-        self.assertEquals(self.dlg.MenuItem("View -> Toolbar").IsChecked(), True)
+        self.dlg.menu_select("View -> Toolbar")
+        self.assertEqual(self.dlg.menu_item("View -> Toolbar").is_checked(), True)
 
     def testClose(self):
         """Test the Close() method of windows"""
         # open about dialog
-        self.dlg.MenuSelect('Help->About RowList...')
+        self.dlg.menu_select('Help->About RowList...')
 
         # make sure it is open and visible
-        self.app.AboutRowList.Wait("visible", 20)
-        self.assertTrue(self.app.Window_(title='About RowList').is_visible(), True)
+        self.app.AboutRowList.wait("visible", 20)
+        self.assertTrue(self.app.window(title='About RowList').is_visible(), True)
 
         # close it
-        self.app.Window_(title='About RowList', class_name='#32770').Close(1)
+        self.app.window(title='About RowList', class_name='#32770').close(1)
 
         # make sure that it is not visible
         try:
             #self.assertRaises(ElementNotFoundError,
-            #                  self.app.Window_(title='About RowList', class_name='#32770').wrapper_object())
+            #                  self.app.window(title='About RowList', class_name='#32770').wrapper_object())
             # vvryabov: TimeoutError is caught by assertRaises, so the second raise is not caught correctly
-            self.app.Window_(title='About RowList', class_name='#32770').WrapperObject()
+            self.app.window(title='About RowList', class_name='#32770').wrapper_object()
         except ElementNotFoundError:
             print('ElementNotFoundError exception is raised as expected. OK.')
 
         # make sure the main RowList dialog is still open
-        self.assertEquals(self.dlg.is_visible(), True)
+        self.assertEqual(self.dlg.is_visible(), True)
 
     def testCloseClick_bug(self):
-        self.dlg.MenuSelect('Help->About RowList...')
-        self.app.AboutRowList.Wait("visible", 10)
+        self.dlg.menu_select('Help->About RowList...')
+        self.app.AboutRowList.wait("visible", 10)
 
-        self.assertEqual(self.app.AboutRowList.Exists(), True)
-        self.app.AboutRowList.CloseButton.CloseClick()
-        self.assertEqual(self.app.AboutRowList.Exists(), False)
+        self.assertEqual(self.app.AboutRowList.exists(), True)
+        self.app.AboutRowList.CloseButton.close_click()
+        self.assertEqual(self.app.AboutRowList.exists(), False)
 
         #Timings.closeclick_dialog_close_wait = .7
         #try:
-        #    self.app.AboutRowList.CloseButton.CloseClick()
+        #    self.app.AboutRowList.CloseButton.close_click()
         #except TimeoutError:
         #    pass
-        #self.app.AboutRowList.Close()
+        #self.app.AboutRowList.close()
 
     def testCloseAltF4(self):
-        self.dlg.MenuSelect('Help->About RowList...')
-        AboutRowList = self.app.Window_(title='About RowList', active_only=True, class_name='#32770')
-        AboutWrapper = AboutRowList.Wait("enabled")
-        AboutRowList.CloseAltF4()
-        AboutRowList.WaitNot('visible')
+        self.dlg.menu_select('Help->About RowList...')
+        AboutRowList = self.app.window(title='About RowList', active_only=True, class_name='#32770')
+        AboutWrapper = AboutRowList.wait("enabled")
+        AboutRowList.close_alt_f4()
+        AboutRowList.wait_not('visible')
         self.assertNotEqual(AboutWrapper.is_visible(), True)
 
 
@@ -653,69 +653,69 @@ class HwndWrapperMouseTests(unittest.TestCase):
         self.app = Application().start(os.path.join(mfc_samples_folder, u"CmnCtrl3.exe"))
 
         self.dlg = self.app.Common_Controls_Sample
-        self.dlg.TabControl.Select('CButton (Command Link)')
+        self.dlg.TabControl.select('CButton (Command Link)')
         self.ctrl = HwndWrapper(self.dlg.NoteEdit.handle)
 
     def tearDown(self):
         """Close the application after tests"""
         try:
-            self.dlg.Close(0.5)
+            self.dlg.close(0.5)
         except Exception:  # TimeoutError:
             pass
         finally:
-            self.app.kill_()
+            self.app.kill()
 
     #def testText(self):
     #    "Test getting the window Text of the dialog"
-    #    self.assertEquals(self.dlg.window_text(), "Untitled - Notepad")
+    #    self.assertEqual(self.dlg.window_text(), "Untitled - Notepad")
 
     def testClick(self):
-        self.ctrl.Click(coords=(50, 5))
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (9, 9))
+        self.ctrl.click(coords=(50, 5))
+        self.assertEqual(self.dlg.Edit.selection_indices(), (9, 9))
 
     def testClickInput(self):
         self.ctrl.click_input(coords=(50, 5))
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (9, 9))
+        self.assertEqual(self.dlg.Edit.selection_indices(), (9, 9))
 
     def testDoubleClick(self):
-        self.ctrl.DoubleClick(coords=(50, 5))
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (8, 13))
+        self.ctrl.double_click(coords=(50, 5))
+        self.assertEqual(self.dlg.Edit.selection_indices(), (8, 13))
 
     def testDoubleClickInput(self):
         self.ctrl.double_click_input(coords=(80, 5))
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (13, 18))
+        self.assertEqual(self.dlg.Edit.selection_indices(), (13, 18))
 
 #    def testRightClick(self):
 #        pass
 
     def testRightClickInput(self):
         self.dlg.Edit.type_keys('{HOME}')
-        self.dlg.Edit.Wait('enabled').right_click_input()
-        self.app.PopupMenu.Wait('ready').Menu().GetMenuPath('Select All')[0].click_input()
+        self.dlg.Edit.wait('enabled').right_click_input()
+        self.app.PopupMenu.wait('ready').menu().get_menu_path('Select All')[0].click_input()
         self.dlg.Edit.type_keys('{DEL}')
-        self.assertEquals(self.dlg.Edit.TextBlock(), '')
+        self.assertEqual(self.dlg.Edit.text_block(), '')
 
     def testPressMoveRelease(self):
-        self.dlg.NoteEdit.PressMouse(coords=(0, 5))
-        self.dlg.NoteEdit.MoveMouse(coords=(65, 5))
-        self.dlg.NoteEdit.ReleaseMouse(coords=(65, 5))
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (0, 12))
+        self.dlg.NoteEdit.press_mouse(coords=(0, 5))
+        self.dlg.NoteEdit.move_mouse(coords=(65, 5))
+        self.dlg.NoteEdit.release_mouse(coords=(65, 5))
+        self.assertEqual(self.dlg.Edit.selection_indices(), (0, 12))
 
     def testDragMouse(self):
-        self.dlg.NoteEdit.DragMouse(press_coords=(0, 5), release_coords=(65, 5))
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (0, 12))
+        self.dlg.NoteEdit.drag_mouse(press_coords=(0, 5), release_coords=(65, 5))
+        self.assertEqual(self.dlg.Edit.selection_indices(), (0, 12))
 
         # continue selection with pressed Shift key
-        self.dlg.NoteEdit.DragMouse(press_coords=(65, 5), release_coords=(90, 5), pressed='shift')
-        self.assertEquals(self.dlg.Edit.SelectionIndices(), (0, 17))
+        self.dlg.NoteEdit.drag_mouse(press_coords=(65, 5), release_coords=(90, 5), pressed='shift')
+        self.assertEqual(self.dlg.Edit.selection_indices(), (0, 17))
 
     def testDebugMessage(self):
-        self.dlg.NoteEdit.DebugMessage('Test message')
+        self.dlg.NoteEdit.debug_message('Test message')
         # TODO: add screenshots comparison
 
     #def testDrawOutline(self):
     #    # TODO: add screenshots comparison
-    #    self.dlg.DrawOutline()
+    #    self.dlg.draw_outline()
 
 #    def testSetWindowText(self):
 #        pass
@@ -724,8 +724,8 @@ class HwndWrapperMouseTests(unittest.TestCase):
 #        pass
 
     def testSetTransparency(self):
-        self.dlg.SetTransparency()
-        self.assertRaises(ValueError, self.dlg.SetTransparency, 256)
+        self.dlg.set_transparency()
+        self.assertRaises(ValueError, self.dlg.set_transparency, 256)
 
 
 class NonActiveWindowFocusTests(unittest.TestCase):
@@ -742,13 +742,13 @@ class NonActiveWindowFocusTests(unittest.TestCase):
 
     def tearDown(self):
         """Close the application after tests"""
-        self.app.kill_()
-        self.app2.kill_()
+        self.app.kill()
+        self.app2.kill()
 
     def test_issue_240(self):
         """Check HwndWrapper.set_focus for a desktop without a focused window"""
         ws = self.app.Common_Controls_Sample
-        ws.TabControl.Select('CButton (Command Link)')
+        ws.TabControl.select('CButton (Command Link)')
         dlg1 = ws.wrapper_object()
         dlg2 = self.app2.Notepad.wrapper_object()
         dlg2.click(coords=(2, 2))
@@ -756,7 +756,7 @@ class NonActiveWindowFocusTests(unittest.TestCase):
         # here is the trick: the window is restored but it isn't activated
         dlg2.restore()
         dlg1.set_focus()
-        self.assertEqual(ws.GetFocus(), ws.Edit.wrapper_object())
+        self.assertEqual(ws.get_focus(), ws.Edit.wrapper_object())
 
 
 class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
@@ -779,8 +779,8 @@ class WindowWithoutMessageLoopFocusTests(unittest.TestCase):
 
     def tearDown(self):
         """Close the application after tests"""
-        self.app1.kill_()
-        self.app2.kill_()
+        self.app1.kill()
+        self.app2.kill()
 
     def test_issue_270(self):
         """
@@ -811,51 +811,51 @@ class NotepadRegressionTests(unittest.TestCase):
         self.app = Application()
         self.app.start(_notepad_exe())
 
-        self.dlg = self.app.Window_(title='Untitled - Notepad', class_name='Notepad')
+        self.dlg = self.app.window(title='Untitled - Notepad', class_name='Notepad')
         self.ctrl = HwndWrapper(self.dlg.Edit.handle)
-        self.dlg.Edit.SetEditText("Here is some text\r\n and some more")
+        self.dlg.Edit.set_edit_text("Here is some text\r\n and some more")
 
         self.app2 = Application().start(_notepad_exe())
 
     def tearDown(self):
         """Close the application after tests"""
         try:
-            self.dlg.Close(0.5)
-            if self.app.Notepad["Do&n't Save"].Exists():
-                self.app.Notepad["Do&n't Save"].Click()
-                self.app.Notepad["Do&n't Save"].WaitNot('visible')
+            self.dlg.close(0.5)
+            if self.app.Notepad["Do&n't Save"].exists():
+                self.app.Notepad["Do&n't Save"].click()
+                self.app.Notepad["Do&n't Save"].wait_not('visible')
         except Exception:  # TimeoutError:
             pass
         finally:
-            self.app.kill_()
-        self.app2.kill_()
+            self.app.kill()
+        self.app2.kill()
 
     def testMenuSelectNotepad_bug(self):
         """In notepad - MenuSelect Edit->Paste did not work"""
         text = b'Here are some unicode characters \xef\xfc\r\n'
-        self.app2.UntitledNotepad.Edit.Wait('enabled')
+        self.app2.UntitledNotepad.Edit.wait('enabled')
         time.sleep(0.3)
-        self.app2.UntitledNotepad.Edit.SetEditText(text)
+        self.app2.UntitledNotepad.Edit.set_edit_text(text)
         time.sleep(0.3)
-        self.assertEquals(self.app2.UntitledNotepad.Edit.TextBlock().encode(locale.getpreferredencoding()), text)
+        self.assertEqual(self.app2.UntitledNotepad.Edit.text_block().encode(locale.getpreferredencoding()), text)
 
         Timings.after_menu_wait = .7
-        self.app2.UntitledNotepad.MenuSelect("Edit->Select All")
+        self.app2.UntitledNotepad.menu_select("Edit->Select All")
         time.sleep(0.3)
-        self.app2.UntitledNotepad.MenuSelect("Edit->Copy")
+        self.app2.UntitledNotepad.menu_select("Edit->Copy")
         time.sleep(0.3)
-        self.assertEquals(clipboard.GetData().encode(locale.getpreferredencoding()), text)
+        self.assertEqual(clipboard.GetData().encode(locale.getpreferredencoding()), text)
 
         self.dlg.set_focus()
-        self.dlg.MenuSelect("Edit->Select All")
-        self.dlg.MenuSelect("Edit->Paste")
-        self.dlg.MenuSelect("Edit->Paste")
-        self.dlg.MenuSelect("Edit->Paste")
+        self.dlg.menu_select("Edit->Select All")
+        self.dlg.menu_select("Edit->Paste")
+        self.dlg.menu_select("Edit->Paste")
+        self.dlg.menu_select("Edit->Paste")
 
-        self.app2.UntitledNotepad.MenuSelect("File->Exit")
-        self.app2.Window_(title='Notepad', class_name='#32770')["Don't save"].Click()
+        self.app2.UntitledNotepad.menu_select("File->Exit")
+        self.app2.window(title='Notepad', class_name='#32770')["Don't save"].click()
 
-        self.assertEquals(self.dlg.Edit.TextBlock().encode(locale.getpreferredencoding()), text * 3)
+        self.assertEqual(self.dlg.Edit.text_block().encode(locale.getpreferredencoding()), text * 3)
 
 
 class ControlStateTests(unittest.TestCase):
@@ -871,12 +871,12 @@ class ControlStateTests(unittest.TestCase):
         self.app.start(os.path.join(mfc_samples_folder, u"CmnCtrl1.exe"))
 
         self.dlg = self.app.Common_Controls_Sample
-        self.dlg.TabControl.Select(4)
-        self.ctrl = self.dlg.EditBox.WrapperObject()
+        self.dlg.TabControl.select(4)
+        self.ctrl = self.dlg.EditBox.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
-        self.app.kill_()
+        self.app.kill()
 
     def test_VerifyEnabled(self):
         """Test for verify_enabled"""
@@ -884,7 +884,7 @@ class ControlStateTests(unittest.TestCase):
 
     def test_VerifyVisible(self):
         """Test for verify_visible"""
-        self.dlg.TabControl.Select(3)
+        self.dlg.TabControl.select(3)
         self.assertRaises(ElementNotVisible, self.ctrl.verify_visible)
 
 
@@ -900,33 +900,33 @@ class DragAndDropTests(unittest.TestCase):
         self.app.start(os.path.join(mfc_samples_folder, u"CmnCtrl1.exe"))
 
         self.dlg = self.app.Common_Controls_Sample
-        self.ctrl = self.dlg.TreeView.WrapperObject()
+        self.ctrl = self.dlg.TreeView.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
-        self.app.kill_()
+        self.app.kill()
 
     #def testDragMouse(self):
-    #    """DragMouse works! But CmnCtrl1.exe crashes in infinite recursion."""
-    #    birds = self.ctrl.GetItem(r'\Birds')
-    #    dogs = self.ctrl.GetItem(r'\Dogs')
-    #    self.ctrl.DragMouse("left", birds.rectangle().mid_point(), dogs.rectangle().mid_point())
-    #    dogs = self.ctrl.GetItem(r'\Dogs')
-    #    self.assertEquals([child.Text() for child in dogs.children()],
+    #    """drag_mouse works! But CmnCtrl1.exe crashes in infinite recursion."""
+    #    birds = self.ctrl.get_item(r'\Birds')
+    #    dogs = self.ctrl.get_item(r'\Dogs')
+    #    self.ctrl.drag_mouse("left", birds.rectangle().mid_point(), dogs.rectangle().mid_point())
+    #    dogs = self.ctrl.get_item(r'\Dogs')
+    #    self.assertEqual([child.Text() for child in dogs.children()],
     #                      [u'Birds', u'Dalmatian', u'German Shepherd', u'Great Dane'])
 
     def testDragMouseInput(self):
         """Test for drag_mouse_input"""
-        birds = self.ctrl.GetItem(r'\Birds')
-        dogs = self.ctrl.GetItem(r'\Dogs')
-        #birds.Select()
+        birds = self.ctrl.get_item(r'\Birds')
+        dogs = self.ctrl.get_item(r'\Dogs')
+        #birds.select()
         birds.click_input()
         time.sleep(5)  # enough pause to prevent double click detection
         self.ctrl.drag_mouse_input(dst=dogs.client_rect().mid_point(),
                                    src=birds.client_rect().mid_point(),
                                    absolute=False)
-        dogs = self.ctrl.GetItem(r'\Dogs')
-        self.assertEquals([child.Text() for child in dogs.children()],
+        dogs = self.ctrl.get_item(r'\Dogs')
+        self.assertEqual([child.text() for child in dogs.children()],
                           [u'Birds', u'Dalmatian', u'German Shepherd', u'Great Dane'])
 
 
@@ -948,16 +948,16 @@ class GetDialogPropsFromHandleTest(unittest.TestCase):
         """Close the application after tests"""
         # close the application
         #self.dlg.type_keys("%{F4}")
-        self.dlg.Close(0.5)
-        self.app.kill_()
+        self.dlg.close(0.5)
+        self.app.kill()
 
     def test_GetDialogPropsFromHandle(self):
         """Test some small stuff regarding GetDialogPropsFromHandle"""
-        props_from_handle = GetDialogPropsFromHandle(self.dlg.handle)
-        props_from_dialog = GetDialogPropsFromHandle(self.dlg)
-        #unused var: props_from_ctrl = GetDialogPropsFromHandle(self.ctrl)
+        props_from_handle = get_dialog_props_from_handle(self.dlg.handle)
+        props_from_dialog = get_dialog_props_from_handle(self.dlg)
+        #unused var: props_from_ctrl = get_dialog_props_from_handle(self.ctrl)
 
-        self.assertEquals(props_from_handle, props_from_dialog)
+        self.assertEqual(props_from_handle, props_from_dialog)
 
 
 class SendEnterKeyTest(unittest.TestCase):
@@ -972,14 +972,14 @@ class SendEnterKeyTest(unittest.TestCase):
         self.ctrl = HwndWrapper(self.dlg.Edit.handle)
 
     def tearDown(self):
-        self.dlg.MenuSelect('File -> Exit')
-        if self.dlg["Do&n't Save"].Exists():
-            self.dlg["Do&n't Save"].Click()
-        self.app.kill_()
+        self.dlg.menu_select('File -> Exit')
+        if self.dlg["Do&n't Save"].exists():
+            self.dlg["Do&n't Save"].click()
+        self.app.kill()
 
     def test_sendEnterChar(self):
         self.ctrl.send_chars('Hello{ENTER}World')
-        self.assertEquals(['Hello\r\nWorld'], self.dlg.Edit.Texts())
+        self.assertEqual(['Hello\r\nWorld'], self.dlg.Edit.Texts())
 
 
 class SendKeystrokesAltComboTests(unittest.TestCase):
@@ -993,12 +993,12 @@ class SendKeystrokesAltComboTests(unittest.TestCase):
         self.dlg = self.app.Control_Test_App
 
     def tearDown(self):
-        self.app.kill_()
+        self.app.kill()
 
     def test_send_keystrokes_alt_combo(self):
         self.dlg.send_keystrokes('%(sc)')
 
-        self.assertTrue(self.app['Using C++ Derived Class'].Exists())
+        self.assertTrue(self.app['Using C++ Derived Class'].exists())
 
 
 class RemoteMemoryBlockTests(unittest.TestCase):
@@ -1013,11 +1013,11 @@ class RemoteMemoryBlockTests(unittest.TestCase):
         self.app.start(os.path.join(mfc_samples_folder, u"CmnCtrl1.exe"))
 
         self.dlg = self.app.Common_Controls_Sample
-        self.ctrl = self.dlg.TreeView.WrapperObject()
+        self.ctrl = self.dlg.TreeView.wrapper_object()
 
     def tearDown(self):
         """Close the application after tests"""
-        self.app.kill_()
+        self.app.kill()
 
     def testGuardSignatureCorruption(self):
         mem = RemoteMemoryBlock(self.ctrl, 16)

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -256,7 +256,7 @@ class HwndWrapperTests(unittest.TestCase):
         # For this reason we can't use an assertRaises statement here because
         # the exception is raised before actual call to DrawOutline
         ctl = self.dlg.child_window(class_name='Button', found_index=3333)
-        self.assertRaises(ElementNotFoundError, ctl.WrapperObject)
+        self.assertRaises(ElementNotFoundError, ctl.wrapper_object)
 
     def testSearchWithPredicateFunc(self):
         """Test an access to a control by filtering with a predicate function"""


### PR DESCRIPTION
Reduce the warnings noise in the tests to a sane level. Since the cleanup introduces a lot changes, I'm publishing it in several splits as we go with the fixes. This part contains major cleanups for the next modules:
test_hwndwrapper
test_action_logger
test_clipboard
test_common_controls