### PR TITLE
Cosmetic cleanups

### DIFF
--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -632,7 +632,7 @@ class _listview_item(object):
         #    raise ctypes.WinError()
         del new_remote_mem
 
-        win32functions.WaitGuiThreadIdle(self.listview_ctrl)
+        win32functions.WaitGuiThreadIdle(self.listview_ctrl.handle)
         time.sleep(Timings.after_listviewselect_wait)
 
     #-----------------------------------------------------------
@@ -1368,7 +1368,7 @@ class _treeview_element(object):
             win32defines.TVM_ENSUREVISIBLE,
             win32defines.TVGN_CARET,
             self.elem)
-        win32functions.WaitGuiThreadIdle(self.tree_ctrl)
+        win32functions.WaitGuiThreadIdle(self.tree_ctrl.handle)
         return self
     # Non PEP-8 alias
     EnsureVisible = deprecated(ensure_visible)
@@ -1647,7 +1647,7 @@ class TreeViewWrapper(hwndwrapper.HwndWrapper):
         if retval != win32defines.TRUE:
             raise ctypes.WinError()
 
-        #win32functions.WaitGuiThreadIdle(self)
+        #win32functions.WaitGuiThreadIdle(self.handle)
         #time.sleep(Timings.after_treeviewselect_wait)
     # Non PEP-8 alias
     Select = deprecated(select)
@@ -2255,7 +2255,7 @@ class TabControlWrapper(hwndwrapper.HwndWrapper):
         else:
             self.send_message(win32defines.TCM_SETCURFOCUS, tab)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_tabselect_wait)
         self.actions.log('Selected tab "' + str(logging_tab) + '"')
 
@@ -2317,7 +2317,7 @@ class _toolbar_button(object):
 #        # Notify the parent that we are finished selecting
 #        #self.toolbar_ctrl.notify_parent(win32defines.TBN_TOOLBARCHANGE)
 #
-#        win32functions.WaitGuiThreadIdle(self.toolbar_ctrl)
+#        win32functions.WaitGuiThreadIdle(self.toolbar_ctrl.handle)
 #        time.sleep(Timings.after_toobarpressbutton_wait)
 #    # Non PEP-8 alias
 #    Press = deprecated(press)
@@ -2345,7 +2345,7 @@ class _toolbar_button(object):
 #        # Notify the parent that we are finished selecting
 #        #self.toolbar_ctrl.notify_parent(win32defines.TBN_TOOLBARCHANGE)
 #
-#        win32functions.WaitGuiThreadIdle(self.toolbar_ctrl)
+#        win32functions.WaitGuiThreadIdle(self.toolbar_ctrl.handle)
 #        time.sleep(Timings.after_toobarpressbutton_wait)
 #
 #    #----------------------------------------------------------------
@@ -3151,7 +3151,7 @@ class UpDownWrapper(hwndwrapper.HwndWrapper):
                 win32defines.SMTO_NORMAL,
                 int(Timings.after_updownchange_wait * 1000),
                 ctypes.byref(result))
-            win32functions.WaitGuiThreadIdle(self)
+            win32functions.WaitGuiThreadIdle(self.handle)
             time.sleep(Timings.after_updownchange_wait)
             if self.get_value() == new_pos:
                 break
@@ -3168,7 +3168,7 @@ class UpDownWrapper(hwndwrapper.HwndWrapper):
         self.click_input(coords=(rect.left + 5, rect.top + 5))
 
         #self.set_value(self.get_value() + 1)
-        #win32functions.WaitGuiThreadIdle(self)
+        #win32functions.WaitGuiThreadIdle(self.handle)
         #time.sleep(Timings.after_updownchange_wait)
     # Non PEP-8 alias
     Increment = deprecated(increment)
@@ -3180,7 +3180,7 @@ class UpDownWrapper(hwndwrapper.HwndWrapper):
         self.click_input(coords=(rect.left + 5, rect.bottom - 5))
 
         #self.set_value(self.get_value() - 1)
