### PR TITLE
ATSPI bits and pieces

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,6 +57,7 @@ before_script:
   - chmod a+x send_keys_test_app
   - cp send_keys_test_app ../
   - cd $TRAVIS_BUILD_DIR
+  - chmod a+x $TRAVIS_BUILD_DIR/apps/Gtk_samples/gtk_example.py
 
 script:
   - coverage run -a --include=pywinauto/mouse.py pywinauto/unittests/test_mouse.py

--- a/apps/Gtk_samples/gtk_example.py
+++ b/apps/Gtk_samples/gtk_example.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python3
+
 from gi import require_version
 require_version("Gtk", "3.0")
 

--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -2,10 +2,8 @@ from __future__ import print_function
 
 import sys
 import os.path
-import pickle
 import time
 import warnings
-import multiprocessing
 import locale
 import codecs
 
@@ -42,7 +40,6 @@ class AppNotConnected(Exception):
     """Application has not been connected to a process yet"""
 
     pass    # pragma: no cover
-
 
 
 # TODO problem with if active_only: in findwindows to use on linux
@@ -572,7 +569,7 @@ class WindowSpecification(object):
                     if control_type:
                         class_name = None  # no need for class_name if control_type exists
                     else:
-                        control_type = None # if control_type is empty, still use class_name instead
+                        control_type = None  # if control_type is empty, still use class_name instead
                 criteria_texts = []
                 if title:
                     criteria_texts.append(u'title="{}"'.format(title))
@@ -639,7 +636,6 @@ class BaseApplication(object):
     def start(self, cmd_line, timeout=None, retry_interval=None,
               create_new_console=False, wait_for_idle=True, work_dir=None):
         """Start the application as specified by cmd_line"""
-
         raise NotImplementedError()
 
     def cpu_usage(self, interval=None):

--- a/pywinauto/controls/atspiwrapper.py
+++ b/pywinauto/controls/atspiwrapper.py
@@ -64,11 +64,11 @@ class InvalidWindowHandle(RuntimeError):
 class AtspiMeta(BaseMeta):
 
     """Metaclass for AtspiWrapper objects"""
+
     control_type_to_cls = {}
 
     def __init__(cls, name, bases, attrs):
         """Register the control types"""
-
         BaseMeta.__init__(cls, name, bases, attrs)
 
         for t in cls._control_types:

--- a/pywinauto/linux/application.py
+++ b/pywinauto/linux/application.py
@@ -132,6 +132,9 @@ class Application(BaseApplication):
         if self._proc_descriptor is not None:
             # Kill process created via Application with subprocess kill
             self._proc_descriptor.kill()
+            # wait for child process to terminate
+            self._proc_descriptor.communicate()
+            self._proc_descriptor = None
 
         if not self.is_process_running():
             return True # already closed
@@ -152,13 +155,7 @@ class Application(BaseApplication):
         if not str(self.process) in os.listdir('/proc'):
             return False
         else:
-            # Check process zombie state
-            with open('/proc/{}/status'.format(self.process), mode='rb') as fd:
-                content = fd.readlines()
-                for line in content:
-                    if line.decode().lower().startswith("state"):
-                        return "zombie" not in line.decode().lower()
-                return True
+            return True
 
 
 def assert_valid_process(process_id):

--- a/pywinauto/linux/atspi_element_info.py
+++ b/pywinauto/linux/atspi_element_info.py
@@ -39,7 +39,9 @@ from ..element_info import ElementInfo
 
 
 class AtspiElementInfo(ElementInfo):
+
     """Wrapper for window handler"""
+
     atspi_accessible = AtspiAccessible()
 
     def __init__(self, handle=None):
@@ -55,6 +57,7 @@ class AtspiElementInfo(ElementInfo):
             self.__get_elements(el, tree, **kwargs)
 
     def __eq__(self, other):
+        """Check if two AtspiElementInfo objects describe the same element"""
         if self.control_type == "Application":
             return self.process_id == other.process_id
         return self.rectangle == other.rectangle
@@ -118,9 +121,9 @@ class AtspiElementInfo(ElementInfo):
         title = kwargs.get("title", None)
         control_type = kwargs.get("control_type", None)
 
-        len = self.atspi_accessible.get_child_count(self._handle, None)
+        cnt = self.atspi_accessible.get_child_count(self._handle, None)
         childrens = []
