### PR TITLE
Better handling of control type in find_wrapper() for UIAWrapper/AtspiWrapper

### DIFF
--- a/pywinauto/controls/atspiwrapper.py
+++ b/pywinauto/controls/atspiwrapper.py
@@ -77,12 +77,13 @@ class AtspiMeta(BaseMeta):
     @staticmethod
     def find_wrapper(element):
         """Find the correct wrapper for this Atspi element"""
-        # Set a general wrapper by default
-        wrapper_match = AtspiWrapper
 
         # Check for a more specific wrapper in the registry
-        if element.control_type in AtspiMeta.control_type_to_cls:
+        try:
             wrapper_match = AtspiMeta.control_type_to_cls[element.control_type]
+        except KeyError:
+            # Set a general wrapper by default
+            wrapper_match = AtspiWrapper
 
         return wrapper_match
 

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -153,12 +153,13 @@ class UiaMeta(BaseMeta):
     @staticmethod
     def find_wrapper(element):
         """Find the correct wrapper for this UIA element"""
-        # Set a general wrapper by default
-        wrapper_match = UIAWrapper
 
         # Check for a more specific wrapper in the registry
-        if element.control_type in UiaMeta.control_type_to_cls:
+        try:
             wrapper_match = UiaMeta.control_type_to_cls[element.control_type]
+        except KeyError:
+            # Set a general wrapper by default
+            wrapper_match = UIAWrapper
 
         return wrapper_match
 


### PR DESCRIPTION
Avoid resolving the control types twice in find_wrapper(), because the
control type can be resolved differently, especially on app exit.
Example of the error we try to solve:
```
  File "C:\projects\pywinauto\pywinauto\unittests\test_application.py", line 1296, in tearDown
    self.desktop.MFC_samplesDialog.wait_not('exists')
  File "C:\projects\pywinauto\pywinauto\base_application.py", line 567, in wait_not
    lambda: not self.__check_all_conditions(check_method_names, retry_interval))
  File "C:\projects\pywinauto\pywinauto\timings.py", line 359, in wait_until
    func_val = func(*args, **kwargs)
  File "C:\projects\pywinauto\pywinauto\base_application.py", line 567, in <lambda>
    lambda: not self.__check_all_conditions(check_method_names, retry_interval))
  File "C:\projects\pywinauto\pywinauto\base_application.py", line 476, in __check_all_conditions
    if not check(retry_interval, float(retry_interval) // 2):
  File "C:\projects\pywinauto\pywinauto\base_application.py", line 427, in exists
    self.__resolve_control(exists_criteria, timeout, retry_interval)
  File "C:\projects\pywinauto\pywinauto\base_application.py", line 258, in __resolve_control
    criteria)
  File "C:\projects\pywinauto\pywinauto\timings.py", line 436, in wait_until_passes
    func_val = func(*args, **kwargs)
  File "C:\projects\pywinauto\pywinauto\base_application.py", line 203, in __get_ctrl
    dialog = self.backend.generic_wrapper_class(findwindows.find_element(**criteria[0]))
  File "C:\projects\pywinauto\pywinauto\controls\uiawrapper.py", line 187, in __new__
    return super(UIAWrapper, cls)._create_wrapper(cls, element_info, UIAWrapper)
  File "C:\projects\pywinauto\pywinauto\base_wrapper.py", line 117, in _create_wrapper
    new_class = cls_spec.find_wrapper(element_info)
  File "C:\projects\pywinauto\pywinauto\controls\uiawrapper.py", line 161, in find_wrapper
    wrapper_match = UiaMeta.control_type_to_cls[element.control_type]
KeyError: None
```