### PR TITLE
Change UIA backend to use RawViewWalker instead of FindAll

### DIFF
--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -613,7 +613,7 @@ class WindowSpecification(object):
         this_ctrl = self.__resolve_control(self.criteria)[-1]
 
         # Create a list of this control and all its descendants
-        all_ctrls = [this_ctrl, ] + this_ctrl.descendants()
+        all_ctrls = [this_ctrl, ] + this_ctrl.descendants(depth=depth)
 
         # Create a list of all visible text controls
         txt_ctrls = [ctrl for ctrl in all_ctrls if ctrl.can_be_label and ctrl.is_visible() and ctrl.window_text()]

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -31,6 +31,7 @@
 
 """Interface for classes which should deal with different backend elements"""
 
+from six import integer_types
 
 class ElementInfo(object):
 
@@ -138,7 +139,7 @@ class ElementInfo(object):
     def filter_with_depth(elements, root, depth):
         """Return filtered elements with particular depth level relative to the root"""
         if depth is not None:
-                if isinstance(depth, int) and depth > 0:
+                if isinstance(depth, integer_types) and depth > 0:
                     return [element for element in elements if element.has_depth(root, depth)]
                 else:
                     raise Exception("Depth must be natural number")

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -1613,7 +1613,7 @@ if UIA_support:
             """Test selecting a WPF menu item by index"""
             path = "#0->#1->#1"  # "File->Close->Later"
             self.dlg.menu_select(path)
-            label = self.dlg.MenuLaterClickLabel.wrapper_object()
+            label = self.dlg.MenuLaterClickStatic.wrapper_object()
             self.assertEqual(label.window_text(), u"MenuLaterClick")
 
             # Non-existing paths
@@ -1626,7 +1626,7 @@ if UIA_support:
             """Test selecting a WPF menu item by exact text match"""
             path = "File->Close->Later"
             self.dlg.menu_select(path, True)
-            label = self.dlg.MenuLaterClickLabel.wrapper_object()
+            label = self.dlg.MenuLaterClickStatic.wrapper_object()
             self.assertEqual(label.window_text(), u"MenuLaterClick")
 
             # A non-exact menu name
@@ -1637,14 +1637,14 @@ if UIA_support:
             """Test selecting a WPF menu item by best match text"""
             path = "file-> close -> later"
             self.dlg.menu_select(path, False)
-            label = self.dlg.MenuLaterClickLabel.wrapper_object()
+            label = self.dlg.MenuLaterClickStatic.wrapper_object()
             self.assertEqual(label.window_text(), u"MenuLaterClick")
 
         def test_menu_by_mixed_match(self):
             """Test selecting a WPF menu item by a path with mixed specifiers"""
             path = "file-> #1 -> later"
             self.dlg.menu_select(path, False)
-            label = self.dlg.MenuLaterClickLabel.wrapper_object()
+            label = self.dlg.MenuLaterClickStatic.wrapper_object()
             self.assertEqual(label.window_text(), u"MenuLaterClick")
 
             # Bad specifiers

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -73,17 +73,11 @@ if UIA_support:
         def test_issue_296(self):
             """Test handling of disappered descendants"""
             wrp = self.dlg.wrapper_object()
-            orig = uia_defs.IUIA().raw_tree_walker.GetFirstChildElement
-            uia_defs.IUIA().raw_tree_walker.GetFirstChildElement = mock.Mock(
-                side_effect=ValueError("Mocked value error"),
-                return_value=[])  # empty list
-            self.assertEqual([], wrp.descendants())
-            exception_err = comtypes.COMError(-2147220991, "Mocked COM error", ())
-            uia_defs.IUIA().raw_tree_walker.GetFirstChildElement = mock.Mock(
-                side_effect=exception_err,
-                return_value=[])  # empty list
-            self.assertEqual([], wrp.descendants())
-            uia_defs.IUIA().raw_tree_walker.GetFirstChildElement = orig  # restore the original method
+            with mock.patch.object(uia_defs.IUIA().raw_tree_walker, 'GetFirstChildElement') as mock_get_first_child:
+                mock_get_first_child.side_effect = ValueError("Mocked value error")
+                self.assertEqual([], wrp.descendants())
+                mock_get_first_child.side_effect = comtypes.COMError(-2147220991, "Mocked COM error", ())
+                self.assertEqual([], wrp.descendants())
 
         def test_issue_278(self):
             """Test that statement menu = app.MainWindow.Menu works for 'uia' backend"""

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -73,15 +73,17 @@ if UIA_support:
         def test_issue_296(self):
             """Test handling of disappered descendants"""
             wrp = self.dlg.wrapper_object()