-        #win32functions.WaitGuiThreadIdle(self)
+        #win32functions.WaitGuiThreadIdle(self.handle)
         #time.sleep(Timings.after_updownchange_wait)
     # Non PEP-8 alias
     Decrement = deprecated(decrement)

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -734,7 +734,7 @@ class HwndWrapper(BaseWrapper):
     #-----------------------------------------------------------
     def wait_for_idle(self):
         """Backend specific function to wait for idle state of a thread or a window"""
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
 
     # -----------------------------------------------------------
     def click(
@@ -854,7 +854,7 @@ class HwndWrapper(BaseWrapper):
 
         _perform_click(self, button='move', coords=coords, absolute=absolute, pressed=pressed)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         return self
     # Non PEP-8 alias
     MoveMouse = deprecated(move_mouse)
@@ -897,7 +897,7 @@ class HwndWrapper(BaseWrapper):
 
         text = ctypes.c_wchar_p(six.text_type(text))
         self.post_message(win32defines.WM_SETTEXT, 0, text)
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
 
         self.actions.log('Set text to the ' + self.friendly_class_name() + ': ' + str(text))
         return self
@@ -1144,7 +1144,7 @@ class HwndWrapper(BaseWrapper):
         if not ret:
             raise ctypes.WinError()
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_movewindow_wait)
     # Non PEP-8 alias
     MoveWindow = deprecated(move_window)
@@ -1325,7 +1325,7 @@ class HwndWrapper(BaseWrapper):
             win32gui.SetForegroundWindow(self.handle)
 
             # make sure that we are idle before returning
-            win32functions.WaitGuiThreadIdle(self)
+            win32functions.WaitGuiThreadIdle(self.handle)
 
             # only sleep if we had to change something!
             time.sleep(Timings.after_setfocus_wait)
@@ -1345,7 +1345,7 @@ class HwndWrapper(BaseWrapper):
         focused = win32gui.GetFocus()
         win32process.AttachThreadInput(control_thread, win32api.GetCurrentThreadId(), 0)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
 
         return self.handle == focused
 
@@ -1356,7 +1356,7 @@ class HwndWrapper(BaseWrapper):
         win32gui.SetFocus(self.handle)
         win32process.AttachThreadInput(control_thread, win32api.GetCurrentThreadId(), 0)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
 
         time.sleep(Timings.after_setfocus_wait)
         return self
@@ -1742,7 +1742,7 @@ def _perform_click(
         time.sleep(Timings.sendmessagetimeout_timeout)
 
         # wait until the thread can accept another message
-        win32functions.WaitGuiThreadIdle(ctrl)
+        win32functions.WaitGuiThreadIdle(ctrl.handle)
 
     # detach the Python process with the process that self is in
     #win32functions.AttachThreadInput(win32functions.GetCurrentThreadId(), control_thread, win32defines.FALSE)

--- a/pywinauto/controls/menuwrapper.py
+++ b/pywinauto/controls/menuwrapper.py
@@ -293,7 +293,7 @@ class MenuItem(object):
 
         mouse.click(coords=(x_pt, y_pt))
 
-        win32functions.WaitGuiThreadIdle(self.ctrl)
+        win32functions.WaitGuiThreadIdle(self.ctrl.handle)
         time.sleep(Timings.after_menu_wait)
     # Non PEP-8 alias
     ClickInput = deprecated(click_input)
@@ -324,7 +324,7 @@ class MenuItem(object):
         self.ctrl.send_message_timeout(
             self.menu.COMMAND, command_id, timeout=1.0)
 
-        win32functions.WaitGuiThreadIdle(self.ctrl)
+        win32functions.WaitGuiThreadIdle(self.ctrl.handle)
         time.sleep(Timings.after_menu_wait)
 
     # _perform_click() doesn't work for MenuItem, so let's call select() method

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -168,7 +168,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_CHECKED)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_buttoncheck_wait)
 
         # return this control so that actions can be chained.
