### PR TITLE
issue #852, issue #547, typos

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -86,12 +86,18 @@ if sys.platform == 'win32':
     sys.coinit_flags = _get_com_threading_mode(sys)
 
 
+#=========================================================================
+class WindowNotFoundError(Exception):
+
+    """No window could be found"""
+    pass
+
 from . import findwindows
 
 WindowAmbiguousError = findwindows.WindowAmbiguousError
-WindowNotFoundError = findwindows.WindowNotFoundError
 ElementNotFoundError = findwindows.ElementNotFoundError
 ElementAmbiguousError = findwindows.ElementAmbiguousError
+
 
 from . import findbestmatch
 from . import backend as backends

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -354,7 +354,8 @@ class BaseWrapper(object):
         # Use a direct call to element_info.rectangle instead of self.rectangle
         # because the latter can be overriden in one of derived wrappers
         # (see _treeview_element.rectangle or _listview_item.rectangle)
-        raise NotImplementedError()
+        rect = self.element_info.rectangle
+        return (client_point[0] + rect.left, client_point[1] + rect.top)
 
     #-----------------------------------------------------------
     def process_id(self):

--- a/pywinauto/controls/atspi_controls.py
+++ b/pywinauto/controls/atspi_controls.py
@@ -119,7 +119,7 @@ class ComboBoxWrapper(atspiwrapper.AtspiWrapper):
         return self.children()[0].is_visible()
 
     def texts(self):
-        """Get texts of all items in in the control as array"""
+        """Get texts of all items in the control as list"""
         combo_box_container = self.children()[0]
         texts = []
         for el in combo_box_container.children():

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -63,6 +63,7 @@ from .. import timings
 from .. import handleprops
 from ..windows.win32_element_info import HwndElementInfo
 from .. import backend
+from .. import WindowNotFoundError  # noqa #E402
 
 # I leave this optional because PIL is a large dependency
 try:
@@ -1165,11 +1166,14 @@ class HwndWrapper(WinBaseWrapper):
 
         # Keep waiting until both this control and it's parent
         # are no longer valid controls
-        timings.wait_until(
-            wait_time,
-            Timings.closeclick_retry,
-            has_closed
-        )
+        try:
+            timings.wait_until(
+                wait_time,
+                Timings.closeclick_retry,
+                has_closed
+            )
+        except timings.TimeoutError:
+            raise WindowNotFoundError
 
         self.actions.log('Closed window "{0}"'.format(window_text))
     # Non PEP-8 alias

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -40,7 +40,7 @@ import warnings
 import comtypes
 
 from .. import backend
-from ..findwindows import WindowNotFoundError
+from .. import WindowNotFoundError  # noqa #E402
 from ..timings import Timings
 from .win_base_wrapper import WinBaseWrapper
 from ..base_wrapper import BaseMeta
@@ -131,7 +131,7 @@ class LazyProperty(object):
         if obj is None:
             return None
         value = self.fget(obj)
-        setattr(obj, self.func_name, value)
+        #setattr(obj, self.func_name, value)
         return value
 lazy_property = LazyProperty
 

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -131,7 +131,7 @@ class LazyProperty(object):
         if obj is None:
             return None
         value = self.fget(obj)
-        #setattr(obj, self.func_name, value)
+        setattr(obj, self.func_name, value)
         return value
 lazy_property = LazyProperty
 

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -40,6 +40,7 @@ import warnings
 import comtypes
 
 from .. import backend
+from ..findwindows import WindowNotFoundError
 from ..timings import Timings
 from .win_base_wrapper import WinBaseWrapper
 from ..base_wrapper import BaseMeta
@@ -436,7 +437,10 @@ class UIAWrapper(WinBaseWrapper):
             if name and control_type:
                 self.actions.log("Closed " + control_type.lower() + ' "' +  name + '"')
         except(uia_defs.NoPatternInterfaceError):
-            self.type_keys("{ESC}")
+            try:
+                self.type_keys("{ESC}")
+            except comtypes.COMError:
+                raise WindowNotFoundError
 
     # -----------------------------------------------------------
     def minimize(self):