-        for i in range(len):
+        for i in range(cnt):
             child = AtspiElementInfo(self.atspi_accessible.get_child_at_index(self._handle, i, None))
             if class_name is not None and class_name != child.class_name:
                 continue

--- a/pywinauto/unittests/test_application_linux.py
+++ b/pywinauto/unittests/test_application_linux.py
@@ -23,10 +23,6 @@ def _test_app():
     return os.path.join(test_folder, app_name)
 
 
-def _test_app_cmd_line():
-    return "python3.4 {}".format(_test_app())
-
-
 sys.path.append(".")
 
 if sys.platform != 'win32':
@@ -61,13 +57,13 @@ if sys.platform != 'win32':
             """test start() works correctly"""
             app = Application()
             self.assertEqual(app.process, None)
-            app.start(_test_app_cmd_line())
+            app.start(_test_app())
             self.assertNotEqual(app.process, None)
             app.kill()
 
         def test_connect_by_pid(self):
             """Create application wia subprocess then connect it to Application"""
-            subprocess_app = subprocess.Popen(['python3.4', _test_app()], stdout=subprocess.PIPE, shell=False)
+            subprocess_app = subprocess.Popen(_test_app().split(), stdout=subprocess.PIPE, shell=False)
             time.sleep(1)
             app = Application()
             app.connect(process=subprocess_app.pid)
@@ -76,30 +72,30 @@ if sys.platform != 'win32':
 
         def test_connect_by_path(self):
             """Create application wia subprocess then connect it to Application by application name"""
-            subprocess_app = subprocess.Popen(['python3.4', _test_app()], stdout=subprocess.PIPE, shell=False)
+            subprocess_app = subprocess.Popen(_test_app().split(), stdout=subprocess.PIPE, shell=False)
             time.sleep(1)
             app = Application()
-            app.connect(path='python3.4 {}'.format(_test_app()))
+            app.connect(path=_test_app())
             self.assertEqual(app.process, subprocess_app.pid)
             app.kill()
 
         def test_get_cpu_usage(self):
             app = Application()
-            app.start(_test_app_cmd_line())
+            app.start(_test_app())
             time.sleep(1)
             self.assertGreater(app.cpu_usage(), 0)
             app.kill()
 
         def test_is_process_running(self):
             app = Application()
-            app.start(_test_app_cmd_line())
+            app.start(_test_app())
             time.sleep(1)
             self.assertTrue(app.is_process_running())
             app.kill()
 
         def test_killed_app_not_running(self):
             app = Application()
-            app.start(_test_app_cmd_line())
+            app.start(_test_app())
             time.sleep(1)
             app.kill()
             time.sleep(1)
@@ -107,14 +103,14 @@ if sys.platform != 'win32':
 
         def test_kill_killed_app(self):
             app = Application()
-            app.start(_test_app_cmd_line())
+            app.start(_test_app())
             time.sleep(1)
             app.kill()
             time.sleep(1)
             self.assertTrue(app.kill())
 
         def test_kill_connected_app(self):
-            subprocess_app = subprocess.Popen(['python3.4', _test_app()], stdout=subprocess.PIPE, shell=False)
+            subprocess_app = subprocess.Popen(_test_app().split(), stdout=subprocess.PIPE, shell=False)
             time.sleep(1)
             app = Application()
             app.connect(process=subprocess_app.pid)

--- a/pywinauto/unittests/test_application_linux.py
+++ b/pywinauto/unittests/test_application_linux.py
@@ -114,7 +114,7 @@ if sys.platform != 'win32':
             app = Application()
             app.connect(process=self.subprocess_app.pid)
             app.kill()
-      
+
             # Unlock the subprocess explicity, otherwise
             # it's presented in /proc as a zombie waiting for
             # the parent process to pickup the return code

--- a/pywinauto/unittests/test_atspi_controls.py
+++ b/pywinauto/unittests/test_atspi_controls.py
@@ -78,7 +78,7 @@ if sys.platform.startswith("linux"):
 
         def setUp(self):
             self.app = Application()
-            self.app.start("python3.4 " + _test_app())
+            self.app.start(_test_app())
             time.sleep(1)
             self.app_window = self.app.gtk_example
             self.button_wrapper = self.app_window.Frame.Panel.Click.wrapper_object()

--- a/pywinauto/unittests/test_atspi_element_info.py
+++ b/pywinauto/unittests/test_atspi_element_info.py
@@ -82,7 +82,7 @@ if sys.platform.startswith("linux"):
         def setUp(self):
             self.desktop_info = AtspiElementInfo()
             self.app = Application()
