### PR TITLE
Update url for pywin32 releases.

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -33,7 +33,7 @@ Manual installation
 - Unpack and run ``python setup.py install``
 
 
-.. _pyWin32: http://sourceforge.net/projects/pywin32/files/pywin32/Build%20220/
+.. _pyWin32: https://github.com/mhammond/pywin32/releases
 .. _comtypes: https://github.com/enthought/comtypes/releases
 .. _six: https://pypi.python.org/pypi/six
 .. _Pillow: https://pypi.python.org/pypi/Pillow/2.7.0


### PR DESCRIPTION
The last release available at SourceForge is 222, but current latest release is 225.

As for https://sourceforge.net/projects/pywin32/files/ new releases can only be found at GitHub.