### PR TITLE
Issue #650: another block of fixes for WinAPI types

### DIFF
--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -135,7 +135,7 @@ class _listview_item(object):
 
         item.iItem = self.item_index
         item.iSubItem = self.subitem_index
-        item.stateMask = win32structures.UINT(-1)
+        item.stateMask = wintypes.UINT(-1)
 
         item.cchTextMax = 2000
         item.pszText = remote_mem.Address() + \
@@ -501,9 +501,9 @@ class _listview_item(object):
 
         lvitem = self.listview_ctrl.LVITEM()
 
-        lvitem.mask = win32structures.UINT(win32defines.LVIF_STATE)
-        lvitem.state = win32structures.UINT(index_to_state_image_mask(1))  # win32structures.UINT(0x1000)
-        lvitem.stateMask = win32structures.UINT(win32defines.LVIS_STATEIMAGEMASK)
+        lvitem.mask = wintypes.UINT(win32defines.LVIF_STATE)
+        lvitem.state = wintypes.UINT(index_to_state_image_mask(1))  # wintypes.UINT(0x1000)
+        lvitem.stateMask = wintypes.UINT(win32defines.LVIS_STATEIMAGEMASK)
 
         remote_mem = RemoteMemoryBlock(self.listview_ctrl)
         remote_mem.Write(lvitem)
@@ -530,9 +530,9 @@ class _listview_item(object):
 
         lvitem = self.listview_ctrl.LVITEM()
 
-        lvitem.mask = win32structures.UINT(win32defines.LVIF_STATE)
-        lvitem.state = win32structures.UINT(index_to_state_image_mask(2))  # win32structures.UINT(0x2000)
-        lvitem.stateMask = win32structures.UINT(win32defines.LVIS_STATEIMAGEMASK)
+        lvitem.mask = wintypes.UINT(win32defines.LVIF_STATE)
+        lvitem.state = wintypes.UINT(index_to_state_image_mask(2))  # wintypes.UINT(0x2000)
+        lvitem.stateMask = wintypes.UINT(win32defines.LVIS_STATEIMAGEMASK)
 
         remote_mem = RemoteMemoryBlock(self.listview_ctrl)
         remote_mem.Write(lvitem)
@@ -591,12 +591,12 @@ class _listview_item(object):
 
         # first we need to change the state of the item
         lvitem = self.listview_ctrl.LVITEM()
-        lvitem.mask = win32structures.UINT(win32defines.LVIF_STATE)
+        lvitem.mask = wintypes.UINT(win32defines.LVIF_STATE)
 
         if to_select:
-            lvitem.state = win32structures.UINT(win32defines.LVIS_FOCUSED | win32defines.LVIS_SELECTED)
+            lvitem.state = wintypes.UINT(win32defines.LVIS_FOCUSED | win32defines.LVIS_SELECTED)
 
-        lvitem.stateMask = win32structures.UINT(win32defines.LVIS_FOCUSED | win32defines.LVIS_SELECTED)
+        lvitem.stateMask = wintypes.UINT(win32defines.LVIS_FOCUSED | win32defines.LVIS_SELECTED)
 
         remote_mem = RemoteMemoryBlock(self.listview_ctrl)
         remote_mem.Write(lvitem, size=ctypes.sizeof(lvitem))
@@ -1424,7 +1424,7 @@ class _treeview_element(object):
         item.pszText = remote_mem.Address() + ctypes.sizeof(item) + 16
         item.cchTextMax = 2000
         item.hItem = self.elem
-        item.stateMask = win32structures.UINT(-1)
+        item.stateMask = wintypes.UINT(-1)
 
         # Write the local TVITEM structure to the remote memory block
         remote_mem.Write(item)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -43,6 +43,7 @@ import win32con
 import win32gui
 import pywintypes
 
+from ctypes import wintypes
 from . import win32functions
 from . import win32defines
 from . import win32structures
