### PR TITLE
Fix base_application.py docstring: "app.child_window" -> "app.window"

### DIFF
--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -44,7 +44,7 @@ Once you have an Application instance you can access dialogs in that
 application by using one of the methods below. ::
 
    dlg = app.YourDialogTitle
-   dlg = app.child_window(name="your title", classname="your class", ...)
+   dlg = app.window(name="your title", classname="your class", ...)
    dlg = app['Your Dialog Title']
 
 Similarly once you have a dialog you can get a control from that dialog


### PR DESCRIPTION
Re-created from `atspi` branch. (requested by @airelil)  
Original PR: #944 
> Simple fix for a typo in docstring for Application class.
> Example in docstring uses child_window method on app instance which doesn't exist in Application class. Method window should be used in this case.
> This got me stumbled a bit while going through documentation and doing hands-on in REPL, hence this PR. I read in another PR that master branch should be used for documentation fixes, please correct me if I'm wrong.

