### PR TITLE
issue #873: re-work the Application documentation

### DIFF
--- a/docs/code/code.txt
+++ b/docs/code/code.txt
@@ -12,7 +12,9 @@ Main User Modules
 .. toctree::
    :maxdepth: 1
    
-   pywinauto.application.txt
+   pywinauto.base_application.txt
+   pywinauto.windows.application.txt
+   pywinauto.linux.application.txt
    pywinauto.findbestmatch.txt
    pywinauto.findwindows.txt
    pywinauto.timings.txt

--- a/docs/code/code.txt
+++ b/docs/code/code.txt
@@ -18,6 +18,7 @@ Main User Modules
    pywinauto.findbestmatch.txt
    pywinauto.findwindows.txt
    pywinauto.timings.txt
+   pywinauto.txt
 
 Specific Functionality
 ======================

--- a/docs/code/pywinauto.application.txt
+++ b/docs/code/pywinauto.application.txt
@@ -1,8 +1,0 @@
-pywinauto.application module
-----------------------------
-
-.. automodule:: pywinauto.application
-    :members:
-    :exclude-members: Kill_, kill_, Window_, window_
-    :undoc-members:
-    :show-inheritance:

--- a/docs/code/pywinauto.base_application.txt
+++ b/docs/code/pywinauto.base_application.txt
@@ -1,0 +1,8 @@
+pywinauto.application module
+---------------------------------
+
+.. automodule:: pywinauto.base_application
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/code/pywinauto.linux.application.txt
+++ b/docs/code/pywinauto.linux.application.txt
@@ -1,0 +1,8 @@
+pywinauto.linux.application
+----------------------------------
+
+.. automodule:: pywinauto.linux.application
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/code/pywinauto.txt
+++ b/docs/code/pywinauto.txt
@@ -1,0 +1,7 @@
+pywinauto
+-----------------------------
+ .. automodule:: pywinauto
+    :members:
+    :undoc-members:
+    :show-inheritance:
+

--- a/docs/code/pywinauto.windows.application.txt
+++ b/docs/code/pywinauto.windows.application.txt
@@ -1,0 +1,9 @@
+pywinauto.windows.application
+------------------------------------
+
+.. automodule:: pywinauto.windows.application
+    :members:
+    :exclude-members: Kill_, kill_, Window_, window_
+    :undoc-members:
+    :show-inheritance:
+

--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -84,76 +84,76 @@ if sys.platform == 'win32':
 
 
     sys.coinit_flags = _get_com_threading_mode(sys)
-    from .sysinfo import UIA_support
-
-    from . import findwindows
-
-    WindowAmbiguousError = findwindows.WindowAmbiguousError
-    WindowNotFoundError = findwindows.WindowNotFoundError
-    ElementNotFoundError = findwindows.ElementNotFoundError
-    ElementAmbiguousError = findwindows.ElementAmbiguousError
-
-    from . import findbestmatch
-    from . import backend as backends
-
-    MatchError = findbestmatch.MatchError
-
-    from pywinauto.application import Application, WindowSpecification
 
 
-    class Desktop(object):
-        """Simple class to call something like ``Desktop().WindowName.ControlName.method()``"""
+from . import findwindows
 
-        def __init__(self, backend=None, allow_magic_lookup=True):
-            """Create desktop element description"""
-            if not backend:
-                backend = backends.registry.name
-            if backend not in backends.registry.backends:
-                raise ValueError('Backend "{0}" is not registered!'.format(backend))
-            self.backend = backends.registry.backends[backend]
-            self.allow_magic_lookup = allow_magic_lookup
+WindowAmbiguousError = findwindows.WindowAmbiguousError
+WindowNotFoundError = findwindows.WindowNotFoundError
+ElementNotFoundError = findwindows.ElementNotFoundError
+ElementAmbiguousError = findwindows.ElementAmbiguousError
 
-        def window(self, **kwargs):
-            """Create WindowSpecification object for top-level window"""
-            if 'top_level_only' not in kwargs:
-                kwargs['top_level_only'] = True
-            if 'backend' in kwargs:
-                raise ValueError('Using another backend than set in Desktop constructor is not allowed!')
-            kwargs['backend'] = self.backend.name
-            return WindowSpecification(kwargs, allow_magic_lookup=self.allow_magic_lookup)
+from . import findbestmatch
+from . import backend as backends
 
