### PR TITLE
Fix ctypes.windll usage conflicts with other libraries

### DIFF
--- a/docs/HISTORY.txt
+++ b/docs/HISTORY.txt
@@ -2,6 +2,26 @@
 Change Log
 ==========
 
+0.6.8 Bug Fixes
+--------------------------------------------------------------------
+TODO: Cooming soon...
+
+Enhancements:
+ * Add ``allow_magic_lookup`` flag for Application and Desktop object. Thanks pakal_!
+ * Don't duplicate already pressed key in internal list in ``win32_hooks.py``. Thanks TomRobo237_!
+
+Bug Fixes:
+ * Fix ctypes.windll usage conflicts with other libraries.
+ * Minor fixes in top-level ``__init__.py``. Thanks pakal_!
+ * Fix logging issues in ``remote_memory_block.py``. Thanks TomRobo237_!
+ * Minor docs improvements. Thanks olesteban_ and caoyaxing221_!
+
+ .. _pakal: https://github.com/pakal
+ .. _TomRobo237: https://github.com/TomRobo237
+ .. _olesteban: https://github.com/olesteban
+ .. _caoyaxing221: https://github.com/caoyaxing221
+
+
 0.6.7 Bug Fixes
 --------------------------------------------------------------------
 07-July-2019

--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -32,7 +32,7 @@
 
 """Python package for automating GUI manipulation on Windows"""
 
-__version__ = "0.6.7"
+__version__ = "0.6.8"
 
 import sys  # noqa: E402
 import warnings  # noqa: E402

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -507,10 +507,10 @@ class HwndWrapper(BaseWrapper):
             if unicode_char:
                 _, char = key_info[:2]
                 vk = win32functions.VkKeyScanExW(chr(char), input_locale_id) & 0xFF
-                scan = keyboard.MapVirtualKey(vk, 0)
+                scan = win32functions.MapVirtualKeyW(vk, 0)
             else:
                 vk, scan = key_info[:2]
-                char = keyboard.MapVirtualKey(vk, 2)
+                char = win32functions.MapVirtualKeyW(vk, 2)
 
             if char > 0:
                 lparam = 1 << 0 | scan << 16 | (flags & 1) << 24
@@ -581,7 +581,7 @@ class HwndWrapper(BaseWrapper):
                     vk_with_flags = win32functions.VkKeyScanExW(char, input_locale_id)
                     vk = vk_with_flags & 0xFF
                     shift_state = (vk_with_flags & 0xFF00) >> 8
-                    scan = keyboard.MapVirtualKey(vk, 0)
+                    scan = win32functions.MapVirtualKeyW(vk, 0)
 
                 if key.down and vk > 0:
                     new_keyboard_state = copy.deepcopy(keyboard_state_stack[-1])

--- a/pywinauto/keyboard.py
+++ b/pywinauto/keyboard.py
@@ -123,13 +123,6 @@ else:
 
     DEBUG = 0
 
-    GetMessageExtraInfo = ctypes.windll.user32.GetMessageExtraInfo
-    MapVirtualKey = ctypes.windll.user32.MapVirtualKeyW
-
-    VkKeyScan = ctypes.windll.user32.VkKeyScanW
-    VkKeyScan.restype = ctypes.c_short
-    VkKeyScan.argtypes = [ctypes.c_wchar]
-
     INPUT_KEYBOARD = 1
     KEYEVENTF_EXTENDEDKEY = 1
     KEYEVENTF_KEYUP = 2
@@ -367,7 +360,7 @@ else:
 
                 # it seems to return 0 every time but it's required by MSDN specification
                 # so call it just in case
-                inp.ki.dwExtraInfo = GetMessageExtraInfo()
+                inp.ki.dwExtraInfo = win32functions.GetMessageExtraInfo()
 
             # if we are releasing - then let it up
             if self.up:
@@ -446,7 +439,7 @@ else:
             # return self.key, 0, 0
 
             # this works for Tic Tac Toe i.e. +{RIGHT} SHIFT + RIGHT
-            return self.key, MapVirtualKey(self.key, 0), flags
+            return self.key, win32functions.MapVirtualKeyW(self.key, 0), flags
 
         def run(self):
             """Execute the action"""
