### PR TITLE
Add use_magic_lookup boolean attribute to WindowSpecification and others (WIP)

### DIFF
--- a/docs/getting_started.txt
+++ b/docs/getting_started.txt
@@ -343,6 +343,27 @@ from the method output. Say
        |    | child_window(title="Close", control_type="Button")
 
 
+
+How to disable magic attribute names
+------------------------------------
+
+In some cases, you might prefer disable the magic lookup system, so that Pywinauto immediately raises
+if you access an attribute which exists neither on the WindowSpecification object, nor on the underlying
+element-wrapper object.
+Indeed, by default, Pywinauto will add your attribute name to the search system, and will only fail on a subsequent
+attribute access or method call.
+
+In this case, turn off the `allow_magic_lookup` argument of your Desktop or Application instance::
+
+    desktop = Desktop(backend='win32', allow_magic_lookup=False)
+
+or::
+
+    app = Application(allow_magic_lookup=False)
+
+This flag will automatically be propagated to generated WindowSpecification objects.
+
+
 Look at the examples
 --------------------
 

--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -106,14 +106,14 @@ if sys.platform == 'win32':
     class Desktop(object):
         """Simple class to call something like ``Desktop().WindowName.ControlName.method()``"""
 
-        def __init__(self, backend=None, use_magic_lookup=True):
+        def __init__(self, backend=None, allow_magic_lookup=True):
             """Create desktop element description"""
             if not backend:
                 backend = backends.registry.name
             if backend not in backends.registry.backends:
                 raise ValueError('Backend "{0}" is not registered!'.format(backend))
             self.backend = backends.registry.backends[backend]
-            self.use_magic_lookup = use_magic_lookup
+            self.allow_magic_lookup = allow_magic_lookup
 
         def window(self, **kwargs):
             """Create WindowSpecification object for top-level window"""
@@ -122,7 +122,7 @@ if sys.platform == 'win32':
             if 'backend' in kwargs:
                 raise ValueError('Using another backend than set in Desktop constructor is not allowed!')
             kwargs['backend'] = self.backend.name
-            return WindowSpecification(kwargs, use_magic_lookup=self.use_magic_lookup)
+            return WindowSpecification(kwargs, allow_magic_lookup=self.allow_magic_lookup)
 
         def windows(self, **kwargs):
             """Return a list of wrapped top level windows"""
@@ -146,11 +146,11 @@ if sys.platform == 'win32':
 
         def __getattribute__(self, attr_name):
             """Attribute access for this class"""
-            use_magic_lookup = object.__getattribute__(self, "use_magic_lookup")  # Beware of recursions here!
+            allow_magic_lookup = object.__getattribute__(self, "allow_magic_lookup")  # Beware of recursions here!
             try:
                 return object.__getattribute__(self, attr_name)
             except AttributeError:
-                if not use_magic_lookup:
+                if not allow_magic_lookup:
                     raise
                 return self[attr_name]  # delegate it to __get_item__
 

--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -141,12 +141,12 @@ class WindowSpecification(object):
                          'active': ('is_active',),
                          }
 
-    def __init__(self, search_criteria, use_magic_lookup=True):
+    def __init__(self, search_criteria, allow_magic_lookup=True):
         """
         Initialize the class
 
         :param search_criteria: the criteria to match a dialog
-        :param use_magic_lookup: whether attribute access must turn into child_window(best_match=...) search as fallback
+        :param allow_magic_lookup: whether attribute access must turn into child_window(best_match=...) search as fallback
         """
         # kwargs will contain however to find this window
         if 'backend' not in search_criteria:
@@ -159,7 +159,7 @@ class WindowSpecification(object):
         self.criteria = [search_criteria, ]
         self.actions = ActionLogger()
         self.backend = registry.backends[search_criteria['backend']]
-        self.use_magic_lookup = use_magic_lookup
+        self.allow_magic_lookup = allow_magic_lookup
 
         if self.backend.name == 'win32':
             # Non PEP-8 aliases for partial backward compatibility
@@ -279,7 +279,7 @@ class WindowSpecification(object):
         if 'top_level_only' not in criteria:
             criteria['top_level_only'] = False
 