-        def windows(self, **kwargs):
-            """Return a list of wrapped top level windows"""
-            if 'top_level_only' not in kwargs:
-                kwargs['top_level_only'] = True
-            if 'backend' in kwargs:
-                raise ValueError('Using another backend than set in Desktop constructor is not allowed!!')
+MatchError = findbestmatch.MatchError
 
-            kwargs['backend'] = self.backend.name
+from pywinauto.application import Application, WindowSpecification
 
-            windows = findwindows.find_elements(**kwargs)
-            return [self.backend.generic_wrapper_class(win) for win in windows]
 
-        def __getitem__(self, key):
-            """Allow describe top-level window as Desktop()['Window Caption']"""
-            return self.window(best_match=key)
+class Desktop(object):
+    """Simple class to call something like ``Desktop().WindowName.ControlName.method()``"""
 
-        def __getattribute__(self, attr_name):
-            """Attribute access for this class"""
-            allow_magic_lookup = object.__getattribute__(self, "allow_magic_lookup")  # Beware of recursions here!
-            try:
-                return object.__getattribute__(self, attr_name)
-            except AttributeError:
-                if not allow_magic_lookup:
-                    raise
-                return self[attr_name]  # delegate it to __get_item__
+    def __init__(self, backend=None, allow_magic_lookup=True):
+        """Create desktop element description"""
+        if not backend:
+            backend = backends.registry.name
+        if backend not in backends.registry.backends:
+            raise ValueError('Backend "{0}" is not registered!'.format(backend))
+        self.backend = backends.registry.backends[backend]
+        self.allow_magic_lookup = allow_magic_lookup
 
-        def from_point(self, x, y):
-            """Get wrapper object for element at specified screen coordinates (x, y)"""
-            element_info = self.backend.element_info_class.from_point(x, y)
-            return self.backend.generic_wrapper_class(element_info)
+    def window(self, **kwargs):
+        """Create WindowSpecification object for top-level window"""
+        if 'top_level_only' not in kwargs:
+            kwargs['top_level_only'] = True
+        if 'backend' in kwargs:
+            raise ValueError('Using another backend than set in Desktop constructor is not allowed!')
+        kwargs['backend'] = self.backend.name
+        return WindowSpecification(kwargs, allow_magic_lookup=self.allow_magic_lookup)
 
-        def top_from_point(self, x, y):
-            """Get wrapper object for top level element at specified screen coordinates (x, y)"""
-            top_element_info = self.backend.element_info_class.top_from_point(x, y)
-            return self.backend.generic_wrapper_class(top_element_info)
+    def windows(self, **kwargs):
+        """Return a list of wrapped top level windows"""
+        if 'top_level_only' not in kwargs:
+            kwargs['top_level_only'] = True
+        if 'backend' in kwargs:
+            raise ValueError('Using another backend than set in Desktop constructor is not allowed!!')
+
+        kwargs['backend'] = self.backend.name
+
+        windows = findwindows.find_elements(**kwargs)
+        return [self.backend.generic_wrapper_class(win) for win in windows]
+
+    def __getitem__(self, key):
+        """Allow describe top-level window as Desktop()['Window Caption']"""
+        return self.window(best_match=key)
+
+    def __getattribute__(self, attr_name):
+        """Attribute access for this class"""
+        allow_magic_lookup = object.__getattribute__(self, "allow_magic_lookup")  # Beware of recursions here!
+        try:
+            return object.__getattribute__(self, attr_name)
+        except AttributeError:
+            if not allow_magic_lookup:
+                raise
+            return self[attr_name]  # delegate it to __get_item__
+
+    def from_point(self, x, y):
+        """Get wrapper object for element at specified screen coordinates (x, y)"""
+        element_info = self.backend.element_info_class.from_point(x, y)
+        return self.backend.generic_wrapper_class(element_info)
+
+    def top_from_point(self, x, y):
+        """Get wrapper object for top level element at specified screen coordinates (x, y)"""
+        top_element_info = self.backend.element_info_class.top_from_point(x, y)
+        return self.backend.generic_wrapper_class(top_element_info)

