### PR TITLE
Fix missing top-level import "WindowNotFoundError".

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -89,7 +89,7 @@ if sys.platform == 'win32':
     from . import findwindows
 
     WindowAmbiguousError = findwindows.WindowAmbiguousError
-    ElementNotFoundError = findwindows.ElementNotFoundError
+    WindowNotFoundError = findwindows.WindowNotFoundError
 
     if UIA_support:
         ElementNotFoundError = findwindows.ElementNotFoundError

--- a/pywinauto/unittests/test_architecture.py
+++ b/pywinauto/unittests/test_architecture.py
@@ -1,0 +1,20 @@
+import unittest
+
+from pywinauto import UIA_support
+
+
+class PublicImportsTests(unittest.TestCase):
+
+    def test_top_level_imports(self):
+        if UIA_support:
+            from pywinauto import ElementNotFoundError, ElementAmbiguousError, WindowNotFoundError, WindowAmbiguousError
+            self.assertEqual(len(set([ElementNotFoundError, ElementAmbiguousError, WindowNotFoundError, WindowAmbiguousError])),
+                             4)
+        else:
+            from pywinauto import WindowNotFoundError, WindowAmbiguousError
+            self.assertEqual(len(set([WindowNotFoundError, WindowAmbiguousError])),
+                             2)
+
+            
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes https://github.com/pywinauto/pywinauto/issues/810

I didn't find a proper place for a quick non-regression test so I added a test file.