-        new_item = WindowSpecification(self.criteria[0], use_magic_lookup=self.use_magic_lookup)
+        new_item = WindowSpecification(self.criteria[0], allow_magic_lookup=self.allow_magic_lookup)
         new_item.criteria.extend(self.criteria[1:])
         new_item.criteria.append(criteria)
 
@@ -326,7 +326,7 @@ class WindowSpecification(object):
 
         # if we get here then we must have only had one criteria so far
         # so create a new :class:`WindowSpecification` for this control
-        new_item = WindowSpecification(self.criteria[0], use_magic_lookup=self.use_magic_lookup)
+        new_item = WindowSpecification(self.criteria[0], allow_magic_lookup=self.allow_magic_lookup)
 
         # add our new criteria
         new_item.criteria.append({"best_match": key})
@@ -347,8 +347,8 @@ class WindowSpecification(object):
         Otherwise delegate functionality to :func:`__getitem__` - which
         sets the appropriate criteria for the control.
         """
-        use_magic_lookup = object.__getattribute__(self, "use_magic_lookup")  # Beware of recursions here!
-        if not use_magic_lookup:
+        allow_magic_lookup = object.__getattribute__(self, "allow_magic_lookup")  # Beware of recursions here!
+        if not allow_magic_lookup:
             try:
                 return object.__getattribute__(self, attr_name)
             except AttributeError:
@@ -358,7 +358,7 @@ class WindowSpecification(object):
                 except AttributeError:
                     message = (
                         'Attribute "%s" exists neither on %s object nor on'
-                        'targeted %s element wrapper (typo? or set use_magic_lookup to True?)' %
+                        'targeted %s element wrapper (typo? or set allow_magic_lookup to True?)' %
                         (attr_name, self.__class__, wrapper_object.__class__))
                     raise AttributeError(message)
 
@@ -888,7 +888,7 @@ class Application(object):
     .. automethod:: __getitem__
     """
 
-    def __init__(self, backend="win32", datafilename=None, use_magic_lookup=True):
+    def __init__(self, backend="win32", datafilename=None, allow_magic_lookup=True):
         """
         Initialize the Application object
 
@@ -904,7 +904,7 @@ class Application(object):
         if backend not in registry.backends:
             raise ValueError('Backend "{0}" is not registered!'.format(backend))
         self.backend = registry.backends[backend]
-        self.use_magic_lookup = use_magic_lookup
+        self.allow_magic_lookup = allow_magic_lookup
         if self.backend.name == 'win32':
             # Non PEP-8 aliases for partial backward compatibility
             self.Start = deprecated(self.start)
@@ -1162,7 +1162,7 @@ class Application(object):
         else:
             criteria['title'] = windows[0].name
 
-        return WindowSpecification(criteria, use_magic_lookup=self.use_magic_lookup)
+        return WindowSpecification(criteria, allow_magic_lookup=self.allow_magic_lookup)
 
     def active(self):
         """Return WindowSpecification for an active window of the application"""
@@ -1186,7 +1186,7 @@ class Application(object):
         else:
             criteria['title'] = windows[0].name
 
-        return WindowSpecification(criteria, use_magic_lookup=self.use_magic_lookup)
+        return WindowSpecification(criteria, allow_magic_lookup=self.allow_magic_lookup)
 
     def windows(self, **kwargs):
         """Return a list of wrapped top level windows of the application"""
@@ -1228,7 +1228,7 @@ class Application(object):
         else:
             # add the restriction for this particular application
             kwargs['app'] = self
-            win_spec = WindowSpecification(kwargs, use_magic_lookup=self.use_magic_lookup)
+            win_spec = WindowSpecification(kwargs, allow_magic_lookup=self.allow_magic_lookup)
 
         return win_spec
     Window_ = window_ = window
@@ -1239,14 +1239,14 @@ class Application(object):
         return self.window(best_match=key)
 
     def __getattribute__(self, attr_name):
-        use_magic_lookup = object.__getattribute__(self, "use_magic_lookup")  # Beware of recursions here!
-        if not use_magic_lookup:
+        allow_magic_lookup = object.__getattribute__(self, "allow_magic_lookup")  # Beware of recursions here!
+        if not allow_magic_lookup:
             try:
                 return object.__getattribute__(self, attr_name)
             except AttributeError:
                 message = (
                     'Attribute "%s" doesn\'t exist on %s object'
-                    ' (typo? or set use_magic_lookup to True?)' %
+                    ' (typo? or set allow_magic_lookup to True?)' %
                     (attr_name, self.__class__))
                 raise AttributeError(message)
 

--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -493,6 +493,8 @@ def find_best_control_matches(search_text, controls):
     """
     name_control_map = build_unique_dict(controls)
 
