### PR TITLE
Fix application.py docstring: "app.child_window" -> "app.window"

### DIFF
--- a/pywinauto/application.py
+++ b/pywinauto/application.py
@@ -40,7 +40,7 @@ Once you have an Application instance you can access dialogs in that
 application either by using one of the methods below. ::
 
    dlg = app.YourDialogTitle
-   dlg = app.child_window(title="your title", classname="your class", ...)
+   dlg = app.window(title="your title", classname="your class", ...)
    dlg = app['Your Dialog Title']
 
 Similarly once you have a dialog you can get a control from that dialog


### PR DESCRIPTION
Simple fix for a typo in docstring for Application class.  
Example in docstring uses `child_window` method on `app` instance which doesn't exist in `Application` class. Method `window` should be used in this case.  
This got me stumbled a bit while going through documentation and doing hands-on in REPL, hence this PR. I read in another PR that `master` branch should be used for documentation fixes, please correct me if I'm wrong.