@@ -467,9 +460,9 @@ else:
 
             The vk and scan code are generated differently.
             """
-            vkey_scan = LoByte(VkKeyScan(self.key))
+            vkey_scan = LoByte(win32functions.VkKeyScanW(self.key))
 
-            return (vkey_scan, MapVirtualKey(vkey_scan, 0), 0)
+            return (vkey_scan, win32functions.MapVirtualKeyW(vkey_scan, 0), 0)
 
         def key_description(self):
             """Return a description of the key"""

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -45,6 +45,10 @@ from ctypes import POINTER
 from ctypes import c_ubyte
 from ctypes import c_size_t
 
+# Quote: "If you want cached libs without polluting ctypes.cdll or
+# ctypes.windll, just create your own instance such as
+# windll = ctypes.LibraryLoader(ctypes.WinDLL)."
+# see https://bugs.python.org/issue22552
 windll = LibraryLoader(WinDLL)
 
 SHORT = c_short

--- a/pywinauto/win32functions.py
+++ b/pywinauto/win32functions.py
@@ -31,7 +31,8 @@
 
 """Defines Windows(tm) functions"""
 
-from ctypes import windll
+from ctypes import LibraryLoader
+from ctypes import WinDLL
 from ctypes import wintypes
 from . import win32defines, win32structures
 from .actionlogger import ActionLogger
@@ -44,6 +45,7 @@ from ctypes import POINTER
 from ctypes import c_ubyte
 from ctypes import c_size_t
 
+windll = LibraryLoader(WinDLL)
 
 SHORT = c_short
 
@@ -206,12 +208,19 @@ GetKeyboardLayout.restype = wintypes.HKL
 GetKeyboardLayout.argtypes = [
     wintypes.DWORD,
 ]
+VkKeyScanW = windll.user32.VkKeyScanW
+VkKeyScanW.restype = SHORT
+VkKeyScanW.argtypes = [
+    wintypes.WCHAR,
+]
 VkKeyScanExW = windll.user32.VkKeyScanExW
 VkKeyScanExW.restype = SHORT
 VkKeyScanExW.argtypes = [
     wintypes.WCHAR,
     wintypes.HKL,
 ]
+GetMessageExtraInfo = windll.user32.GetMessageExtraInfo
+MapVirtualKeyW = windll.user32.MapVirtualKeyW
 # menu functions
 DrawMenuBar = windll.user32.DrawMenuBar
 DrawMenuBar.restype = wintypes.BOOL
@@ -730,21 +739,12 @@ GetQueueStatus = windll.user32.GetQueueStatus
 LoadString = windll.user32.LoadStringW
 
 
-#def VkKeyScanW(p1):
-#    # C:/PROGRA~1/MICROS~4/VC98/Include/winuser.h 4225
-#    return VkKeyScanW._api_(p1)
-#VkKeyScan = stdcall(SHORT, 'user32', [c_wchar]) (VkKeyScanW)
-#
 #def MapVirtualKeyExW(p1, p2, p3):
 #    # C:/PROGRA~1/MICROS~4/VC98/Include/winuser.h 4376
 #    return MapVirtualKeyExW._api_(p1, p2, p3)
 #MapVirtualKeyEx = stdcall(
 #    UINT, 'user32', [c_uint, c_uint, c_long]) (MapVirtualKeyExW)
 #
-#def MapVirtualKeyW(p1, p2):
-#    # C:/PROGRA~1/MICROS~4/VC98/Include/winuser.h 4355
-#    return MapVirtualKeyW._api_(p1, p2)
-#MapVirtualKey = stdcall(UINT, 'user32', [c_uint, c_uint]) (MapVirtualKeyW)
 
 
 #====================================================================

--- a/setup.py
+++ b/setup.py
@@ -69,7 +69,7 @@ else:
     packages = ["pywinauto", "pywinauto.linux"]
 
 setup(name='pywinauto',
-    version = '0.6.7',
+    version = '0.6.8',
     description = 'A set of Python modules to automate the Microsoft Windows GUI',
     keywords = "windows gui automation GuiAuto testing test desktop mouse keyboard",
     url = "http://pywinauto.github.io/",


### PR DESCRIPTION
 * `windll = LibraryLoader(WinDLL)` isolates cached Win32 libraries for pywinauto usage only. Other library may pollute `ctypes.windll` without affecting any pywinauto code.
 * All Win32 function definitions have been moved from `keyboard.py` to `win32functions.py`.
 * Function names use explicit Unicode suffix `W` like `MapVirtualKeyW` instead of `MapVirtualKey`.
 * Add recent changes to 0.6.8 release notes.