### PR TITLE
issue #706: enumerate container items with FindItemByProperty.

### DIFF
--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -782,5 +782,19 @@ class UIAWrapper(BaseWrapper):
 
         return self
 
+    # -----------------------------------------------------------
+    def _texts_from_item_container(self):
+        """Get texts through the ItemContainer interface"""
+        texts = []
+        try:
+            com_elem = self.iface_item_container.FindItemByProperty(0, 0, uia_defs.vt_empty)
+            while com_elem:
+                itm = UIAWrapper(UIAElementInfo(com_elem))
+                texts.append(itm.texts())
+                com_elem = self.iface_item_container.FindItemByProperty(com_elem, 0, uia_defs.vt_empty)
+        except (uia_defs.NoPatternInterfaceError):
+            pass
+        return texts
+
 
 backend.register('uia', UIAElementInfo, UIAWrapper)

--- a/pywinauto/uia_defines.py
+++ b/pywinauto/uia_defines.py
@@ -218,6 +218,8 @@ scroll_no_amount = IUIA().ui_automation_client.ScrollAmount_NoAmount
 scroll_large_increment = IUIA().ui_automation_client.ScrollAmount_LargeIncrement
 scroll_small_increment = IUIA().ui_automation_client.ScrollAmount_SmallIncrement
 
+vt_empty = IUIA().ui_automation_client.VARIANT.empty.vt
+vt_null = IUIA().ui_automation_client.VARIANT.null.vt
 
 def get_elem_interface(element_info, pattern_name):
     """A helper to retrieve an element interface by the specified pattern name

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -627,10 +627,14 @@ if UIA_support:
             for t in combo_box.texts():
                 self.assertEqual((t in ref_texts), True)
 
-            # Mock a combobox without "ExpandCollapse" pattern
-            combo_box.expand = mock.Mock(side_effect=uia_defs.NoPatternInterfaceError())  # empty texts
-            # workaround works even if no ExpandCollapsePattern available
+            # Mock a combobox without "ItemContainer" pattern
+            combo_box.iface_item_container.FindItemByProperty = mock.Mock(side_effect=uia_defs.NoPatternInterfaceError())
             self.assertEqual(combo_box.texts(), ref_texts)
+
+            # Mock a combobox without "ExpandCollapse" pattern
+            # Expect empty texts
+            combo_box.iface_expand_collapse.Expand = mock.Mock(side_effect=uia_defs.NoPatternInterfaceError())
+            self.assertEqual(combo_box.texts(), [])
 
         def test_combobox_select(self):
             """Test select related methods for the combo box control"""
@@ -1355,14 +1359,14 @@ if UIA_support:
                     msg='Method .expand() for {} combo box must return self, always!'.format(combo_name))
                 self.assertTrue(combo.is_expanded(),
                     msg='{} combo box does NOT keep expanded state!'.format(combo_name))
-                
+
                 # collapse
                 self.assertEqual(combo.collapse(), combo,
                     msg='Method .collapse() for {} combo box must return self'.format(combo_name))
                 if combo != self.combo_simple:
                     self.assertFalse(combo.is_expanded(),
                         msg='{} combo box has not been collapsed!'.format(combo_name))
-                
+
                 # collapse already collapsed should keep collapsed state
                 self.assertEqual(combo.collapse(), combo,
                     msg='Method .collapse() for {} combo box must return self, always!'.format(combo_name))

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -627,6 +627,10 @@ if UIA_support:
             for t in combo_box.texts():
                 self.assertEqual((t in ref_texts), True)
 
+            # Mock a 0 pointer to COM element
+            combo_box.iface_item_container.FindItemByProperty = mock.Mock(return_value=0)
+            self.assertEqual(combo_box.texts(), ref_texts)
+
             # Mock a combobox without "ItemContainer" pattern
             combo_box.iface_item_container.FindItemByProperty = mock.Mock(side_effect=uia_defs.NoPatternInterfaceError())
             self.assertEqual(combo_box.texts(), ref_texts)


### PR DESCRIPTION
Use FindItemByProperty to access virtualized items
in ComboBox and ListView