### PR TITLE
Issue #668: add WindowWrapper for uia backend

### DIFF
--- a/pywinauto/base_types.py
+++ b/pywinauto/base_types.py
@@ -192,6 +192,14 @@ class RectExtMixin(object):
             self.left, self.top, self.right, self.bottom)
 
     # ----------------------------------------------------------------
+    def __iter__(self):
+        """Allow iteration through coordinates"""
+        yield self.left
+        yield self.top
+        yield self.right
+        yield self.bottom
+
+    # ----------------------------------------------------------------
     def __sub__(self, other):
         """Return a new rectangle which is offset from the one passed in"""
         new_rect = self._RECT()

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -1080,13 +1080,7 @@ class HwndWrapper(WinBaseWrapper):
     MenuSelect = deprecated(menu_select)
 
     # -----------------------------------------------------------
-    def move_window(
-        self,
-        x = None,
-        y = None,
-        width = None,
-        height = None,
-        repaint = True):
+    def move_window(self, x=None, y=None, width=None, height=None):
         """Move the window to the new coordinates
 
         * **x** Specifies the new left position of the window.
@@ -1097,9 +1091,6 @@ class HwndWrapper(WinBaseWrapper):
           current width of the window.
         * **height** Specifies the new height of the window. Default to the
           current height of the window.
-        * **repaint** Whether the window should be repainted or not.
-          Defaults to True
-
         """
         cur_rect = self.rectangle()
 
@@ -1128,7 +1119,7 @@ class HwndWrapper(WinBaseWrapper):
             height = cur_rect.height()
 
         # ask for the window to be moved
-        ret = win32functions.MoveWindow(self, x, y, width, height, repaint)
+        ret = win32functions.MoveWindow(self, x, y, width, height, True)
 
         # check that it worked correctly
         if not ret:

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -31,9 +31,9 @@
 
 """Wrap various UIA windows controls. To be used with 'uia' backend."""
 import locale
+import time
 import comtypes
 import six
-import time
 
 from . import uiawrapper
 from . import win32_controls

--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -33,6 +33,7 @@
 import locale
 import comtypes
 import six
+import time
 
 from . import uiawrapper
 from . import win32_controls
@@ -46,6 +47,69 @@ from ..windows.uia_defines import toggle_state_on
 from ..windows.uia_defines import get_elem_interface
 from ..windows.uia_element_info import UIAElementInfo
 from ..windows.uia_element_info import elements_from_uia_array
+
+
+# ====================================================================
+class WindowWrapper(uiawrapper.UIAWrapper):
+
+    """Wrap a UIA-compatible Window control"""
+
+    _control_types = ['Window']
+
+    # -----------------------------------------------------------
+    def __init__(self, elem):
+        """Initialize the control"""
+        super(WindowWrapper, self).__init__(elem)
+
+    # -----------------------------------------------------------
+    def move_window(self, x=None, y=None, width=None, height=None):
+        """Move the window to the new coordinates
+
+        * **x** Specifies the new left position of the window.
+                Defaults to the current left position of the window.
+        * **y** Specifies the new top position of the window.
+                Defaults to the current top position of the window.
+        * **width** Specifies the new width of the window.
+                Defaults to the current width of the window.
+        * **height** Specifies the new height of the window.
+                Defaults to the current height of the window.
+        """
+        cur_rect = self.rectangle()
+
+        # if no X is specified - so use current coordinate
+        if x is None:
+            x = cur_rect.left
+        else:
+            try:
+                y = x.top
+                width = x.width()
+                height = x.height()
+                x = x.left
+            except AttributeError:
+                pass
+
+        # if no Y is specified - so use current coordinate
+        if y is None:
+            y = cur_rect.top
+
+        # if no width is specified - so use current width
+        if width is None:
+            width = cur_rect.width()
+
+        # if no height is specified - so use current height
+        if height is None:
+            height = cur_rect.height()
+
+        # ask for the window to be moved
+        self.iface_transform.Move(x, y)
+        self.iface_transform.Resize(width, height)
+
+        time.sleep(timings.Timings.after_movewindow_wait)
+
+    # -----------------------------------------------------------
+    def is_dialog(self):
+        """Window is always a dialog so return True"""
+        return True
 
 
 # ====================================================================

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -799,5 +799,26 @@ class UIAWrapper(WinBaseWrapper):
             pass
         return texts
 
