### PR TITLE
Use new 'name' arg in examples

### DIFF
--- a/examples/list_windows_updates.py
+++ b/examples/list_windows_updates.py
@@ -14,14 +14,14 @@ from pywinauto import Application
 
 # Open "Control Panel"
 Application().start('control.exe')
-app = Application(backend='uia').connect(path='explorer.exe', title='Control Panel')
+app = Application(backend='uia').connect(path='explorer.exe', name='Control Panel')
 
 # Go to "Programs"
-app.window(title='Control Panel').ProgramsHyperlink.invoke()
+app.window(name='Control Panel').ProgramsHyperlink.invoke()
 app.wait_cpu_usage_lower(threshold=0.5, timeout=30, usage_interval=1.0)
 
 # Go to "Installed Updates"
-app.window(title='Programs').child_window(title='View installed updates', control_type='Hyperlink').invoke()
+app.window(name_re='Programs').child_window(name='View installed updates', control_type='Hyperlink').invoke()
 app.wait_cpu_usage_lower(threshold=0.5, timeout=30, usage_interval=1.0)
 
 list_box = app.InstalledUpdates.FolderViewListBox
@@ -33,7 +33,7 @@ print('\nAll updates ({}):\n'.format(len(all_updates)))
 print(all_updates)
 
 # list updates from "Microsoft Windows" group only
-windows_group_box = list_box.child_window(title_re='^Microsoft Windows.*', control_type='Group')
+windows_group_box = list_box.child_window(name_re='^Microsoft Windows.*', control_type='Group')
 windows_items = windows_group_box.descendants(control_type='ListItem')
 windows_updates = [item.window_text() for item in windows_items]
 print('\nWindows updates only ({}):\n'.format(len(windows_updates)))

--- a/examples/mspaint.py
+++ b/examples/mspaint.py
@@ -25,19 +25,19 @@ if args.log:
     logger.handlers[0] = logging.FileHandler(args.log)
 
 app = Application(backend='uia').start(r'mspaint.exe')
-dlg = app.window(title_re='.* - Paint')
+dlg = app.window(name_re='.* - Paint')
 
 # File->Open menu selection
 dlg.File_tab.click()
-dlg.child_window(title='Open', control_type='MenuItem', found_index=0).invoke()
+dlg.child_window(name='Open', control_type='MenuItem', found_index=0).invoke()
 
 # handle Open dialog
-file_name_edit = dlg.Open.child_window(title="File name:", control_type="Edit")
+file_name_edit = dlg.Open.child_window(name="File name:", control_type="Edit")
 file_name_edit.set_text('walter_cat.jpg')
 # There are 2 Open buttons:
 # dlg.Open.Open.click() will call drop down list of the file name combo box.
 # The child_window statement is just copied from print_control_identifiers().
-dlg.Open.child_window(title="Open", auto_id="1", control_type="Button").click()
+dlg.Open.child_window(name="Open", auto_id="1", control_type="Button").click()
 
 dlg.ResizeButton.click()
 dlg.ResizeAndSkew.Pixels.select()
@@ -48,8 +48,8 @@ dlg.ResizeAndSkew.OK.click()
 
 # Select menu "File->Save as->PNG picture"
 dlg.File_tab.click()
-dlg.SaveAsGroup.child_window(title="Save as", found_index=1).invoke()
-dlg.child_window(title='PNG picture', found_index=0).invoke()
+dlg.SaveAsGroup.child_window(name="Save as", found_index=1).invoke()
+dlg.child_window(name='PNG picture', found_index=0).invoke()
 # Type output file name and save
 dlg.SaveAs.File_name_ComboBox.Edit.set_text('walter_cat_resized.png')
 dlg.SaveAs.Save.click()

--- a/examples/notepad_fast.py
+++ b/examples/notepad_fast.py
@@ -148,7 +148,7 @@ def run_notepad():
     # ----- 2nd Page Setup Dialog again ----
     app.PageSetupDlg.Properties.click()
 
-    doc_props = app.window(title_re = ".*Properties$")
+    doc_props = app.window(name_re=".*Properties$")
     doc_props.wait('exists', timeout=40)
 
 #
@@ -193,7 +193,7 @@ def run_notepad():
 #    # close the 4 windows
 #
 #    # ----- Advanced Options Dialog ----
-#    app.window(title_re = ".* Advanced Options").Ok.click()
+#    app.window(name_re = ".* Advanced Options").Ok.click()
 
     # ----- Document Properties Dialog again ----
     doc_props.Cancel.close_click()

--- a/examples/notepad_item.py
+++ b/examples/notepad_item.py
@@ -72,7 +72,7 @@ app['ConnectToPrinter']['OK'].close_click()
 app['PageSetupDlg2']['Properties'].click()
 
 # ----- Document Properties Dialog ----
-doc_props = app.window(title_re = ".*Document Properties")
+doc_props = app.window(name_re = ".*Document Properties")
 
 # Two ways of selecting tabs
 doc_props['TabCtrl'].select(2)
@@ -88,7 +88,7 @@ advbutton.click()
 
 # ----- Advanced Options Dialog ----
 # close the 4 windows
-app.window(title_re = ".* Advanced Options")['Ok'].click()
+app.window(name_re = ".* Advanced Options")['Ok'].click()
 
 # ----- Document Properties Dialog again ----
 doc_props['Cancel'].close_click()

