### PR TITLE
Make method app.kill() hard by default (fix #547)

### DIFF
--- a/docs/HowTo.txt
+++ b/docs/HowTo.txt
@@ -452,11 +452,11 @@ e.g.
 
 
 
-COM Model
+COM Threading Model
 ------------------------------------------------------------------------------------
 By default, pywinauto sets up the client Multithreading COM model (MTA) on init if
 no other model was defined prior to import of pywinauto. The model can be set up by
-another imported module implicitly or specified explicitly through ``sys.coinit_flags``
+another imported module implicitly or specified explicitly through ``sys.coinit_flags``.
 
 Example for overriding MTA by setting the single threaded appartment model explicitly.
 

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -2775,6 +2775,7 @@ class ToolbarWrapper(hwndwrapper.HwndWrapper):
         #app = Application().Connect(handle=self.handle)
 
         current_toolbar = self
+        current_toolbar.set_focus() # to make sure it can be clicked immediately
         for i, index in enumerate(indices):
             windows_before = app.windows(visible_only=True)
             current_toolbar.button(index).click_input()

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -146,6 +146,7 @@ class ApplicationWarningTestCases(unittest.TestCase):
 class ApplicationWin32KillTestCases(unittest.TestCase):
 
     """Unit tests for method Application.kill() with backend='win32'"""
+
     backend = 'win32'
 
     def setUp(self):
@@ -195,6 +196,7 @@ class ApplicationWin32KillTestCases(unittest.TestCase):
 class ApplicationUiaKillTestCases(ApplicationWin32KillTestCases):
 
     """Unit tests for method Application.kill() with backend='uia'"""
+
     backend = 'uia'
     # the same test methods run here
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -96,20 +96,17 @@ class ApplicationWarningTestCases(unittest.TestCase):
         """Set some data and ensure the application is in the state we want"""
         Timings.defaults()
         # Force Display User and Deprecation warnings every time
-        # Python 3.3+nose/unittest trys really hard to suppress them
+        # Python 3.3 + nose/unittest tries really hard to suppress them
         for warning in (UserWarning, PendingDeprecationWarning):
             warnings.simplefilter('always', warning)
 
-        mfc_samples_folder = os.path.join(os.path.dirname(__file__),
-                                          r"..\..\apps\MFC_samples")
         if is_x64_Python():
             self.sample_exe = os.path.join(mfc_samples_folder,
-                                           "x64",
                                            "CmnCtrl1.exe")
-            self.sample_exe_inverted_bitness = os.path.join(mfc_samples_folder,
+            self.sample_exe_inverted_bitness = os.path.join(mfc_samples_folder_32,
                                                             "CmnCtrl1.exe")
         else:
-            self.sample_exe = os.path.join(mfc_samples_folder, "CmnCtrl1.exe")
+            self.sample_exe = os.path.join(mfc_samples_folder_32, "CmnCtrl1.exe")
             self.sample_exe_inverted_bitness = os.path.join(mfc_samples_folder,
                                                             "x64",
                                                             "CmnCtrl1.exe")
@@ -144,6 +141,62 @@ class ApplicationWarningTestCases(unittest.TestCase):
             assert len(args) == 2
             assert "64-bit" in args[0]
             assert args[1].__name__ == 'UserWarning'
+
+
+class ApplicationWin32KillTestCases(unittest.TestCase):
+
+    """Unit tests for method Application.kill() with backend='win32'"""
+    backend = 'win32'
+
+    def setUp(self):
+        """Set some data and ensure the application is in the state we want"""
+        Timings.defaults()
+
+        self.sample_exe = os.path.join(mfc_samples_folder, 'RowList.exe')
+        self.app = Application(backend=self.backend).start(self.sample_exe)
+        self.target_process = self.app.process
+
+    def tearDown(self):
+        self.app.kill(soft=False)
+
+    def test_kill_hard(self):
+        self.assertTrue(self.app.kill(soft=False))
+        self.assertRaises(ProcessNotFoundError, Application().connect, process=self.target_process)
+
+    def test_kill_soft(self):
+        self.assertTrue(self.app.kill(soft=True))
+        self.assertRaises(ProcessNotFoundError, Application().connect, process=self.target_process)
+
+    def test_already_killed_hard(self):
+        self.assertTrue(self.app.kill(soft=False))
+        self.assertRaises(ProcessNotFoundError, Application().connect, process=self.target_process)
+        self.assertTrue(self.app.kill(soft=False)) # already killed, returned True anyway
+
+    def test_already_killed_soft(self):
+        self.assertTrue(self.app.kill(soft=False))
+        self.assertRaises(ProcessNotFoundError, Application().connect, process=self.target_process)
+        self.assertTrue(self.app.kill(soft=True)) # already killed, returned True anyway
+
+    def test_kill_soft_with_modal_subdialog(self):
+        """Kill the app with modal subdialog to cover win.force_close() call"""
+        self.app.RowListSampleApplication.menu_select('Help->About RowList...')
+        if self.backend == 'win32':
+            self.app.window(title='About RowList').wait('visible')
+        elif self.backend == 'uia':
+            self.app.RowListSampleApplication.child_window(title='About RowList').wait('visible')
+        else:
+            raise NotImplementedError('test_kill_soft_with_modal_subdialog: ' \
+                'backend "{}" is not supported'.format(self.backend))
+        self.assertTrue(self.app.kill(soft=True))
+        self.assertRaises(ProcessNotFoundError, Application().connect, process=self.target_process)
+        self.assertTrue(self.app.kill(soft=True)) # already killed, returned True anyway
+
+
+class ApplicationUiaKillTestCases(ApplicationWin32KillTestCases):
+
+    """Unit tests for method Application.kill() with backend='uia'"""
+    backend = 'uia'
+    # the same test methods run here
 
 
 if ctypes.windll.shell32.IsUserAnAdmin() == 0:

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -193,12 +193,13 @@ class ApplicationWin32KillTestCases(unittest.TestCase):
         self.assertTrue(self.app.kill(soft=True)) # already killed, returned True anyway
 
 
-class ApplicationUiaKillTestCases(ApplicationWin32KillTestCases):
+if sysinfo.UIA_support:
+    class ApplicationUiaKillTestCases(ApplicationWin32KillTestCases):
 
-    """Unit tests for method Application.kill() with backend='uia'"""
+        """Unit tests for method Application.kill() with backend='uia'"""
 
-    backend = 'uia'
-    # the same test methods run here
+        backend = 'uia'
+        # the same test methods run here
 
 
 if ctypes.windll.shell32.IsUserAnAdmin() == 0:

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -193,7 +193,7 @@ class ApplicationWin32KillTestCases(unittest.TestCase):
         self.assertTrue(self.app.kill(soft=True)) # already killed, returned True anyway
 
 
-if sysinfo.UIA_support:
+if UIA_support:
     class ApplicationUiaKillTestCases(ApplicationWin32KillTestCases):
 
         """Unit tests for method Application.kill() with backend='uia'"""

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -1250,7 +1250,7 @@ class RebarTestCases(unittest.TestCase):
         """Start the application, set some data and wait for the state we want
 
         The app title can be tricky. If no document is opened the title is just: "RebarTest"
-        However if an document is created/opened in the child frame
+        However if a document is created/opened in the child frame
         the title is appended with a document name: "RebarTest - RebarTest1"
         A findbestmatch proc does well here with guessing the title
         even though the app is started with a short title "RebarTest".

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -1266,8 +1266,7 @@ class RebarTestCases(unittest.TestCase):
 
     def tearDown(self):
         """Close the application after tests"""
-        # close the application
-        self.app.kill()
+        self.app.kill(soft=True)
 
     def testFriendlyClass(self):
         """Make sure the friendly class is set correctly (ReBar)"""

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -718,6 +718,7 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
         self.dlg.set_focus()
         self.dlg.TVS_CHECKBOXES.check_by_click()
         birds = self.ctrl.get_item(r'\Birds')
+        self.ctrl.set_focus() # to make sure focus is not lost by any accident event
         birds.click(where='check')
         self.assertEqual(birds.is_checked(), True)
         birds.click_input(where='check')


### PR DESCRIPTION
 * Made method `kill()` hard by default, but optional param `soft=True` can be specified to try closing the app first.
 * Added tests for `kill()` including "win32" and "uia" backend cases.
 * During test development I've found that after `.kill()` it's still possible to call `.connect()` successfully. So fixed these inconsistencies as well.