### PR TITLE
More thorough check whether UIA can be used

### DIFF
--- a/pywinauto/sysinfo.py
+++ b/pywinauto/sysinfo.py
@@ -42,7 +42,11 @@ try:
     log = logging.getLogger('comtypes')
     log.setLevel('WARNING')
     import comtypes  # noqa: E402
+    import comtypes.client
+    comtypes.client.GetModule('UIAutomationCore.dll')
     UIA_support = True
+except OSError:
+    UIA_support = False
 except ImportError:
     UIA_support = False
 


### PR DESCRIPTION
In order to prevent failed DLL loads e.g. under WINE