### PR TITLE
TravisCI: update to xenial, add python 3.7 and 3.8, remove 3.3 and 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: xenial
 language: cpp
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,23 @@
 sudo: required
-dist: trusty
+dist: xenial
 language: cpp
 notifications:
   email: false
-
+services:
+  xvfb
 
 language: python
 
 python:
-  #- "2.6"
-  - "2.7_with_system_site_packages"
-  - "3.3"
-  - "3.4_with_system_site_packages"
-  - "3.5"
+  - "2.7"
+  - "3.4"
   - "3.6"
+  - "3.7"
+  - "3.8"
 os:
   - linux
 before_install:
-  - sudo add-apt-repository -y ppa:beineri/opt-qt58-trusty
+  - sudo add-apt-repository -y ppa:beineri/opt-qt58-xenial
 
 install:
   - pip install python-xlib codecov coverage
@@ -29,12 +29,10 @@ install:
   - sudo apt-get install xsel
   - sudo apt-get install libgtk-3-dev libgtk2.0-dev
   - sudo apt-get install -y python3-gi
+  - sudo apt-get install --reinstall libgl1-mesa-dev
   - source /opt/qt58/bin/qt58-env.sh;
   
 before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
   - xauth generate :99.0 . trusted
   # Clone test apps
   - git init apps

--- a/apps/Gtk_samples/gtk_example.py
+++ b/apps/Gtk_samples/gtk_example.py
@@ -107,23 +107,23 @@ class TestApplicationMainWindow(Gtk.Window):
         grid = Gtk.Grid()
         self.add(grid)
 
-        self.button1 = Gtk.Button("Click")
+        self.button1 = Gtk.Button(label="Click")
         self.button1.connect("clicked", self.on_click_me_clicked)
 
         self.button2 = Gtk.Button(stock=Gtk.STOCK_OPEN)
         self.button2.connect("clicked", self.on_open_clicked)
 
-        self.button3 = Gtk.Button("C_l_o_s_e", use_underline=True)
+        self.button3 = Gtk.Button(label="C_l_o_s_e", use_underline=True)
         self.button3.connect("clicked", self.on_close_clicked)
 
-        self.button4 = Gtk.CheckButton("Button 1")
+        self.button4 = Gtk.CheckButton(label="Button 1")
         self.button4.connect("toggled", self.on_button_toggled, "1")
 
-        self.button5 = Gtk.CheckButton("Editable", use_underline=True)
+        self.button5 = Gtk.CheckButton(label="Editable", use_underline=True)
         self.button5.set_active(True)
         self.button5.connect("toggled", self.on_text_editable_button_toggled, "2")
 
-        self.label = Gtk.Label("Status")
+        self.label = Gtk.Label(label="Status")
         self.combo = self._add_combobox()
         self.treeview = self._add_listview()
         self.image = _add_image_widget()

--- a/pywinauto/unittests/test_application_linux.py
+++ b/pywinauto/unittests/test_application_linux.py
@@ -83,7 +83,7 @@ if sys.platform.startswith('linux'):
         def test_cpu_usage(self):
             self.app.start(_test_app())
             self.assertGreater(self.app.cpu_usage(0.1), 0)
-            self.app.wait_cpu_usage_lower(threshold=0.1, timeout=2.9, usage_interval=0.2)
+            self.app.wait_cpu_usage_lower(threshold=0.1, timeout=4.0, usage_interval=0.3)
             # default timings
             self.assertEqual(self.app.cpu_usage(), 0)
 

--- a/pywinauto/unittests/test_atspi_wrapper.py
+++ b/pywinauto/unittests/test_atspi_wrapper.py
@@ -115,13 +115,13 @@ if sys.platform.startswith("linux"):
             self.assertEqual(img_wrp.locale(), u'')
             self.assertEqual(img_wrp.size(), (48, 24))
             pos = img_wrp.position()
-            self.assertEqual(pos.x, 422)
-            self.assertAlmostEqual(pos.y, 31, delta=2)
+            self.assertAlmostEqual(pos.x, 408, delta=2)
+            self.assertAlmostEqual(pos.y, 29, delta=2)
             bb = img_wrp.bounding_box()
             self.assertEqual(bb.left, pos.x)
             self.assertEqual(bb.top, pos.y)
-            self.assertEqual(bb.right, 470)
-            self.assertAlmostEqual(bb.bottom, 55, delta=2)
+            self.assertAlmostEqual(bb.right, 456, delta=2)
+            self.assertAlmostEqual(bb.bottom, 53, delta=2)
 
         def test_can_get_rectangle(self):
             rect = self.app_frame.Panel.rectangle()


### PR DESCRIPTION
- Switch to a newer distro in Travis CI.
- Improve tolerance in linux unit tests.
- Fix deprecation warnings in PyGTK test sample