### PR TITLE
Change meaning of depth of elements (children became descendants with depth=1)

### DIFF
--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -653,7 +653,6 @@ class WindowSpecification(object):
                               rect=ctrl.rectangle())
                 output += indent + u'{}'.format(ctrl_id_name_map[ctrl_id])
 
-                title = ctrl_text
                 class_name = ctrl.class_name()
                 auto_id = None
                 control_type = None
@@ -666,15 +665,15 @@ class WindowSpecification(object):
                     else:
                         control_type = None  # if control_type is empty, still use class_name instead
                 criteria_texts = []
-                if title:
-                    criteria_texts.append(u'title="{}"'.format(title))
+                if ctrl_text:
+                    criteria_texts.append(u'name="{}"'.format(ctrl_text))
                 if class_name:
                     criteria_texts.append(u'class_name="{}"'.format(class_name))
                 if auto_id:
                     criteria_texts.append(u'auto_id="{}"'.format(auto_id))
                 if control_type:
                     criteria_texts.append(u'control_type="{}"'.format(control_type))
-                if title or class_name or auto_id:
+                if ctrl_text or class_name or auto_id:
                     output += u'\n' + indent + u'child_window(' + u', '.join(criteria_texts) + u')'
 
                 if six.PY3:

--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -630,12 +630,12 @@ class WindowSpecification(object):
         for name, index in name_ctrl_id_map.items():
             ctrl_id_name_map.setdefault(index, []).append(name)
 
-        def print_identifiers(ctrls, current_depth=1, log_func=print):
+        def print_identifiers(ctrls, current_depth=0, log_func=print):
             """Recursively print ids for ctrls and their descendants in a tree-like format"""
             if len(ctrls) == 0 or current_depth > depth:
                 return
 
-            indent = (current_depth - 1) * u"   | "
+            indent = current_depth * u"   | "
             for ctrl in ctrls:
                 try:
                     ctrl_id = all_ctrls.index(ctrl)

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -1211,7 +1211,7 @@ if UIA_support:
         def setUp(self):
             """Set some data and ensure the application is in the state we want"""
             Timings.defaults()
-            self.app = Application(backend="uia").start("Notepad")
+            self.app = Application(backend="uia").start(_notepad_exe())
             self.dlgspec = self.app.UntitledNotepad
 
         def tearDown(self):

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -1169,6 +1169,19 @@ class WindowSpecificationTestCases(unittest.TestCase):
             len(self.app['Font'].descendants(depth=1)),
             len(self.app['Font'].descendants(depth=2)))
 
+    if UIA_support:
+        def test_child_window_depth(self):
+            """Test that child_window() with depth works correctly"""
+            # TODO fix same elements at different tree levels on win32 backend and switch test back to win32
+            _app = Application(backend="uia").start("Notepad")
+            _dlgspec = _app.UntitledNotepad
+            _dlgspec.menu_select("Format -> Font")
+            font = _dlgspec.child_window(name="Font")
+
+            with self.assertRaises(findbestmatch.MatchError):
+                font.child_window(best_match="ListBox0", depth=1).wrapper_object()
+            font.child_window(best_match="ListBox0", depth=2).wrapper_object()
+
     def test_print_control_identifiers(self):
         """Make sure print_control_identifiers() doesn't crash"""
         self.dlgspec.print_control_identifiers()

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -1169,19 +1169,6 @@ class WindowSpecificationTestCases(unittest.TestCase):
             len(self.app['Font'].descendants(depth=1)),
             len(self.app['Font'].descendants(depth=2)))
 
-    if UIA_support:
-        def test_child_window_depth(self):
-            """Test that child_window() with depth works correctly"""
-            # TODO fix same elements at different tree levels on win32 backend and switch test back to win32
-            _app = Application(backend="uia").start("Notepad")
-            _dlgspec = _app.UntitledNotepad
-            _dlgspec.menu_select("Format -> Font")
-            font = _dlgspec.child_window(name="Font")
-
-            with self.assertRaises(findbestmatch.MatchError):
-                font.child_window(best_match="ListBox0", depth=1).wrapper_object()
-            font.child_window(best_match="ListBox0", depth=2).wrapper_object()
-
     def test_print_control_identifiers(self):
         """Make sure print_control_identifiers() doesn't crash"""
         self.dlgspec.print_control_identifiers()
@@ -1216,6 +1203,30 @@ class WindowSpecificationTestCases(unittest.TestCase):
         windows = findwindows.find_elements(name_re="Untitled - Notepad")
         self.assertTrue(len(windows) >= 1)
 
+
+if UIA_support:
+    class UIAWindowSpecificationTestCases(unittest.TestCase):
+        """Unit tests for the application.Application class with UIA backend"""
+
+        def setUp(self):
+            """Set some data and ensure the application is in the state we want"""
+            Timings.defaults()
+            self.app = Application(backend="uia").start("Notepad")
+            self.dlgspec = self.app.UntitledNotepad
+
+        def tearDown(self):
+            """Close the application after tests"""
+            self.app.kill()
+
+        def test_child_window_depth(self):
+            """Test that child_window() with depth works correctly"""
+            # TODO fix same elements at different tree levels on win32 backend
+            self.dlgspec.menu_select("Format -> Font")
+            font = self.dlgspec.child_window(name="Font")
+
+            with self.assertRaises(findbestmatch.MatchError):
+                font.child_window(best_match="ListBox0", depth=1).wrapper_object()
+            font.child_window(best_match="ListBox0", depth=2).wrapper_object()
 
 class WaitUntilDecoratorTests(unittest.TestCase):
     """Unit tests for always_wait_until and always_wait_until_passes decorators"""


### PR DESCRIPTION
Changed `print_control_identifiers` behavior.
Result of `element.descendants(depth=1)` already was equal to `element.children()`, test `test_depth_level_one_descendants`

resolve #699 