+    # -----------------------------------------------------------
+    def move_window(self, x=None, y=None, width=None, height=None, repaint=True):
+        """Move the window to the new coordinates
+        The method should be implemented explicitly by controls that
+        support this action. The most obvious is the Window control.
+        Otherwise the method throws NotImplementedError.
+
+        * **x** Specifies the new left position of the window.
+          Defaults to the current left position of the window.
+        * **y** Specifies the new top position of the window.
+          Defaults to the current top position of the window.
+        * **width** Specifies the new width of the window. Defaults to the
+          current width of the window.
+        * **height** Specifies the new height of the window. Default to the
+          current height of the window.
+        * **repaint** Whether the window should be repainted or not.
+          Defaults to True
+
+        """
+        raise NotImplementedError("This method is not supported for {0}".format(self))
+
 
 backend.register('uia', UIAElementInfo, UIAWrapper)

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -800,7 +800,7 @@ class UIAWrapper(WinBaseWrapper):
         return texts
 
     # -----------------------------------------------------------
-    def move_window(self, x=None, y=None, width=None, height=None, repaint=True):
+    def move_window(self, x=None, y=None, width=None, height=None):
         """Move the window to the new coordinates
         The method should be implemented explicitly by controls that
         support this action. The most obvious is the Window control.
@@ -814,9 +814,6 @@ class UIAWrapper(WinBaseWrapper):
           current width of the window.
         * **height** Specifies the new height of the window. Default to the
           current height of the window.
-        * **repaint** Whether the window should be repainted or not.
-          Defaults to True
-
         """
         raise NotImplementedError("This method is not supported for {0}".format(self))
 

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -804,7 +804,7 @@ class UIAWrapper(WinBaseWrapper):
         """Move the window to the new coordinates
         The method should be implemented explicitly by controls that
         support this action. The most obvious is the Window control.
-        Otherwise the method throws NotImplementedError.
+        Otherwise the method throws AttributeError
 
         * **x** Specifies the new left position of the window.
           Defaults to the current left position of the window.
@@ -815,7 +815,7 @@ class UIAWrapper(WinBaseWrapper):
         * **height** Specifies the new height of the window. Default to the
           current height of the window.
         """
-        raise NotImplementedError("This method is not supported for {0}".format(self))
+        raise AttributeError("This method is not supported for {0}".format(self))
 
 
 backend.register('uia', UIAElementInfo, UIAWrapper)

--- a/pywinauto/unittests/test_atspi_element_info.py
+++ b/pywinauto/unittests/test_atspi_element_info.py
@@ -39,7 +39,6 @@ import time
 import unittest
 import re
 import mock
-import ctypes
 
 if sys.platform.startswith("linux"):
     sys.path.append(".")
@@ -118,6 +117,15 @@ if sys.platform.startswith("linux"):
             """Test RECT repr"""
             r0 = RECT(0)
             self.assertEqual(r0.__repr__(), "<RECT L0, T0, R0, B0>")
+
+        def test_RECT_iter(self):
+            """Test RECT is iterable"""
+            r = RECT(1, 2, 3, 4)
+            (left, top, right, bottom) = r
+            self.assertEqual(left, r.left)
+            self.assertEqual(right, r.right)
+            self.assertEqual(top, r.top)
+            self.assertEqual(bottom, r.bottom)
 
 
     class AtspiElementInfoTests(unittest.TestCase):

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -441,7 +441,7 @@ class HwndWrapperTests(unittest.TestCase):
 #    def testVerifyActionable(self):
 
     def testMoveWindow_same(self):
-        """Test calling movewindow without any parameters"""
+        """Test calling move_window without any parameters"""
         prevRect = self.dlg.rectangle()
         self.dlg.move_window()
         self.assertEqual(prevRect, self.dlg.rectangle())

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -18,6 +18,7 @@ from pywinauto.actionlogger import ActionLogger  # noqa: E402
 from pywinauto import Desktop
 from pywinauto import mouse  # noqa: E402
 from pywinauto import WindowNotFoundError  # noqa: E402
+from pywinauto.windows import win32structures  # noqa: E402
 if UIA_support:
     import comtypes
     import pywinauto.windows.uia_defines as uia_defs
@@ -179,6 +180,45 @@ if UIA_support:
             button = self.dlg.child_window(class_name="Button",
                                            name="OK").wrapper_object()
             self.assertEqual(button.is_dialog(), False)