+
+    #print ">>>>>>>", repr(name_control_map).decode("ascii", "ignore")
 #    # collect all the possible names for all controls
 #    # and build a list of them
 #    for ctrl in controls:

--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -331,8 +331,9 @@ def get_control_names(control, allcontrols, textcontrols):
         if non_text_names:
             names.extend(non_text_names)
 
-    # return the names - and make sure there are no duplicates
-    return set(names)
+    # return the names - and make sure there are no duplicates or empty values
+    cleaned_names = set(names) - set([None, ""])
+    return cleaned_names
 
 
 #====================================================================

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -771,10 +771,10 @@ class ApplicationTestCases(unittest.TestCase):
 
     def test_non_magic_application(self):
         app = Application()
-        self.assertEqual(app.use_magic_lookup, True)
+        self.assertEqual(app.allow_magic_lookup, True)
 
-        app_no_magic = Application(use_magic_lookup=False)
-        self.assertEqual(app_no_magic.use_magic_lookup, False)
+        app_no_magic = Application(allow_magic_lookup=False)
+        self.assertEqual(app_no_magic.allow_magic_lookup, False)
 
         app_no_magic.start(_notepad_exe())
 
@@ -889,9 +889,9 @@ class WindowSpecificationTestCases(unittest.TestCase):
 
     def test_non_magic_getattr(self):
         ws = WindowSpecification(dict(best_match="Notepad"))
-        self.assertEqual(ws.use_magic_lookup, True)
-        ws_no_magic = WindowSpecification(dict(best_match="Notepad"), use_magic_lookup=False)
-        self.assertEqual(ws_no_magic.use_magic_lookup, False)
+        self.assertEqual(ws.allow_magic_lookup, True)
+        ws_no_magic = WindowSpecification(dict(best_match="Notepad"), allow_magic_lookup=False)
+        self.assertEqual(ws_no_magic.allow_magic_lookup, False)
 
         dlg = ws_no_magic.child_window(best_match="Edit")
         has_focus = dlg.has_keyboard_focus()
@@ -1285,7 +1285,7 @@ if UIA_support:
             Timings.slow()
             self.app = Application().start('explorer.exe "' + mfc_samples_folder_32 + '"')
             self.desktop = Desktop(backend='uia')
-            self.desktop_no_magic = Desktop(backend='uia', use_magic_lookup=False)
+            self.desktop_no_magic = Desktop(backend='uia', allow_magic_lookup=False)
 
         def tearDown(self):
             """Close the application after tests"""
@@ -1332,14 +1332,14 @@ if UIA_support:
         def test_non_magic_desktop(self):
             from pywinauto.controls.uiawrapper import UIAWrapper
 
-            self.assertEqual(self.desktop.use_magic_lookup, True)
-            self.assertEqual(self.desktop_no_magic.use_magic_lookup, False)
+            self.assertEqual(self.desktop.allow_magic_lookup, True)
+            self.assertEqual(self.desktop_no_magic.allow_magic_lookup, False)
 
             dlgs = self.desktop_no_magic.windows()
             self.assertTrue(len(dlgs) > 1)
 
             window = self.desktop_no_magic.window(title="MFC_samples")
-            self.assertEqual(window.use_magic_lookup, False)
+            self.assertEqual(window.allow_magic_lookup, False)
 
             dlg = window.child_window(class_name="ShellTabWindowClass").wrapper_object()
             self.assertIsInstance(dlg, UIAWrapper)
@@ -1363,7 +1363,7 @@ class DesktopWin32WindowSpecificationTests(unittest.TestCase):
         Timings.defaults()
         self.app = Application(backend='win32').start(os.path.join(mfc_samples_folder, u"CmnCtrl3.exe"))
         self.desktop = Desktop(backend='win32')
