### PR TITLE
Stop using UIA_support to alter top level imports

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -90,10 +90,8 @@ if sys.platform == 'win32':
 
     WindowAmbiguousError = findwindows.WindowAmbiguousError
     WindowNotFoundError = findwindows.WindowNotFoundError
-
-    if UIA_support:
-        ElementNotFoundError = findwindows.ElementNotFoundError
-        ElementAmbiguousError = findwindows.ElementAmbiguousError
+    ElementNotFoundError = findwindows.ElementNotFoundError
+    ElementAmbiguousError = findwindows.ElementAmbiguousError
 
     from . import findbestmatch
     from . import backend as backends

--- a/pywinauto/unittests/test_architecture.py
+++ b/pywinauto/unittests/test_architecture.py
@@ -1,19 +1,12 @@
 import unittest
 
-from pywinauto import UIA_support
-
 
 class PublicImportsTests(unittest.TestCase):
 
     def test_top_level_imports(self):
-        if UIA_support:
-            from pywinauto import ElementNotFoundError, ElementAmbiguousError, WindowNotFoundError, WindowAmbiguousError
-            self.assertEqual(len(set([ElementNotFoundError, ElementAmbiguousError, WindowNotFoundError, WindowAmbiguousError])),
-                             4)
-        else:
-            from pywinauto import WindowNotFoundError, WindowAmbiguousError
-            self.assertEqual(len(set([WindowNotFoundError, WindowAmbiguousError])),
-                             2)
+        from pywinauto import ElementNotFoundError, ElementAmbiguousError, WindowNotFoundError, WindowAmbiguousError
+        self.assertEqual(len(set([ElementNotFoundError, ElementAmbiguousError, WindowNotFoundError, WindowAmbiguousError])),
+                         4)
 
             
 if __name__ == "__main__":


### PR DESCRIPTION
As a follow up to https://github.com/pywinauto/pywinauto/pull/811, since changing top-level imports depending on UIA_support doesn't seem needed here.