@@ -331,8 +332,8 @@ def children(handle):
     # define the child proc type
     enum_child_proc_t = ctypes.WINFUNCTYPE(
         ctypes.c_int,            # return type
-        ctypes.wintypes.HWND,    # the window handle
-        ctypes.wintypes.LPARAM)  # extra information
+        wintypes.HWND,           # the window handle
+        wintypes.LPARAM)         # extra information
 
     # update the proc to the correct type
     proc = enum_child_proc_t(enum_child_proc)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -331,8 +331,8 @@ def children(handle):
     # define the child proc type
     enum_child_proc_t = ctypes.WINFUNCTYPE(
         ctypes.c_int,            # return type
-        wintypes.HWND,    # the window handle
-        wintypes.LPARAM)  # extra information
+        ctypes.wintypes.HWND,    # the window handle
+        ctypes.wintypes.LPARAM)  # extra information
 
     # update the proc to the correct type
     proc = enum_child_proc_t(enum_child_proc)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -35,7 +35,6 @@ These are implemented in a procedural way so as to to be
 useful to other modules with the least conceptual overhead
 """
 
-import ctypes
 import warnings
 import win32process
 import win32api
@@ -44,6 +43,11 @@ import win32gui
 import pywintypes
 
 from ctypes import wintypes
+from ctypes import WINFUNCTYPE
+from ctypes import c_int
+from ctypes import byref
+from ctypes import sizeof
+from ctypes import create_unicode_buffer
 from . import win32functions
 from . import win32defines
 from . import win32structures
@@ -72,7 +76,7 @@ def text(handle):
         0,
         win32defines.SMTO_ABORTIFHUNG,
         500,
-        ctypes.byref(c_length)
+        byref(c_length)
     )
     if result == 0:
         ActionLogger().log('WARNING! Cannot retrieve text length for handle = ' + str(handle))
@@ -86,10 +90,10 @@ def text(handle):
     if length > 0:
         length += 1
 
-        buffer_ = ctypes.create_unicode_buffer(length)
+        buffer_ = create_unicode_buffer(length)
 
         ret = win32functions.SendMessage(
-            handle, win32defines.WM_GETTEXT, length, ctypes.byref(buffer_))
+            handle, win32defines.WM_GETTEXT, length, byref(buffer_))
 
         if ret:
             textval = buffer_.value
@@ -102,7 +106,7 @@ def classname(handle):
     """Return the class name of the window"""
     if handle is None:
         return None
-    class_name = ctypes.create_unicode_buffer(u"", 257)
+    class_name = create_unicode_buffer(u"", 257)
     win32functions.GetClassName(handle, class_name, 256)
     return class_name.value
 
@@ -202,7 +206,7 @@ def is64bitbinary(filename):
 def clientrect(handle):
     """Return the client rectangle of the control"""
     client_rect = win32structures.RECT()
-    win32functions.GetClientRect(handle, ctypes.byref(client_rect))
+    win32functions.GetClientRect(handle, byref(client_rect))
     return client_rect
 
 
@@ -250,7 +254,7 @@ def font(handle):
     # Get the Logfont structure of the font of the control
     fontval = win32structures.LOGFONTW()
     ret = win32functions.GetObject(
-        font_handle, ctypes.sizeof(fontval), ctypes.byref(fontval))
+        font_handle, sizeof(fontval), byref(fontval))
 
     # The function could not get the font - this is probably
     # because the control does not have associated Font/Text
@@ -269,11 +273,11 @@ def font(handle):
             # get the title font based on the system metrics rather
             # than the font of the control itself
             ncms = win32structures.NONCLIENTMETRICSW()
-            ncms.cbSize = ctypes.sizeof(ncms)
+            ncms.cbSize = sizeof(ncms)
             win32functions.SystemParametersInfo(
                 win32defines.SPI_GETNONCLIENTMETRICS,
-                ctypes.sizeof(ncms),
-                ctypes.byref(ncms),
+                sizeof(ncms),
+                byref(ncms),
                 0)
 
             # with either of the following 2 flags set the font of the
@@ -325,8 +329,8 @@ def children(handle):
         return True
 
     # define the child proc type
-    enum_child_proc_t = ctypes.WINFUNCTYPE(
-        ctypes.c_int,            # return type
+    enum_child_proc_t = WINFUNCTYPE(
+        c_int,                   # return type
         wintypes.HWND,           # the window handle
         wintypes.LPARAM)         # extra information
 

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -331,8 +331,8 @@ def children(handle):
     # define the child proc type
     enum_child_proc_t = ctypes.WINFUNCTYPE(
         ctypes.c_int,            # return type
-        win32structures.HWND,    # the window handle
-        win32structures.LPARAM)  # extra information
+        wintypes.HWND,    # the window handle
+        wintypes.LPARAM)  # extra information
 
     # update the proc to the correct type
     proc = enum_child_proc_t(enum_child_proc)

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -247,11 +247,6 @@ def font(handle):
                 font_handle = win32functions.GetStockObject(
                     win32defines.ANSI_VAR_FONT)
 
-    else:
-        fontval = win32structures.LOGFONTW()
-        ret = win32functions.GetObject(
-            font_handle, ctypes.sizeof(fontval), ctypes.byref(fontval))
-
     # Get the Logfont structure of the font of the control
     fontval = win32structures.LOGFONTW()
     ret = win32functions.GetObject(

--- a/pywinauto/remote_memory_block.py
+++ b/pywinauto/remote_memory_block.py
@@ -39,6 +39,7 @@ import ctypes
 import win32api
 import win32process
 
+from ctypes import wintypes
 from . import win32functions
 from . import win32defines
 from . import win32structures
@@ -108,7 +109,7 @@ class RemoteMemoryBlock(object):
         self._as_parameter_ = self.mem_address
 
         # write guard signature at the end of memory block
-        signature = ctypes.wintypes.LONG(0x66666666)
+        signature = wintypes.LONG(0x66666666)
         ret = win32functions.WriteProcessMemory(
             ctypes.c_void_p(self.process),
             ctypes.c_void_p(self.mem_address + self.size),
@@ -143,7 +144,7 @@ class RemoteMemoryBlock(object):
                 ctypes.c_void_p(self.process),
                 ctypes.c_void_p(self.mem_address),
                 win32structures.ULONG_PTR(0),
-                ctypes.wintypes.DWORD(win32defines.MEM_RELEASE))
+                wintypes.DWORD(win32defines.MEM_RELEASE))
             if ret == 0:
                 print('Error: CleanUp: VirtualFreeEx() returned zero for address ', hex(self.mem_address))
                 last_error = win32api.GetLastError()

--- a/pywinauto/remote_memory_block.py
+++ b/pywinauto/remote_memory_block.py
@@ -108,7 +108,7 @@ class RemoteMemoryBlock(object):
         self._as_parameter_ = self.mem_address
 
         # write guard signature at the end of memory block
-        signature = win32structures.LONG(0x66666666)
+        signature = ctypes.wintypes.LONG(0x66666666)
         ret = win32functions.WriteProcessMemory(
             ctypes.c_void_p(self.process),
             ctypes.c_void_p(self.mem_address + self.size),
@@ -143,7 +143,7 @@ class RemoteMemoryBlock(object):
                 ctypes.c_void_p(self.process),
                 ctypes.c_void_p(self.mem_address),
                 win32structures.ULONG_PTR(0),
-                win32structures.DWORD(win32defines.MEM_RELEASE))
+                ctypes.wintypes.DWORD(win32defines.MEM_RELEASE))
             if ret == 0:
                 print('Error: CleanUp: VirtualFreeEx() returned zero for address ', hex(self.mem_address))
                 last_error = win32api.GetLastError()

--- a/pywinauto/win32defines.py
+++ b/pywinauto/win32defines.py
@@ -4524,9 +4524,9 @@ IMAGE_SCN_MEM_WRITE                  = 2147483648 # Variable c_uint
 IMAGE_RESOURCE_NAME_IS_STRING        = win32con.IMAGE_RESOURCE_NAME_IS_STRING # -2147483648
 IMAGE_ARCHIVE_START                  = win32con.IMAGE_ARCHIVE_START # !<arch>
 
-IMAGE_ARCHIVE_LINKER_MEMBER          = win32con.IMAGE_ARCHIVE_LINKER_MEMBER # /               
-IMAGE_ARCHIVE_LONGNAMES_MEMBER       = win32con.IMAGE_ARCHIVE_LONGNAMES_MEMBER # //              
-IMAGE_ARCHIVE_PAD                    = win32con.IMAGE_ARCHIVE_PAD # 
+IMAGE_ARCHIVE_LINKER_MEMBER          = win32con.IMAGE_ARCHIVE_LINKER_MEMBER # /
+IMAGE_ARCHIVE_LONGNAMES_MEMBER       = win32con.IMAGE_ARCHIVE_LONGNAMES_MEMBER # //
+IMAGE_ARCHIVE_PAD                    = win32con.IMAGE_ARCHIVE_PAD #
 
 IMAGE_ARCHIVE_END                    = win32con.IMAGE_ARCHIVE_END # `
 
@@ -6427,12 +6427,6 @@ MIIM_DATA       = win32con.MIIM_DATA # 32
 MIIM_STRING     = win32con.MIIM_STRING # 64
 MIIM_BITMAP     = win32con.MIIM_BITMAP # 128
 MIIM_FTYPE      = win32con.MIIM_FTYPE # 256
-MIIM_STATE      = win32con.MIIM_STATE # 1
-MIIM_ID         = win32con.MIIM_ID # 2
-MIIM_SUBMENU    = win32con.MIIM_SUBMENU # 4
-MIIM_CHECKMARKS = win32con.MIIM_CHECKMARKS # 8
-MIIM_TYPE       = win32con.MIIM_TYPE # 16
-MIIM_DATA       = win32con.MIIM_DATA # 32
 
 MIM_MAXHEIGHT       = win32con.MIM_MAXHEIGHT # 1
 MIM_BACKGROUND      = win32con.MIM_BACKGROUND # 2
@@ -7455,18 +7449,15 @@ PBM_SETMARQUEE  = 0x040A # Windows XP ~
 PBM_GETSTEP     = 0x040D # Windows Vista ~
 PBM_GETBKCOLOR  = 0x040E
 PBM_GETBARCOLOR = 0x040F
-PBM_SETRANGE    = 0x0401
-PBM_SETPOS      = 0x0402
-PBM_SETRANGE32  = 0x0406 # Internet Explorer 3.0 ~
+PBM_SETRANGE    = 0x0401  # 1025, Variable c_int
+PBM_SETPOS      = 0x0402  # 1026, Variable c_int
+PBM_SETRANGE32  = 0x0406  # 1030, Variable c_int, Internet Explorer 3.0 ~
 PBM_SETSTATE    = 0x0410
 PBM_GETSTATE    = 0x0411
 PBM_SETBKCOLOR  = 0x2001
-PBM_SETRANGE    = 1025 # Variable c_int
-PBM_SETPOS      = 1026 # Variable c_int
 PBM_DELTAPOS    = 1027 # Variable c_int
 PBM_SETSTEP     = 1028 # Variable c_int
 PBM_STEPIT      = 1029 # Variable c_int
-PBM_SETRANGE32  = 1030 # Variable c_int
 PBM_GETRANGE    = 1031 # Variable c_int
 PBM_GETPOS      = 1032 # Variable c_int
 PBM_SETBARCOLOR = 1033 # Variable c_int

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -194,6 +194,13 @@ DebugBreakProcess	=	ctypes.windll.kernel32.DebugBreakProcess
 VirtualAlloc		=	ctypes.windll.kernel32.VirtualAlloc
 VirtualFree			=	ctypes.windll.kernel32.VirtualFree
 WriteProcessMemory	=	ctypes.windll.kernel32.WriteProcessMemory
+WriteProcessMemory.argtypes = [ wintypes.HANDLE,
+                                wintypes.LPVOID,
+                                wintypes.LPVOID,
+                                ctypes.c_size_t,
+                                ctypes.POINTER(ctypes.c_size_t)]
+WriteProcessMemory.restype = wintypes.BOOL
+
 GetActiveWindow		=	ctypes.windll.user32.GetActiveWindow
 GetLastActivePopup 	=	ctypes.windll.user32.GetLastActivePopup
 FindWindow			=	ctypes.windll.user32.FindWindowW

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -143,7 +143,7 @@ OpenProcess.restype = wintypes.HANDLE
 OpenProcess.argtypes = [
     wintypes.DWORD,
     wintypes.BOOL,
-    wintypes.DWORD
+    wintypes.DWORD,
     ]
 CloseHandle = ctypes.windll.kernel32.CloseHandle
 CloseHandle.restype = wintypes.BOOL
@@ -159,7 +159,7 @@ ReadProcessMemory.argtypes = [
     wintypes.LPVOID,
     wintypes.LPVOID,
     ctypes.c_size_t,
-    ctypes.POINTER(ctypes.c_size_t)
+    ctypes.POINTER(ctypes.c_size_t),
 ]
 GlobalAlloc = ctypes.windll.kernel32.GlobalAlloc
 GlobalLock = ctypes.windll.kernel32.GlobalLock
@@ -203,7 +203,7 @@ VirtualAllocEx.argtypes = [
     wintypes.LPVOID,
     ctypes.c_size_t,
     wintypes.DWORD,
-    wintypes.DWORD
+    wintypes.DWORD,
 ]
 VirtualFreeEx =	ctypes.windll.kernel32.VirtualFreeEx
 VirtualFreeEx.restype = wintypes.BOOL
@@ -211,7 +211,7 @@ VirtualFreeEx.argtypes = [
     wintypes.HANDLE,
     wintypes.LPVOID,
     ctypes.c_size_t,
-    wintypes.DWORD
+    wintypes.DWORD,
     ]
 DebugBreakProcess	=	ctypes.windll.kernel32.DebugBreakProcess
 
@@ -221,14 +221,14 @@ VirtualAlloc.argtypes = [
     wintypes.LPVOID,
     ctypes.c_size_t,
     wintypes.DWORD,
-    wintypes.DWORD
+    wintypes.DWORD,
 ]
 VirtualFree = ctypes.windll.kernel32.VirtualFree
 VirtualFree.retype = wintypes.BOOL
 VirtualFree.argtypes = [
     wintypes.LPVOID,
     ctypes.c_size_t,
-    wintypes.DWORD
+    wintypes.DWORD,
 ]
 WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
 WriteProcessMemory.restype = wintypes.BOOL

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -237,7 +237,7 @@ WriteProcessMemory.argtypes = [
     wintypes.LPVOID,
     wintypes.LPVOID,
     ctypes.c_size_t,
-    ctypes.POINTER(ctypes.c_size_t)
+    ctypes.POINTER(ctypes.c_size_t),
 ]
 
 GetActiveWindow		=	ctypes.windll.user32.GetActiveWindow

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -145,6 +145,12 @@ TerminateProcess    = ctypes.windll.kernel32.TerminateProcess
 ExitProcess         = ctypes.windll.kernel32.ExitProcess
 
 ReadProcessMemory   =   ctypes.windll.kernel32.ReadProcessMemory
+ReadProcessMemory.argtypes = [wintypes.HANDLE,
+                        wintypes.LPVOID,
+                        wintypes.LPVOID,
+                        ctypes.c_size_t,
+                        ctypes.POINTER(ctypes.c_size_t)]
+ReadProcessMemory.restypes = wintypes.BOOL
 GlobalAlloc = ctypes.windll.kernel32.GlobalAlloc
 GlobalLock = ctypes.windll.kernel32.GlobalLock
 GlobalUnlock = ctypes.windll.kernel32.GlobalUnlock

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -144,13 +144,15 @@ CreateProcess       = ctypes.windll.kernel32.CreateProcessW
 TerminateProcess    = ctypes.windll.kernel32.TerminateProcess
 ExitProcess         = ctypes.windll.kernel32.ExitProcess
 
-ReadProcessMemory   =   ctypes.windll.kernel32.ReadProcessMemory
-ReadProcessMemory.argtypes = [wintypes.HANDLE,
-                        wintypes.LPVOID,
-                        wintypes.LPVOID,
-                        ctypes.c_size_t,
-                        ctypes.POINTER(ctypes.c_size_t)]
+ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
 ReadProcessMemory.restypes = wintypes.BOOL
+ReadProcessMemory.argtypes = [
+    wintypes.HANDLE,
+    wintypes.LPVOID,
+    wintypes.LPVOID,
+    ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_size_t)
+]
 GlobalAlloc = ctypes.windll.kernel32.GlobalAlloc
 GlobalLock = ctypes.windll.kernel32.GlobalLock
 GlobalUnlock = ctypes.windll.kernel32.GlobalUnlock
@@ -186,20 +188,49 @@ try:
 except AttributeError:
     SetWindowLongPtr = SetWindowLong
 SystemParametersInfo =	ctypes.windll.user32.SystemParametersInfoW
-VirtualAllocEx		=	ctypes.windll.kernel32.VirtualAllocEx
-VirtualAllocEx.restype = ctypes.c_void_p
-VirtualFreeEx		=	ctypes.windll.kernel32.VirtualFreeEx
+VirtualAllocEx = ctypes.windll.kernel32.VirtualAllocEx
+VirtualAllocEx.restype = wintypes.LPVOID
+VirtualAllocEx.argtypes = [
+    wintypes.HANDLE,
+    wintypes.LPVOID,
+    ctypes.c_size_t,
+    wintypes.DWORD,
+    wintypes.DWORD
+]
+VirtualFreeEx =	ctypes.windll.kernel32.VirtualFreeEx
+VirtualFreeEx.restypes = wintypes.BOOL
+VirtualFreeEx.argtypes = [
+    wintypes.HANDLE,
+    wintypes.LPVOID,
+    ctypes.c_size_t,
+    wintypes.DWORD
+    ]
 DebugBreakProcess	=	ctypes.windll.kernel32.DebugBreakProcess
 
-VirtualAlloc		=	ctypes.windll.kernel32.VirtualAlloc
-VirtualFree			=	ctypes.windll.kernel32.VirtualFree
-WriteProcessMemory	=	ctypes.windll.kernel32.WriteProcessMemory
-WriteProcessMemory.argtypes = [ wintypes.HANDLE,
-                                wintypes.LPVOID,
-                                wintypes.LPVOID,
-                                ctypes.c_size_t,
-                                ctypes.POINTER(ctypes.c_size_t)]
+VirtualAlloc = ctypes.windll.kernel32.VirtualAlloc
+VirtualAlloc.restype = wintypes.LPVOID
+VirtualAlloc.argtypes = [
+    wintypes.LPVOID,
+    ctypes.c_size_t,
+    wintypes.DWORD,
+    wintypes.DWORD
+]
+VirtualFree = ctypes.windll.kernel32.VirtualFree
+VirtualFree.retype = wintypes.BOOL
+VirtualFree.argtypes = [
+    wintypes.LPVOID,
+    ctypes.c_size_t,
+    wintypes.DWORD
+]
+WriteProcessMemory = ctypes.windll.kernel32.WriteProcessMemory
 WriteProcessMemory.restype = wintypes.BOOL
+WriteProcessMemory.argtypes = [
+    wintypes.HANDLE,
+    wintypes.LPVOID,
+    wintypes.LPVOID,
+    ctypes.c_size_t,
+    ctypes.POINTER(ctypes.c_size_t)
+]
 
 GetActiveWindow		=	ctypes.windll.user32.GetActiveWindow
 GetLastActivePopup 	=	ctypes.windll.user32.GetLastActivePopup

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -138,14 +138,22 @@ AttachThreadInput.argtypes = [wintypes.DWORD, wintypes.DWORD, wintypes.BOOL]
 #GetWindowThreadProcessId    =   ctypes.windll.user32.GetWindowThreadProcessId
 GetLastError = ctypes.windll.kernel32.GetLastError
 
-OpenProcess			=	ctypes.windll.kernel32.OpenProcess
-CloseHandle         =   ctypes.windll.kernel32.CloseHandle
+OpenProcess = ctypes.windll.kernel32.OpenProcess
+OpenProcess.restype = wintypes.HANDLE
+OpenProcess.argtypes = [
+    wintypes.DWORD,
+    wintypes.BOOL,
+    wintypes.DWORD
+    ]
+CloseHandle = ctypes.windll.kernel32.CloseHandle
+CloseHandle.restype = wintypes.BOOL
+CloseHandle.argtypes = [ wintypes.HANDLE ]
 CreateProcess       = ctypes.windll.kernel32.CreateProcessW
 TerminateProcess    = ctypes.windll.kernel32.TerminateProcess
 ExitProcess         = ctypes.windll.kernel32.ExitProcess
 
 ReadProcessMemory = ctypes.windll.kernel32.ReadProcessMemory
-ReadProcessMemory.restypes = wintypes.BOOL
+ReadProcessMemory.restype = wintypes.BOOL
 ReadProcessMemory.argtypes = [
     wintypes.HANDLE,
     wintypes.LPVOID,
@@ -198,7 +206,7 @@ VirtualAllocEx.argtypes = [
     wintypes.DWORD
 ]
 VirtualFreeEx =	ctypes.windll.kernel32.VirtualFreeEx
-VirtualFreeEx.restypes = wintypes.BOOL
+VirtualFreeEx.restype = wintypes.BOOL
 VirtualFreeEx.argtypes = [
     wintypes.HANDLE,
     wintypes.LPVOID,


### PR DESCRIPTION
Switch to wintypes in handleprops and common_controls.
Explicit signatures for WinAPI functions used by RemoteMemoryBlock