-        self.desktop_no_magic = Desktop(backend='win32', use_magic_lookup=False)
+        self.desktop_no_magic = Desktop(backend='win32', allow_magic_lookup=False)
         self.window_title = 'Common Controls Sample'
 
     def tearDown(self):
@@ -1423,11 +1423,11 @@ class DesktopWin32WindowSpecificationTests(unittest.TestCase):
         self.assertEqual(dlg, dlg_from_point)
 
     def test_non_magic_desktop(self):
-        self.assertEqual(self.desktop.use_magic_lookup, True)
-        self.assertEqual(self.desktop_no_magic.use_magic_lookup, False)
+        self.assertEqual(self.desktop.allow_magic_lookup, True)
+        self.assertEqual(self.desktop_no_magic.allow_magic_lookup, False)
 
         window = self.desktop_no_magic.window(title=self.window_title, process=self.app.process)
-        self.assertEqual(window.use_magic_lookup, False)
+        self.assertEqual(window.allow_magic_lookup, False)
 
         dlg = window.child_window(class_name="msctls_trackbar32").wrapper_object()
         self.assertIsInstance(dlg, TrackbarWrapper)

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -58,6 +58,7 @@ from pywinauto.application import process_get_modules
 from pywinauto.application import ProcessNotFoundError
 from pywinauto.application import AppStartError
 from pywinauto.application import AppNotConnected
+from pywinauto.controls.common_controls import TrackbarWrapper
 from pywinauto import findwindows
 from pywinauto import findbestmatch
 from pywinauto.timings import Timings
@@ -767,6 +768,26 @@ class ApplicationTestCases(unittest.TestCase):
         app = ApplicationTestCases.TestInheritedApp()
         self.assertTrue(app.test_method())
 
+    def test_non_magic_application(self):
+        app = Application()
+        self.assertEqual(app.use_magic_lookup, True)
+
+        app_no_magic = Application(use_magic_lookup=False)
+        self.assertEqual(app_no_magic.use_magic_lookup, False)
+
+        app_no_magic.start(_notepad_exe())
+
+        window = app_no_magic.window(best_match="UntitledNotepad")
+
+        dlg = window.child_window(best_match="Edit")
+        dlg.draw_outline()
+
+        with self.assertRaises(AttributeError):
+            app_no_magic.UntitledNotepad
+
+        with self.assertRaises(AttributeError):
+            window.Edit
+
 
 class WindowSpecificationTestCases(unittest.TestCase):
 
@@ -862,6 +883,20 @@ class WindowSpecificationTestCases(unittest.TestCase):
         # Check handling 'parent' as a WindowSpecification
         spec = self.ctrlspec.child_window(parent=self.dlgspec)
         self.assertEqual(spec.class_name(), "Edit")
+
+    def test_non_magic_getattr(self):
+        ws = WindowSpecification(dict(best_match="Notepad"))
+        self.assertEqual(ws.use_magic_lookup, True)
+        ws_no_magic = WindowSpecification(dict(best_match="Notepad"), use_magic_lookup=False)
+        self.assertEqual(ws_no_magic.use_magic_lookup, False)
+
+        dlg = ws_no_magic.child_window(best_match="Edit")
+        has_focus = dlg.has_keyboard_focus()
+        self.assertIn(has_focus, (True, False))
+
+        with self.assertRaises(AttributeError):
+            ws_no_magic.Edit
+
 
     def test_exists(self):
         """Check that windows exist"""
@@ -1247,10 +1282,11 @@ if UIA_support:
             Timings.slow()
             self.app = Application().start('explorer.exe "' + mfc_samples_folder_32 + '"')
             self.desktop = Desktop(backend='uia')
+            self.desktop_no_magic = Desktop(backend='uia', use_magic_lookup=False)
 
         def tearDown(self):
             """Close the application after tests"""
-            self.desktop.MFC_samplesDialog.CloseButton.click()
+            self.desktop.MFC_samplesDialog.close()
             self.desktop.MFC_samplesDialog.wait_not('visible')
 
         def test_folder_list(self):
@@ -1290,6 +1326,30 @@ if UIA_support:
             dlgs = self.desktop.windows(enabled_only=True)
             self.assertTrue(all([win.is_enabled() for win in dlgs]))
 