-            orig = wrp.element_info._element.FindAll
-            wrp.element_info._element.FindAll = mock.Mock(side_effect=ValueError("Mocked value error"),
-                                                          return_value=[])  # empty list
+            orig = uia_defs.IUIA().raw_tree_walker.GetFirstChildElement
+            uia_defs.IUIA().raw_tree_walker.GetFirstChildElement = mock.Mock(
+                side_effect=ValueError("Mocked value error"),
+                return_value=[])  # empty list
             self.assertEqual([], wrp.descendants())
             exception_err = comtypes.COMError(-2147220991, "Mocked COM error", ())
-            wrp.element_info._element.FindAll = mock.Mock(side_effect=exception_err,
-                                                          return_value=[])  # empty list
+            uia_defs.IUIA().raw_tree_walker.GetFirstChildElement = mock.Mock(
+                side_effect=exception_err,
+                return_value=[])  # empty list
             self.assertEqual([], wrp.descendants())
-            wrp.element_info._element.FindAll = orig  # restore the original method
+            uia_defs.IUIA().raw_tree_walker.GetFirstChildElement = orig  # restore the original method
 
         def test_issue_278(self):
             """Test that statement menu = app.MainWindow.Menu works for 'uia' backend"""

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -79,6 +79,26 @@ class IUIA(object):
             self.known_control_types[ctrl_type] = type_id
             self.known_control_type_ids[type_id] = ctrl_type
 
+    def is_element_satisfies_criterias(self, element, process=None, class_name=None, name=None, control_type=None,
+                                       content_only=None):
+        is_appropriate_control_type = True
+        if control_type:
+            if isinstance(control_type, six.string_types):
+                is_appropriate_control_type = element.CurrentControlType == self.known_control_types[control_type]
+            elif not isinstance(control_type, int):
+                raise TypeError('control_type must be string or integer')
+            else:
+                is_appropriate_control_type = element.CurrentControlType == control_type
+
+        def check_condition(criteria, prop):
+            return criteria is None or criteria and prop == criteria
+
+        return check_condition(process, element.CurrentProcessId) \
+            and check_condition(class_name, element.CurrentClassName) \
+            and check_condition(name, element.CurrentName) \
+            and is_appropriate_control_type \
+            and (content_only is None or isinstance(content_only, bool) and element.CurrentIsContentElement == content_only)
+
     def build_condition(self, process=None, class_name=None, name=None, control_type=None,
                         content_only=None):
         """Build UIA filtering conditions"""

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -62,6 +62,7 @@ class IUIA(object):
                 'subtree': self.UIA_dll.TreeScope_Subtree,
                 }
         self.root = self.iuia.GetRootElement()
+        self.raw_tree_walker = self.iuia.CreateTreeWalker(self.true_condition)
 
         self.get_focused_element = self.iuia.GetFocusedElement
 
@@ -80,7 +81,7 @@ class IUIA(object):
             self.known_control_type_ids[type_id] = ctrl_type
 
     def is_element_satisfies_criterias(self, element, process=None, class_name=None, name=None, control_type=None,
-                                       content_only=None):
+                                       content_only=None, **kwargs):
         is_appropriate_control_type = True
         if control_type:
             if isinstance(control_type, six.string_types):

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -80,26 +80,6 @@ class IUIA(object):
             self.known_control_types[ctrl_type] = type_id
             self.known_control_type_ids[type_id] = ctrl_type
 
