### PR TITLE
Converted ActionLogger().log commands from print style to string concat

### DIFF
--- a/pywinauto/remote_memory_block.py
+++ b/pywinauto/remote_memory_block.py
@@ -205,9 +205,9 @@ class RemoteMemoryBlock(object):
         )
 
         if ret == 0:
-            ActionLogger().log('Error: Write failed: address = ', address)
+            ActionLogger().log('Error: Write failed: address = ' + str(address))
             last_error = win32api.GetLastError()
-            ActionLogger().log('Error: LastError = ', last_error, ': ',
+            ActionLogger().log('Error: LastError = ' + str(last_error) + ': ' +
                                win32api.FormatMessage(last_error).rstrip())
             raise WinError()
         self.CheckGuardSignature()


### PR DESCRIPTION
Fixed Action logging in print style by swapping to strings as described in issue #798 