+        def test_non_magic_desktop(self):
+            from pywinauto.controls.uiawrapper import UIAWrapper
+
+            self.assertEqual(self.desktop.use_magic_lookup, True)
+            self.assertEqual(self.desktop_no_magic.use_magic_lookup, False)
+
+            dlgs = self.desktop_no_magic.windows()
+            self.assertTrue(len(dlgs) > 1)
+
+            window = self.desktop_no_magic.window(title="MFC_samples")
+            self.assertEqual(window.use_magic_lookup, False)
+
+            dlg = window.child_window(class_name="ShellTabWindowClass").wrapper_object()
+            self.assertIsInstance(dlg, UIAWrapper)
+
+            has_focus = dlg.has_keyboard_focus()
+            self.assertIn(has_focus, (True, False))
+
+            with self.assertRaises(AttributeError):
+                self.desktop_no_magic.MFC_samples
+
+            with self.assertRaises(AttributeError):
+                window.ShellTabWindowClass
+
 
 class DesktopWin32WindowSpecificationTests(unittest.TestCase):
 
@@ -1300,6 +1360,7 @@ class DesktopWin32WindowSpecificationTests(unittest.TestCase):
         Timings.defaults()
         self.app = Application(backend='win32').start(os.path.join(mfc_samples_folder, u"CmnCtrl3.exe"))
         self.desktop = Desktop(backend='win32')
+        self.desktop_no_magic = Desktop(backend='win32', use_magic_lookup=False)
         self.window_title = 'Common Controls Sample'
 
     def tearDown(self):
@@ -1357,6 +1418,25 @@ class DesktopWin32WindowSpecificationTests(unittest.TestCase):
         x, y = combo.rectangle().mid_point()
         dlg_from_point = self.desktop.top_from_point(x, y)
         self.assertEqual(dlg, dlg_from_point)
+
+    def test_non_magic_desktop(self):
+        self.assertEqual(self.desktop.use_magic_lookup, True)
+        self.assertEqual(self.desktop_no_magic.use_magic_lookup, False)
+
+        window = self.desktop_no_magic.window(title=self.window_title, process=self.app.process)
+        self.assertEqual(window.use_magic_lookup, False)
+
+        dlg = window.child_window(class_name="msctls_trackbar32").wrapper_object()
+        self.assertIsInstance(dlg, TrackbarWrapper)
+
+        pos = dlg.get_position()
+        self.assertIsInstance(pos, int)
+
+        with self.assertRaises(AttributeError):
+            getattr(self.desktop_no_magic, self.window_title.replace(" ", "_"))
+
+        with self.assertRaises(AttributeError):
+            window.msctls_trackbar32
 
 
 if __name__ == "__main__":

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -45,6 +45,7 @@ import warnings
 from threading import Thread
 import ctypes
 import mock
+import six
 
 sys.path.append(".")
 from pywinauto import Desktop
@@ -788,6 +789,8 @@ class ApplicationTestCases(unittest.TestCase):
         with self.assertRaises(AttributeError):
             window.Edit
 
+        app_no_magic.kill()
+        app_no_magic.wait_for_process_exit()
 
 class WindowSpecificationTestCases(unittest.TestCase):
 
@@ -1287,7 +1290,7 @@ if UIA_support:
         def tearDown(self):
             """Close the application after tests"""
             self.desktop.MFC_samplesDialog.close()
-            self.desktop.MFC_samplesDialog.wait_not('visible')
+            self.desktop.MFC_samplesDialog.wait_not('exists')
 
         def test_folder_list(self):
             """Test that ListViewWrapper returns correct files list in explorer.exe"""
@@ -1430,7 +1433,7 @@ class DesktopWin32WindowSpecificationTests(unittest.TestCase):
         self.assertIsInstance(dlg, TrackbarWrapper)
 
         pos = dlg.get_position()
-        self.assertIsInstance(pos, int)
+        self.assertIsInstance(pos, six.integer_types)
 
         with self.assertRaises(AttributeError):
             getattr(self.desktop_no_magic, self.window_title.replace(" ", "_"))


### PR DESCRIPTION
This would allow disabling magic getattr() lookup of child widgets, which in some applications (with lots of similar elements) is more confusing than handy.