### PR TITLE
Add workaround to fix set_focus() failure on UIA (call win32 in this case)

### DIFF
--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -410,16 +410,7 @@ class BaseWrapper(object):
         a top level window already!)
         """
         if not ("top_level_parent" in self._cache.keys()):
-            parent = self.parent()
-
-            if parent:
-                if self.parent() == self.root():
-                    self._cache["top_level_parent"] = self
-                else:
-                    return self.parent().top_level_parent()
-            else:
-                self._cache["top_level_parent"] = self
-
+            self._cache["top_level_parent"] = self.backend.generic_wrapper_class(self.element_info.top_level_parent)
         return self._cache["top_level_parent"]
 
     #-----------------------------------------------------------

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -409,7 +409,10 @@ class UIAWrapper(WinBaseWrapper):
             pass
         try:
             self.element_info.element.SetFocus()
-            if self.element_info != UIAElementInfo.get_active():
+
+            # SetFocus() can return S_OK even if the element isn't focused actually
+            active_element = UIAElementInfo.get_active()
+            if self.element_info != active_element and self.element_info != active_element.top_level_parent:
                 if self.handle:
                     warnings.warn("Failed to set focus on element, trying win32 backend", RuntimeWarning)
                     HwndWrapper(self.element_info).set_focus()

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -414,18 +414,18 @@ class UIAWrapper(WinBaseWrapper):
                     warnings.warn("Failed to set focus on element, trying win32 backend", RuntimeWarning)
                     HwndWrapper(self.element_info).set_focus()
                 else:
-                    warnings.warn("The window has not been focused because UIA SetFocus() failed "
+                    warnings.warn("The element has not been focused because UIA SetFocus() failed "
                                   "and we can't use win32 backend instead because "
-                                  "the window doesn't have native handle", RuntimeWarning)
+                                  "the element doesn't have native handle", RuntimeWarning)
         except comtypes.COMError as exc:
             if self.handle:
                 warnings.warn("Failed to set focus on element due to COMError: {}, "
                               "trying win32 backend".format(exc), RuntimeWarning)
                 HwndWrapper(self.element_info).set_focus()
             else:
-                warnings.warn("The window has not been focused due to COMError: {} "
+                warnings.warn("The element has not been focused due to COMError: {}, "
                               "and we can't use win32 backend instead because "
-                              "the window doesn't have native handle".format(exc), RuntimeWarning)
+                              "the element doesn't have native handle".format(exc), RuntimeWarning)
 
         return self
 

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -115,6 +115,26 @@ class ElementInfo(object):
         """Return the parent of the element"""
         raise NotImplementedError()
 
+    @property
+    def top_level_parent(self):
+        """
+        Return the top level window of this element
+
+        The TopLevel parent is different from the parent in that the parent
+        is the element that owns this element - but it may not be a dialog/main
+        window. For example most Comboboxes have an Edit. The ComboBox is the
+        parent of the Edit control.
+
+        This will always return a valid window element (if the control has
+        no top level parent then the control itself is returned - as it is
+        a top level window already!)
+        """
+        parent = self.parent
+        if parent and parent != self.__class__():
+            return parent.top_level_parent
+        else:
+            return self
+
     def children(self, **kwargs):
         """Return children of the element"""
         raise NotImplementedError()


### PR DESCRIPTION
Sometimes set_focus() on UIA backend failed without any exceptions (for example, on Wireshark)