-            self.app.start("python3.4 " + _test_app())
+            self.app.start(_test_app())
             time.sleep(1)
             self.app_info = self.get_app(app_name)
 

--- a/pywinauto/unittests/test_atspi_wrapper.py
+++ b/pywinauto/unittests/test_atspi_wrapper.py
@@ -78,14 +78,15 @@ if sys.platform.startswith("linux"):
             self.app = Application()
             self.app.start(_test_app())
             time.sleep(1)
-            self.app_wrapper = self.app.gtk_example
+            self.app_wrapper = self.app.gtk_example.wrapper_object()
+            self.app_frame = self.app.gtk_example.Frame
 
         def tearDown(self):
             self.app.kill()
 
         def test_set_window_focus(self):
-            self.app_wrapper.Frame.set_focus()
-            states = self.app_wrapper.Frame.get_states()
+            self.app_frame.set_focus()
+            states = self.app_frame.get_states()
             self.assertIn("STATE_VISIBLE", states)
             self.assertIn("STATE_SHOWING", states)
 
@@ -93,7 +94,7 @@ if sys.platform.startswith("linux"):
             self.assertEqual(self.app_wrapper.top_level_parent().element_info.control_type, "Application")
 
         def test_top_level_parent_for_button_return_app(self):
-            self.assertEqual(self.app_wrapper.Frame.Panel.top_level_parent().element_info.control_type,
+            self.assertEqual(self.app_frame.Panel.top_level_parent().element_info.control_type,
                              "Application")
 
         def test_root_return_desktop(self):
@@ -109,7 +110,7 @@ if sys.platform.startswith("linux"):
             self.assertEqual(self.app_wrapper.control_id(), IATSPI().known_control_types["Application"])
 
         def test_can_get_rectangle(self):
-            rect = self.app_wrapper.Frame.Panel.rectangle()
+            rect = self.app_frame.Panel.rectangle()
             self.assertEqual(rect.width(), 600)
             self.assertEqual(rect.height(), 492)
 
@@ -120,10 +121,10 @@ if sys.platform.startswith("linux"):
             self.assertTrue(self.app_wrapper.is_dialog())
 
         def test_is_dialog_for_button_is_false(self):
-            self.assertFalse(self.app_wrapper.Frame.Panel.Click.is_dialog())
+            self.assertFalse(self.app_frame.Panel.Click.is_dialog())
 
         def test_can_get_children(self):
-            self.assertEqual(self.app_wrapper.Frame.control_id(), IATSPI().known_control_types["Frame"])
+            self.assertEqual(self.app_frame.control_id(), IATSPI().known_control_types["Frame"])
 
         def test_can_get_descendants(self):
             self.assertTrue(len(self.app_wrapper.descendants()) > len(self.app_wrapper.children()))

--- a/pywinauto/unittests/test_atspi_wrapper.py
+++ b/pywinauto/unittests/test_atspi_wrapper.py
@@ -76,7 +76,7 @@ if sys.platform.startswith("linux"):
             self.desktop_info = AtspiElementInfo()
             self.desktop_wrapper = AtspiWrapper(self.desktop_info)
             self.app = Application()
-            self.app.start("python3.4 " + _test_app())
+            self.app.start(_test_app())
             time.sleep(1)
             self.app_wrapper = self.app.gtk_example
 

--- a/pywinauto/windows/application.py
+++ b/pywinauto/windows/application.py
@@ -621,19 +621,6 @@ class Application(BaseApplication):
             is_running = False
         return is_running
 
-    def wait_for_process_exit(self, timeout=None, retry_interval=None):
-        """
-        Waits for process to exit until timeout reaches
-
-        Raises TimeoutError exception if timeout was reached
-        """
-        if timeout is None:
-            timeout = Timings.app_exit_timeout
-        if retry_interval is None:
-            retry_interval = Timings.app_exit_retry
-
-        wait_until(timeout, retry_interval, self.is_process_running, value=False)
-
 
 #=========================================================================
 def assert_valid_process(process_id):


### PR DESCRIPTION
- Better use of wrapper_object() in `AtspiWrapperTests`
- Codacy warnings fixes
- Properly close child process with `Application.kill()`
- Fix `AtspiElementInfoTests` to use system-wide python3
- Remove duplicated `Application.wait_for_process_exit()`
- Use system python3 for running gtk_example.py