-    def is_element_satisfies_criterias(self, element, process=None, class_name=None, name=None, control_type=None,
-                                       content_only=None, **kwargs):
-        is_appropriate_control_type = True
-        if control_type:
-            if isinstance(control_type, six.string_types):
-                is_appropriate_control_type = element.CurrentControlType == self.known_control_types[control_type]
-            elif not isinstance(control_type, int):
-                raise TypeError('control_type must be string or integer')
-            else:
-                is_appropriate_control_type = element.CurrentControlType == control_type
-
-        def check_condition(criteria, prop):
-            return criteria is None or criteria and prop == criteria
-
-        return check_condition(process, element.CurrentProcessId) \
-            and check_condition(class_name, element.CurrentClassName) \
-            and check_condition(name, element.CurrentName) \
-            and is_appropriate_control_type \
-            and (content_only is None or isinstance(content_only, bool) and element.CurrentIsContentElement == content_only)
-
     def build_condition(self, process=None, class_name=None, name=None, control_type=None,
                         content_only=None):
         """Build UIA filtering conditions"""

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -62,7 +62,7 @@ class IUIA(object):
                 'subtree': self.UIA_dll.TreeScope_Subtree,
                 }
         self.root = self.iuia.GetRootElement()
-        self.raw_tree_walker = self.iuia.CreateTreeWalker(self.true_condition)
+        self.raw_tree_walker = self.iuia.RawViewWalker
 
         self.get_focused_element = self.iuia.GetFocusedElement
 

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -80,38 +80,39 @@ class IUIA(object):
             self.known_control_types[ctrl_type] = type_id
             self.known_control_type_ids[type_id] = ctrl_type
 
-    def build_condition(self, process=None, class_name=None, name=None, control_type=None,
-                        content_only=None):
-        """Build UIA filtering conditions"""
-        conditions = []
-        if process:
-            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ProcessIdPropertyId, process))
-
-        if class_name:
-            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ClassNamePropertyId, class_name))
-
-        if control_type:
-            if isinstance(control_type, six.string_types):
-                control_type = self.known_control_types[control_type]
-            elif not isinstance(control_type, int):
-                raise TypeError('control_type must be string or integer')
-            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ControlTypePropertyId, control_type))
-
-        if name:
-            # TODO: CreatePropertyConditionEx with PropertyConditionFlags_IgnoreCase
-            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_NamePropertyId, name))
-
-        if isinstance(content_only, bool):
-            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_IsContentElementPropertyId,
-                                                                content_only))
-
-        if len(conditions) > 1:
-            return self.iuia.CreateAndConditionFromArray(conditions)
-
-        if len(conditions) == 1:
-            return conditions[0]
-
-        return self.true_condition
+    # TODO add parameter to use FindAll instead of RawTreeWalker and uncomment
+    # def build_condition(self, process=None, class_name=None, name=None, control_type=None,
+    #                     content_only=None):
+    #     """Build UIA filtering conditions"""
+    #     conditions = []
+    #     if process:
+    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ProcessIdPropertyId, process))
+    #
+    #     if class_name:
+    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ClassNamePropertyId, class_name))
+    #
+    #     if control_type:
+    #         if isinstance(control_type, six.string_types):
+    #             control_type = self.known_control_types[control_type]
+    #         elif not isinstance(control_type, int):
+    #             raise TypeError('control_type must be string or integer')
+    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ControlTypePropertyId, control_type))
+    #
+    #     if name:
+    #         # TODO: CreatePropertyConditionEx with PropertyConditionFlags_IgnoreCase
+    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_NamePropertyId, name))
+    #
+    #     if isinstance(content_only, bool):
+    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_IsContentElementPropertyId,
+    #                                                             content_only))
+    #
+    #     if len(conditions) > 1:
+    #         return self.iuia.CreateAndConditionFromArray(conditions)
+    #
+    #     if len(conditions) == 1:
+    #         return conditions[0]
+    #
+    #     return self.true_condition
 
 # Build a list of named constants that identify Microsoft UI Automation
 # control patterns and their appropriate comtypes classes

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -280,6 +280,16 @@ class UIAElementInfo(ElementInfo):
         else:
             return None
 
+    def _get_elements(self, tree_scope, cond=IUIA().true_condition, cache_enable=False):
+        """Find all elements according to the given tree scope and conditions"""
+        try:
+            ptrs_array = self._element.FindAll(tree_scope, cond)
+            return elements_from_uia_array(ptrs_array, cache_enable)
+        except(COMError, ValueError) as e:
+            print(e)
+            ActionLogger().log("COM error: can't get elements")
+            return []
+
     def _iter_children_raw(self):
         """Return a generator of only immediate children of the element"""
         try:

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -302,6 +302,17 @@ class UIAElementInfo(ElementInfo):
         else:
             return None
 