+            self.assertEqual(self.dlg.is_dialog(), True)
+
+        def test_move_window(self):
+            """Test  move_window without any parameters"""
+
+            # move_window with default parameters
+            prevRect = self.dlg.rectangle()
+            self.dlg.move_window()
+            self.assertEqual(prevRect, self.dlg.rectangle())
+
+            # move_window call for a not supported control
+            button = self.dlg.child_window(class_name="Button", name="OK")
+            self.assertRaises(NotImplementedError, button.move_window)
+
+            dlg_rect = self.dlg.parent().rectangle()  # use the parent as a reference
+            prev_rect = self.dlg.rectangle() - dlg_rect
+
+            new_rect = win32structures.RECT(prev_rect)
+            new_rect.left -= 1
+            new_rect.top -= 1
+            new_rect.right += 2
+            new_rect.bottom += 2
+
+            self.dlg.move_window(
+                new_rect.left,
+                new_rect.top,
+                new_rect.width(),
+                new_rect.height(),
+            )
+            time.sleep(0.1)
+            logger = ActionLogger()
+            logger.log("prev_rect = ", prev_rect)
+            logger.log("new_rect = ", new_rect)
+            logger.log("dlg_rect = ", dlg_rect)
+            logger.log("self.dlg.rectangle() = ", self.dlg.rectangle())
+            self.assertEqual(self.dlg.rectangle(), new_rect + dlg_rect)
+
+            self.dlg.move_window(prev_rect)
+            self.assertEqual(self.dlg.rectangle(), prev_rect + dlg_rect)
 
         def test_close(self):
             """Test close method of a control"""
@@ -529,8 +569,8 @@ if UIA_support:
                          "^<uia_controls.StaticWrapper - 'TestLabel', Static, [0-9-]+>$")
 
             wrp = self.dlg.wrapper_object()
-            assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog$")
-            assert_regex(wrp.__repr__(), "^<uiawrapper\.UIAWrapper - 'WPF Sample Application', Dialog, [0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.WindowWrapper - 'WPF Sample Application', Dialog$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.WindowWrapper - 'WPF Sample Application', Dialog, [0-9-]+>$")
 
             # ElementInfo.__str__
             assert_regex(wrp.element_info.__str__(),
@@ -541,10 +581,10 @@ if UIA_support:
             # mock a failure in window_text() method
             orig = wrp.window_text
             wrp.window_text = mock.Mock(return_value="")  # empty text
-            assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '', Dialog$")
-            assert_regex(wrp.__repr__(), "^<uiawrapper\.UIAWrapper - '', Dialog, [0-9-]+>$")
+            assert_regex(wrp.__str__(), "^uia_controls\.WindowWrapper - '', Dialog$")
+            assert_regex(wrp.__repr__(), "^<uia_controls\.WindowWrapper - '', Dialog, [0-9-]+>$")
             wrp.window_text.return_value = u'\xd1\xc1\\\xa1\xb1\ua000'  # unicode string
-            assert_regex(wrp.__str__(), "^uiawrapper\.UIAWrapper - '.+', Dialog$")
+            assert_regex(wrp.__str__(), "^uia_controls\.WindowWrapper - '.+', Dialog$")
             wrp.window_text = orig  # restore the original method
 
             # mock a failure in element_info.name property (it's based on _get_name())

--- a/pywinauto/unittests/test_win32functions.py
+++ b/pywinauto/unittests/test_win32functions.py
@@ -159,6 +159,15 @@ class Win32FunctionsTestCases(unittest.TestCase):
         r0 = RECT(0)
         self.assertEqual(r0.__repr__(), "<RECT L0, T0, R0, B0>")
 
+    def test_RECT_iter(self):
+        """Test RECT is iterable"""
+        r = RECT(1, 2, 3, 4)
+        (left, top, right, bottom) = r
+        self.assertEqual(left, r.left)
+        self.assertEqual(right, r.right)
+        self.assertEqual(top, r.top)
+        self.assertEqual(bottom, r.bottom)
+
     def test_Structure(self):
         class Structure0(Structure):
             _fields_ = [("f0", ctypes.c_int)]


### PR DESCRIPTION
The wrapper contains only `move_window` and `is_dialog` methods.
For others UIA controls the `move_window` throws AttributeError.
Make RECT iterable