--- a/examples/notepad_slow.py
+++ b/examples/notepad_slow.py
@@ -127,7 +127,7 @@ def run_notepad():
     # ----- 2nd Page Setup Dialog again ----
     app.PageSetupDlg.Properties.click()
 
-    doc_props = app.window(title_re = ".*Properties$")
+    doc_props = app.window(name_re = ".*Properties$")
     doc_props.wait('exists', timeout=40)
 
     # ----- Document Properties Dialog ----
@@ -168,7 +168,7 @@ def run_notepad():
 #    # close the 4 windows
 #
 #    # ----- Advanced Options Dialog ----
-#    app.window(title_re = ".* Advanced Options").Ok.click()
+#    app.window(name_re = ".* Advanced Options").Ok.click()
 
     # ----- Document Properties Dialog again ----
     doc_props.Cancel.close_click()

--- a/examples/save_from_firefox.py
+++ b/examples/save_from_firefox.py
@@ -83,11 +83,11 @@ time.sleep(5)
 #  - find the actual process
 #  - connect to it
 if app.windows():
-    mozilla =  app.window(title_re=".*Mozilla Firefox")
+    mozilla =  app.window(name_re=".*Mozilla Firefox")
 
 else:
-    app = application.Application().connect(title_re=".*Mozilla Firefox")
-    mozilla = app.window(title_re=".*Mozilla Firefox")
+    app = application.Application().connect(name_re=".*Mozilla Firefox")
+    mozilla = app.window(name_re=".*Mozilla Firefox")
 
 # ie doesn't define it's menus as Menu's but actually as a toolbar!
 print("No Menu's in FireFox:", mozilla.menu_items())

--- a/examples/save_from_internet_explorer.py
+++ b/examples/save_from_internet_explorer.py
@@ -69,7 +69,7 @@ app = application.Application().start(
 # some pages are slow to open - so wait some seconds
 time.sleep(10)
 
-ie =  app.window(title_re = ".*Windows Internet Explorer.*")
+ie =  app.window(name_re = ".*Windows Internet Explorer.*")
 
 # ie doesn't define it's menus as Menu's but actually as a toolbar!
 print("No Menu's in IE:", ie.menu_items())

--- a/examples/test_sakura.py
+++ b/examples/test_sakura.py
@@ -43,7 +43,7 @@ def sakura_test():
     app = application.Application()
     app.start(r"C:\Program Files\sakura\sakura.exe")
 
-    mainwin = app.window(title_re = u'\(無題\) - sakura .*')
+    mainwin = app.window(name_re = u'\(無題\) - sakura .*')
 
     # menu's from this application are not recovered well
     # but even with Japanese Regional settings they are not
@@ -53,8 +53,8 @@ def sakura_test():
     # open some dialog
     mainwin.type_keys("%OC")
 
-    dlg = app.window(title = u'共通設定')
-    dlg.window(title_re = r"フリーカーソル.*").click()
+    dlg = app.window(name = u'共通設定')
+    dlg.window(name_re = r"フリーカーソル.*").click()
     dlg.MSDOS.click()
     dlg.Cancel.click()
 

--- a/examples/uninstall_7zip.py
+++ b/examples/uninstall_7zip.py
@@ -19,7 +19,7 @@ try:
     NewWindow.type_keys(r'Control Panel\Programs\Programs and Features{ENTER}',
                         with_spaces=True, set_foreground=False)
     ProgramsAndFeatures = explorer.window(top_level_only=True, active_only=True,
-                                          title='Programs and Features', class_name='CabinetWClass')
+                                          name='Programs and Features', class_name='CabinetWClass')
 
     # wait while the list of programs is loading
     explorer.wait_cpu_usage_lower(threshold=5)
@@ -29,16 +29,16 @@ try:
     item_7z.click_input(button='right', where='icon')
     explorer.PopupMenu.menu_item('Uninstall').click()
 
-    Confirmation = explorer.window(title='Programs and Features', class_name='#32770', active_only=True)
+    Confirmation = explorer.window(name='Programs and Features', class_name='#32770', active_only=True)
     if Confirmation.Exists():
         Confirmation.Yes.click_input()
         Confirmation.wait_not('visible')
 
-    WindowsInstaller = explorer.window(title='Windows Installer', class_name='#32770', active_only=True)
+    WindowsInstaller = explorer.window(name='Windows Installer', class_name='#32770', active_only=True)
     if WindowsInstaller.Exists():
         WindowsInstaller.wait_not('visible', timeout=20)
 
-    SevenZipInstaller = explorer.window(title='7-Zip 9.20 (x64 edition)', class_name='#32770', active_only=True)
+    SevenZipInstaller = explorer.window(name='7-Zip 9.20 (x64 edition)', class_name='#32770', active_only=True)
     if SevenZipInstaller.Exists():
         SevenZipInstaller.wait_not('visible', timeout=20)
 

--- a/examples/win10_calculator.py
+++ b/examples/win10_calculator.py
@@ -22,4 +22,4 @@ dlg.type_keys('2*3=')
 dlg.print_control_identifiers()
 
 dlg.minimize()
-Desktop(backend="uia").window(title='Calculator', visible=None).restore()
+Desktop(backend="uia").window(name='Calculator', visible=None).restore()


### PR DESCRIPTION
Replace old 'title' keyword with the new 'name'.
Verified list_windows_updates, mspaint and win10_calculator
examples running properly on Win10