+    # TODO add parameter to use FindAll instead of RawTreeWalker and uncomment
+    # def _get_elements(self, tree_scope, cond=IUIA().true_condition, cache_enable=False):
+    #     """Find all elements according to the given tree scope and conditions"""
+    #     try:
+    #         ptrs_array = self._element.FindAll(tree_scope, cond)
+    #         return elements_from_uia_array(ptrs_array, cache_enable)
+    #     except(COMError, ValueError) as e:
+    #         print(e)
+    #         ActionLogger().log("COM error: can't get elements")
+    #         return []
+
     def _iter_children_raw(self):
         """Return a generator of only immediate children of the element"""
         try:
@@ -328,7 +339,7 @@ class UIAElementInfo(ElementInfo):
         cache_enable = kwargs.pop('cache_enable', False)
         depth = kwargs.pop("depth", None)
         if not isinstance(depth, (integer_types, type(None))) or isinstance(depth, integer_types) and depth < 0:
-            raise Exception("Depth must be integer")
+            raise Exception("Depth must be an integer")
 
         if depth == 0:
             return

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -326,7 +326,9 @@ class UIAElementInfo(ElementInfo):
         """
         cache_enable = kwargs.pop('cache_enable', False)
         depth = kwargs.pop('depth', None)
-
+        if not isinstance(depth, (int, type(None))) or isinstance(depth, int) and depth <= 0:
+            raise Exception("Depth must be natural number")
+            
         tree_walker = IUIA().iuia.CreateTreeWalker(IUIA().true_condition)
         elements = []
 

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -295,9 +295,9 @@ class UIAElementInfo(ElementInfo):
          * **kwargs** is a criteria to reduce a list by process,
            class_name, control_type, content_only and/or title.
         """
-        cache_enable = kwargs.pop('cache_enable', False)
-        cond = IUIA().build_condition(**kwargs)
-        return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
+
+        elements = [elem for elem in self.iter_children(**kwargs)]
+        return elements
 
     def iter_children(self, **kwargs):
         """Return a generator of only immediate children of the element
@@ -305,11 +305,12 @@ class UIAElementInfo(ElementInfo):
          * **kwargs** is a criteria to reduce a list by process,
            class_name, control_type, content_only and/or title.
         """
+        cache_enable = kwargs.pop('cache_enable', False)
         cond = IUIA().build_condition(**kwargs)
         tree_walker = IUIA().iuia.CreateTreeWalker(cond)
         element = tree_walker.GetFirstChildElement(self._element)
         while element:
-            yield UIAElementInfo(element)
+            yield UIAElementInfo(element, cache_enable)
             element = tree_walker.GetNextSiblingElement(element)
 
     def descendants(self, **kwargs):

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -307,12 +307,12 @@ class UIAElementInfo(ElementInfo):
            class_name, control_type, content_only and/or title.
         """
         cache_enable = kwargs.pop('cache_enable', False)
-        cond = IUIA().build_condition(**kwargs)
-        tree_walker = IUIA().iuia.CreateTreeWalker(cond)
+        tree_walker = IUIA().iuia.CreateTreeWalker(IUIA().true_condition)
         try:
             element = tree_walker.GetFirstChildElement(self._element)
             while element:
-                yield UIAElementInfo(element, cache_enable)
+                if IUIA().is_element_satisfies_criterias(element, **kwargs):
+                    yield UIAElementInfo(element, cache_enable)
                 element = tree_walker.GetNextSiblingElement(element)
         except COMError as e:
             print(e)
@@ -326,8 +326,8 @@ class UIAElementInfo(ElementInfo):
         """
         cache_enable = kwargs.pop('cache_enable', False)
         depth = kwargs.pop('depth', None)
-        cond = IUIA().build_condition(**kwargs)
-        tree_walker = IUIA().iuia.CreateTreeWalker(cond)
+
+        tree_walker = IUIA().iuia.CreateTreeWalker(IUIA().true_condition)
         elements = []
 
         def traverse(current_root_element, current_depth=1):
