### PR TITLE
Issue 621

### DIFF
--- a/pywinauto/uia_element_info.py
+++ b/pywinauto/uia_element_info.py
@@ -228,7 +228,10 @@ class UIAElementInfo(ElementInfo):
     @property
     def runtime_id(self):
         """Return Runtime ID (hashable value but may be different from run to run)"""
-        return self._element.GetRuntimeId()
+        try:
+            return self._element.GetRuntimeId()
+        except COMError:
+            return 0
 
     @property
     def name(self):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -277,12 +277,6 @@ if UIA_support:
             self.assertEqual(edit.is_keyboard_focusable(), True)
             self.assertEqual(label.is_keyboard_focusable(), False)
 
-        def test_has_keyboard_focus(self):
-            """Test verifying a keyboard focus on a control"""
-            edit = self.dlg.TestLabelEdit.wrapper_object()
-            edit.set_focus()
-            self.assertEqual(edit.has_keyboard_focus(), True)
-
         def test_set_focus(self):
             """Test setting a keyboard focus on a control"""
             edit = self.dlg.TestLabelEdit.wrapper_object()

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -67,10 +67,11 @@ if UIA_support:
             wrp.element_info._element.FindAll = mock.Mock(side_effect=ValueError("Mocked value error"),
                                                           return_value=[])  # empty list
             self.assertEqual([], wrp.descendants())
-            wrp.element_info._element.FindAll = mock.Mock(side_effect=comtypes.COMError("Mocked COM error", 0, 0),
+            exception_err = comtypes.COMError(-2147220991, "Mocked COM error", ())
+            wrp.element_info._element.FindAll = mock.Mock(side_effect=exception_err,
                                                           return_value=[])  # empty list
             self.assertEqual([], wrp.descendants())
-            wrp.element_info._element = orig  # restore the original method
+            wrp.element_info._element.FindAll = orig  # restore the original method
 
         def test_issue_278(self):
             """Test that statement menu = app.MainWindow.Menu works for 'uia' backend"""
@@ -122,6 +123,18 @@ if UIA_support:
             button = self.dlg.child_window(class_name="Button",
                                            title="OK").wrapper_object()
             self.assertEqual(button.control_id(), None)
+
+        def test_runtime_id(self):
+            """Test getting runtime ID"""
+            button = self.dlg.child_window(class_name="Button",
+                                           title="OK").wrapper_object()
+            self.assertNotEqual(button.__hash__(), 0)
+
+            orig = button.element_info._element.GetRuntimeId
+            exception_err = comtypes.COMError(-2147220991, 'An event was unable to invoke any of the subscribers', ())
+            button.element_info._element.GetRuntimeId = mock.Mock(side_effect=exception_err)
+            self.assertEqual(button.__hash__(), 0)
+            button.element_info._element.GetRuntimeId = orig  # restore the original method
 
         def test_automation_id(self):
             """Test getting automation ID"""


### PR DESCRIPTION
- Fix #621: return zero as runtime ID on COMError exception
- Remove duplicate test_has_keyboard_focus from UIAWrapperTests
- Cleanup in UIAWrapperTests.test_issue_296