### PR TITLE
Issue #691: tighten args for SendMessage and GetWindowLong

### DIFF
--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -219,6 +219,8 @@ def rectangle(handle):
 def font(handle):
     """Return the font as a LOGFONTW of the window"""
     # get the font handle
+    if handle is None:
+        handle = 0  # make sure we don't pass window handle down as None
     font_handle = win32functions.SendMessage(
         handle, win32defines.WM_GETFONT, 0, 0)
 

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -145,13 +145,13 @@ def contexthelpid(handle):
 #=========================================================================
 def iswindow(handle):
     """Return True if the handle is a window"""
-    return False if handle is None else  bool(win32functions.IsWindow(handle))
+    return False if handle is None else bool(win32functions.IsWindow(handle))
 
 
 #=========================================================================
 def isvisible(handle):
     """Return True if the window is visible"""
-    return False if handle is None else  bool(win32functions.IsWindowVisible(handle))
+    return False if handle is None else bool(win32functions.IsWindowVisible(handle))
 
 
 #=========================================================================
@@ -192,8 +192,8 @@ def is64bitbinary(filename):
         binary_type = win32file.GetBinaryType(filename)
         return binary_type != win32file.SCS_32BIT_BINARY
     except Exception as exc:
-        warnings.warn('Cannot get binary type for file "{}". Error: {}' \
-            ''.format(filename, exc), RuntimeWarning, stacklevel=2)
+        warnings.warn('Cannot get binary type for file "{}". Error: {}'
+                      .format(filename, exc), RuntimeWarning, stacklevel=2)
         return None
 
 

--- a/pywinauto/unittests/test_handleprops.py
+++ b/pywinauto/unittests/test_handleprops.py
@@ -38,6 +38,7 @@ import sys
 import warnings
 sys.path.append(".")
 
+from pywinauto import win32structures
 from pywinauto.handleprops import children, classname, clientrect, contexthelpid, \
     controlid, dumpwindow, exstyle, font, has_exstyle, has_style, is64bitprocess, \
     is_toplevel_window, isenabled, isunicode, isvisible, iswindow, parent, processid, \
@@ -199,6 +200,12 @@ class HandlepropsTestCases(unittest.TestCase):
 
         editfont = font(self.edit_handle)
         self.assertEqual(True, isinstance(editfont.lfFaceName, six.string_types))
+
+        # handle.props font should return DEFAULT font for an invalid handle
+        # Check only for a returned type as the default font can vary
+        expected = win32structures.LOGFONTW()
+        self.assertEqual(type(expected), type(font(sys.maxsize)))
+        self.assertEqual(type(expected), type(font(None)))
 
     def test_processid(self):
         """Make sure processid() function works"""

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -103,13 +103,15 @@ GetWindow			=	ctypes.windll.user32.GetWindow
 ShowWindow			= 	ctypes.windll.user32.ShowWindow
 GetWindowContextHelpId =	ctypes.windll.user32.GetWindowContextHelpId
 GetWindowLong		=	ctypes.windll.user32.GetWindowLongW
+GetWindowLong.argtypes = [win32structures.HWND, ctypes.c_int]
+GetWindowLong.restype = win32structures.LONG
 GetWindowPlacement  =   ctypes.windll.user32.GetWindowPlacement
 GetWindowRect		=	ctypes.windll.user32.GetWindowRect
 GetWindowText		=	ctypes.windll.user32.GetWindowTextW
 GetWindowTextLength	=	ctypes.windll.user32.GetWindowTextLengthW
 GetClassName        =   ctypes.windll.user32.GetClassNameW
 GetClassName.argtypes = [win32structures.HWND, wintypes.LPWSTR, ctypes.c_int]
-GetClassName.restrype = ctypes.c_int
+GetClassName.restype = ctypes.c_int
 GetClientRect       =   ctypes.windll.user32.GetClientRect
 IsChild				=	ctypes.windll.user32.IsChild
 IsWindow 			=	ctypes.windll.user32.IsWindow
@@ -148,6 +150,10 @@ GlobalLock = ctypes.windll.kernel32.GlobalLock
 GlobalUnlock = ctypes.windll.kernel32.GlobalUnlock
 
 SendMessage			=	ctypes.windll.user32.SendMessageW
+SendMessage.argtypes = [win32structures.HWND, win32structures.UINT, win32structures.WPARAM,
+                        win32structures.LPVOID]
+SendMessage.restype = win32structures.LRESULT
+
 SendMessageTimeout  =   ctypes.windll.user32.SendMessageTimeoutW
 SendMessageTimeout.argtypes = [win32structures.HWND, win32structures.UINT, win32structures.WPARAM,
                                win32structures.LPARAM, win32structures.UINT, win32structures.UINT,


### PR DESCRIPTION
Another fix for win32 signatures. Similarly to issue #641 it should help to process window handles with values beyond usual int range.

The last arg for SendMessage, actually, should be LPARAM, but it's tricky to pass it as a pointer from ctypes.byref() so LPVOID is selected instead

Also fixed a typo for GetClassName return type and PEP-8 typos