### PR TITLE
Bind WindowSpecification to Application object instead of hard-set process ID

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -150,6 +150,10 @@ class WindowSpecification(object):
         # kwargs will contain however to find this window
         if 'backend' not in search_criteria:
             search_criteria['backend'] = registry.active_backend.name
+        if 'process' in search_criteria:
+            raise KeyError('Keyword "process" is not supported any more. ' \
+                'Use Application instance with keyword "app" instead.')
+        self.app = search_criteria.pop('app', None)
         self.criteria = [search_criteria, ]
         self.actions = ActionLogger()
         self.backend = registry.backends[search_criteria['backend']]
@@ -189,6 +193,8 @@ class WindowSpecification(object):
         # find the dialog
         if 'backend' not in criteria[0]:
             criteria[0]['backend'] = self.backend.name
+        if self.app is not None:
+            criteria[0]['process'] = self.app.process
         dialog = self.backend.generic_wrapper_class(findwindows.find_element(**criteria[0]))
 
         ctrls = []
@@ -1195,7 +1201,8 @@ class Application(object):
                                   "anything else")
         else:
             # add the restriction for this particular process
-            kwargs['process'] = self.process
+            # kwargs['process'] = self.process
+            kwargs['app'] = self
             win_spec = WindowSpecification(kwargs)
 
         return win_spec

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -150,9 +150,10 @@ class WindowSpecification(object):
         # kwargs will contain however to find this window
         if 'backend' not in search_criteria:
             search_criteria['backend'] = registry.active_backend.name
-        if 'process' in search_criteria:
-            raise KeyError('Keyword "process" is not supported any more. ' \
-                'Use Application instance with keyword "app" instead.')
+        if 'process' in search_criteria and 'app' in search_criteria:
+            raise KeyError('Keywords "process" and "app" cannot be combined (ambiguous). ' \
+                'Use one option at a time: Application object with keyword "app" or ' \
+                'integer process ID with keyword "process".')
         self.app = search_criteria.pop('app', None)
         self.criteria = [search_criteria, ]
         self.actions = ActionLogger()

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -154,7 +154,7 @@ class WindowSpecification(object):
             raise KeyError('Keywords "process" and "app" cannot be combined (ambiguous). ' \
                 'Use one option at a time: Application object with keyword "app" or ' \
                 'integer process ID with keyword "process".')
-        self.app = search_criteria.pop('app', None)
+        self.app = search_criteria.get('app', None)
         self.criteria = [search_criteria, ]
         self.actions = ActionLogger()
         self.backend = registry.backends[search_criteria['backend']]
@@ -195,7 +195,9 @@ class WindowSpecification(object):
         if 'backend' not in criteria[0]:
             criteria[0]['backend'] = self.backend.name
         if self.app is not None:
+            # find_elements(...) accepts only "process" argument
             criteria[0]['process'] = self.app.process
+            del criteria[0]['app']
         dialog = self.backend.generic_wrapper_class(findwindows.find_element(**criteria[0]))
 
         ctrls = []
@@ -1201,8 +1203,7 @@ class Application(object):
             raise AppNotConnected("Please use start or connect before trying "
                                   "anything else")
         else:
-            # add the restriction for this particular process
-            # kwargs['process'] = self.process
+            # add the restriction for this particular application
             kwargs['app'] = self
             win_spec = WindowSpecification(kwargs)
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -758,6 +758,7 @@ class ApplicationTestCases(unittest.TestCase):
         app = ApplicationTestCases.TestInheritedApp()
         self.assertTrue(app.test_method())
 
+
 class WindowSpecificationTestCases(unittest.TestCase):
 
     """Unit tests for the application.Application class"""
@@ -787,6 +788,12 @@ class WindowSpecificationTestCases(unittest.TestCase):
         self.assertEqual(
             wspec.window_text(),
             u"Untitled - Notepad")
+
+    def test__init__both_keywords(self):
+        """Test creating a new spec with ambiguity by process and app simultaneously"""
+        self.assertRaises(KeyError, WindowSpecification,
+            dict(best_match=u"UntitledNotepad", app=self.app, process=self.app.process)
+            )
 
     def test__call__(self):
         """Test that __call__() correctly raises an error"""

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -781,7 +781,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
         wspec = WindowSpecification(
             dict(
                 best_match = u"UntitledNotepad",
-                process = self.app.process)
+                app = self.app)
             )
 
         self.assertEqual(
@@ -795,7 +795,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
         # no best_match!
         wspec = WindowSpecification(
-            dict(title = u"blah", process = self.app.process) )
+            dict(title = u"blah", app = self.app) )
 
         self.assertRaises(AttributeError, wspec)
 

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -781,8 +781,8 @@ class WindowSpecificationTestCases(unittest.TestCase):
         """Test creating a new spec by hand"""
         wspec = WindowSpecification(
             dict(
-                best_match = u"UntitledNotepad",
-                app = self.app)
+                best_match=u"UntitledNotepad",
+                app=self.app)
             )
 
         self.assertEqual(
@@ -802,7 +802,8 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
         # no best_match!
         wspec = WindowSpecification(
-            dict(title = u"blah", app = self.app) )
+            dict(title=u"blah", app=self.app)
+            )
 
         self.assertRaises(AttributeError, wspec)
 


### PR DESCRIPTION
 * Fix #613 
 * Allow separate usage of `process` and `app` keyword in WindowSpecification criteria.
 * Add test case for prohibited scenario.