--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -78,18 +78,6 @@ class WinBaseWrapper(BaseWrapper):
     def __new__(cls, element_info):
         return WinBaseWrapper._create_wrapper(cls, element_info, WinBaseWrapper)
 
-    #------------------------------------------------------------
-    def client_to_screen(self, client_point):
-        """Maps point from client to screen coordinates"""
-        # Use a direct call to element_info.rectangle instead of self.rectangle
-        # because the latter can be overriden in one of derived wrappers
-        # (see _treeview_element.rectangle or _listview_item.rectangle)
-        rect = self.element_info.rectangle
-        if isinstance(client_point, win32structures.POINT):
-            return (client_point.x + rect.left, client_point.y + rect.top)
-        else:
-            return (client_point[0] + rect.left, client_point[1] + rect.top)
-
     #-----------------------------------------------------------
     def draw_outline(
         self,

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -36,17 +36,12 @@ import re
 import six
 
 from . import findbestmatch
+from . import WindowNotFoundError
 from . import controls
 from .backend import registry
 
 
 # TODO: we should filter out invalid elements before returning
-
-#=========================================================================
-class WindowNotFoundError(Exception):
-
-    """No window could be found"""
-    pass
 
 
 #=========================================================================

--- a/pywinauto/linux/application.py
+++ b/pywinauto/linux/application.py
@@ -49,8 +49,8 @@ class Application(BaseApplication):
         Initialize the Application object
 
         * **backend** is a name of used back-end (values: "atspi").
-	* **allow_magic_lookup** whether attribute access must turn into
-		child_window(best_match=...) search as fallback
+        * **allow_magic_lookup** whether attribute access must turn into
+            child_window(best_match=...) search as fallback
         """
         self.process = None
         self.xmlpath = ''
@@ -58,7 +58,7 @@ class Application(BaseApplication):
         self._proc_descriptor = None
         self.match_history = []
         self.use_history = False
-        self.actions = None # TODO Action logger for linux
+        self.actions = None  # TODO Action logger for linux
         if backend not in registry.backends:
             raise ValueError('Backend "{0}" is not registered!'.format(backend))
         self.backend = registry.backends[backend]
@@ -122,6 +122,7 @@ class Application(BaseApplication):
             raise AppNotConnected("Please use start or connect before trying "
                                   "anything else")
         proc_pid_stat = "/proc/{}/stat".format(self.process)
+
         def read_cpu_info():
             with open(proc_pid_stat, 'r') as s:
                 pid_info = s.read().split()
@@ -130,7 +131,7 @@ class Application(BaseApplication):
             # return a tuple as following:
             # pid utime, pid stime, total utime, total stime
             return (int(pid_info[13]), int(pid_info[14]), int(info[1]), int(info[3]))
-        
+
         try:
             before = read_cpu_info()
             if not interval:
@@ -166,7 +167,7 @@ class Application(BaseApplication):
             self._proc_descriptor = None
 
         if not self.is_process_running():
-            return True # already closed
+            return True  # already closed
         status = subprocess.check_output(["kill", "-9", str(self.process)], universal_newlines=True)
         if "Operation not permitted" in status:
             raise Exception("Cannot kill process: {}".format(status))

--- a/pywinauto/linux/application.py
+++ b/pywinauto/linux/application.py
@@ -144,7 +144,6 @@ class Application(BaseApplication):
                 res = 0.0
             else:
                 res = 100.0 * (float(pid_time) / float(sys_time))
-            #print("linux app cpu usage: ", res)
             return res
 
         except IOError:

--- a/pywinauto/unittests/test_application_linux.py
+++ b/pywinauto/unittests/test_application_linux.py
@@ -6,10 +6,13 @@ import subprocess
 import time
 
 sys.path.append(".")
-from pywinauto.linux.application import Application, AppStartError, AppNotConnected
 from pywinauto.application import WindowSpecification  # noqa: E402
 if sys.platform.startswith('linux'):
     from pywinauto.controls import atspiwrapper  # register atspi backend
+    from pywinauto.linux.application import Application  # noqa: E402
+    from pywinauto.linux.application import AppStartError  # noqa: E402
+    from pywinauto.linux.application import AppNotConnected  # noqa: E402
+    from pywinauto.linux.application import ProcessNotFoundError  # noqa: E402
 
 app_name = r"gtk_example.py"
 
@@ -77,10 +80,19 @@ if sys.platform.startswith('linux'):
             self.app.connect(path=_test_app())
             self.assertEqual(self.app.process, self.subprocess_app.pid)
 
-        def test_get_cpu_usage(self):
+        def test_cpu_usage(self):
             self.app.start(_test_app())
-            time.sleep(1)
-            self.assertGreater(self.app.cpu_usage(), 0)
+            self.assertGreater(self.app.cpu_usage(0.1), 0)
+            self.app.wait_cpu_usage_lower(threshold=0.1, timeout=2.9, usage_interval=0.2)
+            # default timings
+            self.assertEqual(self.app.cpu_usage(), 0)
+
+            # non-existing process
+            self.app.kill()
+            self.assertRaises(ProcessNotFoundError, self.app.cpu_usage, 7.8)
+
+            # not connected or not started app
+            self.assertRaises(AppNotConnected, Application().cpu_usage, 12.3)
 
         def test_is_process_running(self):
             self.app.start(_test_app())

--- a/pywinauto/unittests/test_atspi_wrapper.py
+++ b/pywinauto/unittests/test_atspi_wrapper.py
@@ -34,7 +34,6 @@
 
 import os
 import sys
-import time
 import unittest
 
 if sys.platform.startswith("linux"):
@@ -43,7 +42,7 @@ if sys.platform.startswith("linux"):
     from pywinauto.linux.application import Application
     from pywinauto.controls.atspiwrapper import AtspiWrapper
     from pywinauto.linux.atspi_objects import IATSPI
-    from pywinauto import mouse
+    from pywinauto.linux.atspi_objects import POINT
 
 app_name = r"gtk_example.py"
 
@@ -129,6 +128,13 @@ if sys.platform.startswith("linux"):
             self.assertEqual(rect.width(), 600)
             rect = self.app_frame.Icon.rectangle()
             self.assertAlmostEqual(rect.height(), 26, delta=2)
+
+        def test_client_to_screen(self):
+            rect = self.app_wrapper.rectangle()
+            self.assertEqual(self.app_wrapper.client_to_screen((0, 0)),
+                    (rect.left, rect.top))
+            self.assertEqual(self.app_wrapper.client_to_screen(POINT(20, 20)),
+                    (rect.left + 20, rect.top + 20))
 
         def test_can_get_process_id(self):
             self.assertEqual(self.app_wrapper.process_id(), self.app.process)

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -64,6 +64,8 @@ from pywinauto.base_wrapper import ElementNotEnabled  # noqa E402
 from pywinauto.base_wrapper import ElementNotVisible  # noqa E402
 from pywinauto import findbestmatch  # noqa E402
 from pywinauto import keyboard  # noqa E402
+from pywinauto import timings  # noqa E402
+from pywinauto import WindowNotFoundError  # noqa E402
 
 
 mfc_samples_folder = os.path.join(
@@ -102,6 +104,13 @@ class HwndWrapperTests(unittest.TestCase):
         #self.dlg.type_keys("%{F4}")
         #self.dlg.close()
         self.app.kill()
+
+    def test_close_not_found(self):
+        """Test dialog close handle non existing window"""
+        wrp = self.dlg.wrapper_object()
+        with mock.patch.object(timings, 'wait_until') as mock_wait_until:
+            mock_wait_until.side_effect = timings.TimeoutError
+            self.assertRaises(WindowNotFoundError, wrp.close)
 
     def test_scroll(self):
         """Test control scrolling"""


### PR DESCRIPTION
List of all fixes:
- issue #852: re-work Application.cpu_usage for Linux platform
- typo in ATSPI `ComboBoxWrapper.text` doc string
- move `client_to_screen` implementation into BaseWrapper. This is to have a single method for all backends
- spaces and indentation in linux/application.py
- issue #547: throw same exception from HwndWrapper.close and UIAWrapper.close
    Both backends should raise the same WindowNotFoundError exception if their `close` methods fail to find the window to close
