### PR TITLE
ctypes adaptations in order to work with other packages

### DIFF
--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -184,12 +184,12 @@ SetCursorPos.argtypes = [
 GetCursorPos = windll.user32.GetCursorPos
 GetCursorPos.restype = wintypes.BOOL
 GetCursorPos.argtypes = [
-    POINTER(win32structures.POINT),
+    POINTER(wintypes.POINT),
 ]
 GetCaretPos = windll.user32.GetCaretPos
 GetCaretPos.restype = wintypes.BOOL
 GetCaretPos.argtypes = [
-    POINTER(win32structures.POINT),
+    POINTER(wintypes.POINT),
 ]
 GetKeyboardState = windll.user32.GetKeyboardState
 GetKeyboardState.restype = wintypes.BOOL
@@ -310,7 +310,7 @@ MenuItemFromPoint.restype = c_int
 MenuItemFromPoint.argtypes = [
     wintypes.HWND,
     wintypes.HMENU,
-    POINTER(win32structures.POINT),
+    POINTER(wintypes.POINT),
 ]
 BringWindowToTop = windll.user32.BringWindowToTop
 BringWindowToTop.restype = wintypes.BOOL
@@ -413,13 +413,13 @@ ClientToScreen = windll.user32.ClientToScreen
 ClientToScreen.restype = wintypes.BOOL
 ClientToScreen.argtypes = [
     wintypes.HWND,
-    POINTER(win32structures.POINT),
+    POINTER(wintypes.POINT),
 ]
 ScreenToClient = windll.user32.ScreenToClient
 ScreenToClient.restype = wintypes.BOOL
 ScreenToClient.argtypes = [
     wintypes.HWND,
-    POINTER(win32structures.POINT),
+    POINTER(wintypes.POINT),
 ]
 GetCurrentThreadId = windll.kernel32.GetCurrentThreadId
 GetCurrentThreadId.restype = wintypes.DWORD
@@ -624,7 +624,7 @@ ReleaseCapture.argtypes = [
 WindowFromPoint = windll.user32.WindowFromPoint
 WindowFromPoint.restype = wintypes.HWND
 WindowFromPoint.argtypes = [
-    win32structures.POINT,
+    wintypes.POINT,
 ]
 WaitForSingleObject = windll.kernel32.WaitForSingleObject
 WaitForSingleObject.restype = wintypes.DWORD

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -96,7 +96,7 @@ DrawText.argtypes = [
     wintypes.HDC,
     wintypes.LPCWSTR,
     c_int,
-    POINTER(win32structures.RECT),
+    POINTER(wintypes.RECT),
     wintypes.UINT,
 ]
 TextOut = windll.gdi32.TextOutW
@@ -264,7 +264,7 @@ GetMenuItemRect.argtypes = [
     wintypes.HWND,
     wintypes.HMENU,
     wintypes.UINT,
-    POINTER(win32structures.RECT),
+    POINTER(wintypes.RECT),
 ]
 CheckMenuItem = windll.user32.CheckMenuItem
 CheckMenuItem.restype = wintypes.DWORD
@@ -381,7 +381,7 @@ GetClientRect = windll.user32.GetClientRect
 GetClientRect.restype = wintypes.BOOL
 GetClientRect.argtypes = [
     wintypes.HWND,
-    POINTER(win32structures.RECT),
+    POINTER(wintypes.RECT),
 ]
 IsChild = windll.user32.IsChild
 IsChild.restype = wintypes.BOOL

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -153,13 +153,9 @@ LPARAM = wintypes.LPARAM
 WPARAM = wintypes.WPARAM
 
 
-class POINT(Structure):
-    _pack_ = 4
-    _fields_ = [
-        # C:/PROGRA~1/MIAF9D~1/VC98/Include/windef.h 307
-        ('x', LONG),
-        ('y', LONG),
-    ]
+class POINT(wintypes.POINT):
+
+    """Wrap the POINT structure and add extra functionality"""
 
     def __iter__(self):
         """Allow iteration through coordinates"""

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -153,7 +153,7 @@ LPARAM = wintypes.LPARAM
 WPARAM = wintypes.WPARAM
 
 
-class POINT(wintypes.POINT, Structure):
+class POINT(wintypes.POINT):
 
     """Wrap the POINT structure and add extra functionality"""
 
@@ -170,6 +170,9 @@ class POINT(wintypes.POINT, Structure):
             return self.y
         else:
             raise IndexError("Illegal index")
+
+    __eq__ = Structure.__eq__
+    __str__ = Structure.__str__
 
 assert sizeof(POINT) == 8, sizeof(POINT)
 assert alignment(POINT) == 4, alignment(POINT)

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -41,9 +41,9 @@ from .win32defines import LF_FACESIZE
 from . import sysinfo
 
 
-class Structure(Struct):
+class StructureMixIn:
 
-    """Override the Structure class from ctypes to add printing and comparison"""
+    """Define printing and comparison behaviors to be used for the Structure class from ctypes"""
 
     #----------------------------------------------------------------
     def __str__(self):
@@ -91,6 +91,11 @@ class Structure(Struct):
                 return False
 
         return False
+
+
+class Structure(Struct, StructureMixIn):
+    """Override the Structure class from ctypes to add printing and comparison"""
+    pass
 
 ##====================================================================
 #def PrintCtypesStruct(struct, exceptList = []):
@@ -153,7 +158,7 @@ LPARAM = wintypes.LPARAM
 WPARAM = wintypes.WPARAM
 
 
-class POINT(wintypes.POINT):
+class POINT(wintypes.POINT, StructureMixIn):
 
     """Wrap the POINT structure and add extra functionality"""
 
@@ -171,8 +176,6 @@ class POINT(wintypes.POINT):
         else:
             raise IndexError("Illegal index")
 
-    __eq__ = Structure.__eq__
-    __str__ = Structure.__str__
 
 assert sizeof(POINT) == 8, sizeof(POINT)
 assert alignment(POINT) == 4, alignment(POINT)

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -99,6 +99,7 @@ class Structure(Struct, StructureMixIn):
 
     pass
 
+
 ##====================================================================
 #def PrintCtypesStruct(struct, exceptList = []):
 #    """Print out the fields of the ctypes Structure

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -41,7 +41,7 @@ from .win32defines import LF_FACESIZE
 from . import sysinfo
 
 
-class StructureMixIn:
+class StructureMixIn(object):
 
     """Define printing and comparison behaviors to be used for the Structure class from ctypes"""
 

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -153,7 +153,7 @@ LPARAM = wintypes.LPARAM
 WPARAM = wintypes.WPARAM
 
 
-class POINT(wintypes.POINT):
+class POINT(wintypes.POINT, Structure):
 
     """Wrap the POINT structure and add extra functionality"""
 

--- a/pywinauto/win32structures.py
+++ b/pywinauto/win32structures.py
@@ -94,7 +94,9 @@ class StructureMixIn:
 
 
 class Structure(Struct, StructureMixIn):
+
     """Override the Structure class from ctypes to add printing and comparison"""
+
     pass
 
 ##====================================================================


### PR DESCRIPTION
This is related to [\[GitHub\]: ctypes.ArgumentError @ click\_input](https://github.com/pywinauto/pywinauto/issues/419) (my comment suggesting extending classes from *wintypes* instead of redefining them).

As a test example, I used the same code from [\[SO\]: ctypes.ArgumentError when using kivy with pywinauto (@CristiFati's answer)](https://stackoverflow.com/questions/55928463/ctypes-argumenterror-when-using-kivy-with-pywinauto/55931295#55931295).

Of course, switching back to *ctypes*, brought everything back. I successfully tested but changes were needed on *kivy*'s side as well. Once this *PR* passes (if it does), I will submit another one to them.