@@ -336,7 +336,8 @@ class UIAElementInfo(ElementInfo):
             try:
                 element = tree_walker.GetFirstChildElement(current_root_element)
                 while element:
-                    elements.append(UIAElementInfo(element, cache_enable))
+                    if IUIA().is_element_satisfies_criterias(element, **kwargs):
+                        elements.append(UIAElementInfo(element, cache_enable))
                     traverse(element, current_depth+1)
                     element = tree_walker.GetNextSiblingElement(element)
             except COMError as e:

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -42,7 +42,6 @@ from .uia_defines import get_elem_interface
 from pywinauto.handleprops import dumpwindow, controlid
 from pywinauto.element_info import ElementInfo
 from .win32structures import RECT
-from pywinauto.actionlogger import ActionLogger
 
 
 def elements_from_uia_array(ptrs, cache_enable=False):
@@ -56,14 +55,14 @@ def elements_from_uia_array(ptrs, cache_enable=False):
     return elements
 
 
-def is_element_satisfies_criteria(element, process=None, class_name=None, name=None, control_type=None,
-                                  content_only=None, **kwargs):
-    """Check if element satisfy filter criteria"""
+def is_element_satisfying_criteria(element, process=None, class_name=None, name=None, control_type=None,
+                                   content_only=None, **kwargs):
+    """Check if element satisfies filter criteria"""
     is_appropriate_control_type = True
     if control_type:
         if isinstance(control_type, string_types):
             is_appropriate_control_type = element.CurrentControlType == IUIA().known_control_types[control_type]
-        elif not isinstance(control_type, int):
+        elif not isinstance(control_type, integer_types):
             raise TypeError('control_type must be string or integer')
         else:
             is_appropriate_control_type = element.CurrentControlType == control_type
@@ -303,16 +302,6 @@ class UIAElementInfo(ElementInfo):
         else:
             return None
 
-    # def _get_elements(self, tree_scope, cond=IUIA().true_condition, cache_enable=False):
-    #     """Find all elements according to the given tree scope and conditions"""
-    #     try:
-    #         ptrs_array = self._element.FindAll(tree_scope, cond)
-    #         return elements_from_uia_array(ptrs_array, cache_enable)
-    #     except(COMError, ValueError) as e:
-    #         print(e)
-    #         ActionLogger().log("COM error: can't get elements")
-    #         return []
-
     def _iter_children_raw(self):
         """Return a generator of only immediate children of the element"""
         try:
@@ -331,25 +320,25 @@ class UIAElementInfo(ElementInfo):
         """
         cache_enable = kwargs.pop('cache_enable', False)
         for element in self._iter_children_raw():
-            if is_element_satisfies_criteria(element, **kwargs):
+            if is_element_satisfying_criteria(element, **kwargs):
                 yield UIAElementInfo(element, cache_enable)
 
     def iter_descendants(self, **kwargs):
         """Iterate over descendants of the element"""
         cache_enable = kwargs.pop('cache_enable', False)
         depth = kwargs.pop("depth", None)
-        if not isinstance(depth, (int, type(None))) or isinstance(depth, int) and depth < 0:
-            raise Exception("Depth must be natural number")
+        if not isinstance(depth, (integer_types, type(None))) or isinstance(depth, integer_types) and depth < 0:
+            raise Exception("Depth must be integer")
 
         if depth == 0:
             return
         for child in self._iter_children_raw():
-            if is_element_satisfies_criteria(child, **kwargs):
+            if is_element_satisfying_criteria(child, **kwargs):
                 yield UIAElementInfo(child, cache_enable)
             if depth is not None:
                 kwargs["depth"] = depth - 1
             for c in UIAElementInfo(child, cache_enable).iter_descendants(**kwargs):
-                if is_element_satisfies_criteria(c._element, **kwargs):
+                if is_element_satisfying_criteria(c._element, **kwargs):
                     yield c
 
     def children(self, **kwargs):


### PR DESCRIPTION
Methods `children()` and `descendants()` of the UIAElementInfo changed to use `IUIAutomation::RawViewWalker` instead of `IUIAutomationElement::FindAll`.

This allows to find more elements than FindAll returns (for example, solves the problem mentioned in #644)

Related issues #644 #696 