--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -1,3 +1,80 @@
+# GUI Application automation and testing library
+# Copyright (C) 2006-2020 Mark Mc Mahon and Contributors
+# https://github.com/pywinauto/pywinauto/graphs/contributors
+# http://pywinauto.readthedocs.io/en/latest/credits.html
+# All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+#
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+#
+# * Neither the name of pywinauto nor the names of its
+#   contributors may be used to endorse or promote products derived from
+#   this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+# DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+# FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+# DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+# CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+# OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+"""pywinauto.base_application module
+------------------------------------
+
+The application module is the main one that users will use first.
+
+When starting to automate an application you must initialize an instance
+of the Application class. Then you have to start the program with
+:meth:`Application.start<pywinauto.base_application.BaseApplication.start>`
+or connect to a runing process of an application with:
+:meth:`Application.connect<pywinauto.base_application.BaseApplication.connect>`
+
+Once you have an Application instance you can access dialogs in that
+application by using one of the methods below. ::
+
+   dlg = app.YourDialogTitle
+   dlg = app.child_window(name="your title", classname="your class", ...)
+   dlg = app['Your Dialog Title']
+
+Similarly once you have a dialog you can get a control from that dialog
+in almost exactly the same ways. ::
+
+   ctrl = dlg.YourControlTitle
+   ctrl = dlg.child_window(name="Your control", classname="Button", ...)
+   ctrl = dlg["Your control"]
+
+.. note::
+
+   For attribute access of controls and dialogs you do not have to
+   specify the exact name/title/text of the control. Pywinauto automatically
+   performs a best match of the available dialogs or controls.
+
+   With introducing the cross-platform support in pywinauto,
+   the Application class is automatically created with the platform
+   default backend. For MS Windows OS it is 'win32' and for Linux OS it is 'atspi'.
+
+.. seealso::
+
+   :func:`pywinauto.findwindows.find_elements` for the keyword arguments that
+   can be passed to both:
+   :meth:`WindowSpecification.child_window<pywinauto.base_application.WindowSpecification.child_window>` and
+   :meth:`WindowSpecification.window<pywinauto.base_application.WindowSpecification.window>`
+
+   :class:`pywinauto.windows.application.Application` for the 'win32' and 'uia' backends
+
+   :class:`pywinauto.linux.application.Application` for the 'atspi' backend
+"""
 from __future__ import print_function
 
 import sys
@@ -653,7 +730,15 @@ class BaseApplication(object):
 
     def start(self, cmd_line, timeout=None, retry_interval=None,
               create_new_console=False, wait_for_idle=True, work_dir=None):
-        """Start the application as specified by cmd_line"""
+        """Start the application as specified by **cmd_line**
+
+        :param cmd_line: a string with a path to launch the target
+        :param timeout: a timeout for process to start (optional)
+        :param retry_interval: retry interval (optional)
+        :param create_new_console: create a new console (optional)
+        :param wait_for_idle: wait for idle (optional)
+        :param work_dir: working directory (optional)
+        """
         raise NotImplementedError()
 
     def cpu_usage(self, interval=None):

--- a/pywinauto/linux/application.py
+++ b/pywinauto/linux/application.py
@@ -30,7 +30,7 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""Linux Application class"""
+"""Implementation of Application class for Linux platform."""
 
 import os.path
 import time
@@ -65,6 +65,7 @@ class Application(BaseApplication):
 
     def start(self, cmd_line, timeout=None, retry_interval=None,
               create_new_console=False, wait_for_idle=True, work_dir=None):
+        """Start the application as specified by cmd_line"""
         command_line = shlex.split(cmd_line)
         try:
             process = subprocess.Popen(command_line, shell=create_new_console)

--- a/pywinauto/linux/atspi_element_info.py
+++ b/pywinauto/linux/atspi_element_info.py
@@ -69,6 +69,11 @@ class AtspiElementInfo(ElementInfo):
         else:
             self._handle = handle
 
+        # Cache non-mutable element IDs
+        self._pid = self.atspi_accessible.get_process_id(self._handle, None)
+        self._root_id = self.atspi_accessible.get_id(self._handle, None)
+        self._runtime_id = self.atspi_accessible.get_index_in_parent(self._handle, None)
+
     def __get_elements(self, root, tree, **kwargs):
         tree.append(root)
         for el in root.children(**kwargs):