@@ -183,7 +183,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_UNCHECKED)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_buttoncheck_wait)
 
         # return this control so that actions can be chained.
@@ -198,7 +198,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_INDETERMINATE)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_buttoncheck_wait)
 
         # return this control so that actions can be chained.
@@ -432,7 +432,7 @@ class ComboBoxWrapper(hwndwrapper.HwndWrapper):
             self.notify_parent(win32defines.CBN_CLOSEUP)
 
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_comboboxselect_wait)
 
         # return this control so that actions can be chained.
@@ -626,7 +626,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
         # Notify the parent that we have changed
         self.notify_parent(win32defines.LBN_SELCHANGE)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_listboxselect_wait)
 
         return self
@@ -645,7 +645,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
         else:
             self.send_message_timeout(win32defines.LB_SETCURSEL, index)
 
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
         time.sleep(Timings.after_listboxfocuschange_wait)
 
         # return this control so that actions can be chained.
@@ -870,7 +870,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
         self.send_message(win32defines.EM_SETSEL, start, end)
 
         # give the control a chance to catch up before continuing
-        win32functions.WaitGuiThreadIdle(self)
+        win32functions.WaitGuiThreadIdle(self.handle)
 
         time.sleep(Timings.after_editselect_wait)
 

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -820,10 +820,9 @@ class NotepadRegressionTests(unittest.TestCase):
     def tearDown(self):
         """Close the application after tests"""
         try:
-            self.dlg.close(0.5)
-            if self.app.Notepad["Do&n't Save"].exists():
-                self.app.Notepad["Do&n't Save"].click()
-                self.app.Notepad["Do&n't Save"].wait_not('visible')
+            self.app.UntitledNotepad.menu_select("File->Exit")
+            self.app.Notepad["Do&n't Save"].click()
+            self.app.Notepad["Do&n't Save"].wait_not('visible')
         except Exception:  # TimeoutError:
             pass
         finally:

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -979,7 +979,7 @@ class SendEnterKeyTest(unittest.TestCase):
 
     def test_sendEnterChar(self):
         self.ctrl.send_chars('Hello{ENTER}World')
-        self.assertEqual(['Hello\r\nWorld'], self.dlg.Edit.Texts())
+        self.assertEqual(['Hello\r\nWorld'], self.dlg.Edit.texts())
 
 
 class SendKeystrokesAltComboTests(unittest.TestCase):

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -973,13 +973,14 @@ class SendEnterKeyTest(unittest.TestCase):
 
     def tearDown(self):
         self.dlg.menu_select('File -> Exit')
-        if self.dlg["Do&n't Save"].exists():
-            self.dlg["Do&n't Save"].click()
-        self.app.kill()
+        try:
+            self.app.Notepad["Do&n't Save"].click()
+        except findbestmatch.MatchError:
+            self.app.kill()
 
     def test_sendEnterChar(self):
         self.ctrl.send_chars('Hello{ENTER}World')
-        self.assertEqual(['Hello\r\nWorld'], self.dlg.Edit.texts())
+        self.assertEqual('Hello\r\nWorld', self.dlg.Edit.window_text())
 
 
 class SendKeystrokesAltComboTests(unittest.TestCase):


### PR DESCRIPTION
This branch was started as an attempt to fix #623 , but later on I realized that ```BaseWrapper.__init__``` already sets up the ```_as_parameter_``` attribute to pass the handle to ctypes implicitly.  So basically, there were no bug here. However, I think we'd better stick to the explicit form of passing the parameter. This is to avoid similar confusions in the future and to make the code more consistent.

I also noticed in our unittests that we didn't click properly "Don't save" button when we close the Notepad with unsaved changes. This led to unnecessary delays.

Here is the list of proposed changes in this PR:
- pass handle to WaitGuiThreadIdle explicitly
- fix deprecation warning in SendEnterKeyTest.test_sendEnterChar (see a separate issue #639 )
- better handling of application close in tearDown of NotepadRegressionTests and SendEnterKeyTest