@@ -76,7 +81,7 @@ class AtspiElementInfo(ElementInfo):
 
     def __hash__(self):
         """Return a unique hash value based on the element's handle"""
-        return hash(self.handle)
+        return hash((self._pid, self._root_id, self._runtime_id))
 
     def __eq__(self, other):
         """Check if two AtspiElementInfo objects describe the same element"""
@@ -116,12 +121,12 @@ class AtspiElementInfo(ElementInfo):
     @property
     def runtime_id(self):
         """Return the runtime ID of the element"""
-        return self.atspi_accessible.get_index_in_parent(self._handle, None)
+        return self._runtime_id
 
     @property
     def process_id(self):
         """Return the ID of process that controls this window"""
-        return self.atspi_accessible.get_process_id(self._handle, None)
+        return self._pid
 
     pid = process_id
 

--- a/pywinauto/unittests/test_atspi_element_info.py
+++ b/pywinauto/unittests/test_atspi_element_info.py
@@ -113,7 +113,7 @@ if sys.platform.startswith("linux"):
             r0.bottom = 5
             self.assertEqual(r0, RECT(1, 2, 3, 5))
             self.assertEqual(r0, (1, 2, 3, 5))
-    
+
         def test_RECT_repr(self):
             """Test RECT repr"""
             r0 = RECT(0)
@@ -130,7 +130,7 @@ if sys.platform.startswith("linux"):
                 pid = self.app.process
             for child in self.desktop_info.children():
                 if child.name == name and pid == child.process_id:
-                        return child
+                    return child
             raise Exception("Application not found")
 
         def setUp(self):
@@ -254,7 +254,7 @@ if sys.platform.startswith("linux"):
             self.app2 = Application().start(_test_app())
             time.sleep(1)
             app_info2 = self.get_app(app_name, pid=self.app2.process)
-            
+
             frame_info1 = self.app_info.children()[0]
             frame_info2 = app_info2.children()[0]
             d = { frame_info1 : 1, frame_info2 : 2, }

--- a/pywinauto/windows/application.py
+++ b/pywinauto/windows/application.py
@@ -29,39 +29,8 @@
 # OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"""The application module is the main one that users will use first.
+"""Implementation of Application class for MS Windows platform."""
 
-When starting to automate an application you must initialize an instance
-of the Application class. Then you must :func:`Application.start` that
-application or :func:`Application.connect()` to a running instance of that
-application.
-
-Once you have an Application instance you can access dialogs in that
-application either by using one of the methods below. ::
-
-   dlg = app.YourDialogTitle
-   dlg = app.child_window(name="your title", classname="your class", ...)
-   dlg = app['Your Dialog Title']
-
-Similarly once you have a dialog you can get a control from that dialog
-in almost exactly the same ways. ::
-
-  ctrl = dlg.YourControlTitle
-  ctrl = dlg.child_window(name="Your control", classname="Button", ...)
-  ctrl = dlg["Your control"]
-
-.. note::
-
-   For attribute access of controls and dialogs you do not have to
-   have the name/title/text of the control exactly, it does a best match
-   of the available dialogs or controls.
-
-.. seealso::
-
-   :func:`pywinauto.findwindows.find_elements` for the keyword arguments that
-   can be passed to both: :func:`Application.window` and
-   :func:`WindowSpecification.child_window`
-"""
 from __future__ import print_function
 
 import os.path


### PR DESCRIPTION
Issue #873 :
- Use the `pywinauto.base_application` as the main source for Application module
- Fix methods links in the Applicaiton documentation
- Mention Windows/Linux specific implementations of Application

Issue #877 :
- Enable Desktop class for all current platforms: Windows, Linux
- Enable automatic doc generation for Desktop
- Fix AtspiElementInfo.__hash__ method as the previous implementation was using non-hashable object.

The docs preview for this PR can be found here: https://airelil-pywinauto.readthedocs.io/en/atspi/
New doc for the Desktop class: https://airelil-pywinauto.readthedocs.io/en/atspi/code/pywinauto.html