### PR TITLE
Optional use of RawViewWalker inside the UIA backend

### DIFF
--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -166,6 +166,22 @@ class ElementInfo(object):
         else:
             return elements
 
+    @staticmethod
+    def get_descendants_with_depth(elem, depth=None, **kwargs):
+        def traverse_tree(root, output_list, **kwargs):
+            depth = kwargs.pop("depth", None)
+            if depth == 0:
+                return
+            for child in root.children(**kwargs):
+                output_list.append(child)
+                if depth is not None:
+                    kwargs["depth"] = depth - 1
+                traverse_tree(child, output_list, **kwargs)
+
+        descendants = []
+        traverse_tree(elem, descendants, depth=depth, **kwargs)
+        return descendants
+
     def descendants(self, **kwargs):
         """Return descendants of the element"""
         raise NotImplementedError()

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -166,8 +166,7 @@ class ElementInfo(object):
         else:
             return elements
 
-    @staticmethod
-    def get_descendants_with_depth(elem, depth=None, **kwargs):
+    def get_descendants_with_depth(self, depth=None, **kwargs):
         """Return a list of all descendant children of the element with the specified depth"""
         descendants = []
 
@@ -179,7 +178,7 @@ class ElementInfo(object):
                 next_depth = None if depth is None else depth - 1
                 walk_the_tree(child, next_depth, **kwargs)
 
-        walk_the_tree(elem, depth, **kwargs)
+        walk_the_tree(self, depth, **kwargs)
         return descendants
 
     def descendants(self, **kwargs):

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -168,18 +168,17 @@ class ElementInfo(object):
 
     @staticmethod
     def get_descendants_with_depth(elem, depth=None, **kwargs):
-        def traverse_tree(root, output_list, **kwargs):
-            depth = kwargs.pop("depth", None)
+        """Return a list of all descendant children of the element with the specified depth"""
+        def traverse_tree(root, output_list, depth, **kwargs):
             if depth == 0:
                 return
             for child in root.children(**kwargs):
                 output_list.append(child)
-                if depth is not None:
-                    kwargs["depth"] = depth - 1
-                traverse_tree(child, output_list, **kwargs)
+                next_depth = None if depth is None else depth - 1
+                traverse_tree(child, output_list, next_depth, **kwargs)
 
         descendants = []
-        traverse_tree(elem, descendants, depth=depth, **kwargs)
+        traverse_tree(elem, descendants, depth, **kwargs)
         return descendants
 
     def descendants(self, **kwargs):

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -169,16 +169,17 @@ class ElementInfo(object):
     @staticmethod
     def get_descendants_with_depth(elem, depth=None, **kwargs):
         """Return a list of all descendant children of the element with the specified depth"""
-        def traverse_tree(root, output_list, depth, **kwargs):
+        descendants = []
+
+        def walk_the_tree(root, depth, **kwargs):
             if depth == 0:
                 return
             for child in root.children(**kwargs):
-                output_list.append(child)
+                descendants.append(child)
                 next_depth = None if depth is None else depth - 1
-                traverse_tree(child, output_list, next_depth, **kwargs)
+                walk_the_tree(child, next_depth, **kwargs)
 
-        descendants = []
-        traverse_tree(elem, descendants, depth, **kwargs)
+        walk_the_tree(elem, depth, **kwargs)
         return descendants
 
     def descendants(self, **kwargs):

--- a/pywinauto/unittests/test_uia_element_info.py
+++ b/pywinauto/unittests/test_uia_element_info.py
@@ -113,12 +113,12 @@ if UIA_support:
         """Unit tests for the UIAElementInfo class with enabled RawViewWalker implementation"""
 
         def setUp(self):
-            self.assertEqual(UIAElementInfo.use_raw_view_walker, False)
+            self.default_use_raw_view_walker = UIAElementInfo.use_raw_view_walker
             UIAElementInfo.use_raw_view_walker = True
             super(UIAElementInfoRawViewWalkerTests, self).setUp()
 
         def tearDown(self):
-            UIAElementInfo.use_raw_view_walker = False
+            UIAElementInfo.use_raw_view_walker = self.default_use_raw_view_walker
             super(UIAElementInfoRawViewWalkerTests, self).tearDown()
 
         def test_use_findall_children(self):

--- a/pywinauto/unittests/test_uia_element_info.py
+++ b/pywinauto/unittests/test_uia_element_info.py
@@ -108,59 +108,62 @@ if UIA_support:
             self.assertSequenceEqual(self.ctrl.descendants(depth=3), descendants)
 
 
-    class UIAElementInfoUsePropertyConditionsTests(UIAElementInfoTests):
+    class UIAElementInfoRawViewWalkerTests(UIAElementInfoTests):
+
+        """Unit tests for the UIAElementInfo class with enabled RawViewWalker implementation"""
+
         def setUp(self):
-            self.assertEqual(UIAElementInfo.use_property_conditions, False)
-            UIAElementInfo.use_property_conditions = True
-            super(UIAElementInfoUsePropertyConditionsTests, self).setUp()
+            self.assertEqual(UIAElementInfo.use_raw_view_walker, False)
+            UIAElementInfo.use_raw_view_walker = True
+            super(UIAElementInfoRawViewWalkerTests, self).setUp()
 
         def tearDown(self):
-            UIAElementInfo.use_property_conditions = False
-            super(UIAElementInfoUsePropertyConditionsTests, self).tearDown()
+            UIAElementInfo.use_raw_view_walker = False
+            super(UIAElementInfoRawViewWalkerTests, self).tearDown()
 
-        def test_use_property_conditions_children(self):
-            """Test use FindAll option for children method"""
+        def test_use_findall_children(self):
+            """Test use FindAll inside children method"""
             with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
-                UIAElementInfo.use_property_conditions = True
+                UIAElementInfo.use_raw_view_walker = False
                 self.ctrl.children()
                 self.assertEqual(mock_findall.call_count, 1)
 
-                UIAElementInfo.use_property_conditions = False
+                UIAElementInfo.use_raw_view_walker = True
                 self.ctrl.children()
                 self.assertEqual(mock_findall.call_count, 1)
 
-        def test_use_property_conditions_descendants(self):
-            """Test use FindAll option for descendants method"""
+        def test_use_findall_descendants(self):
+            """Test use FindAll inside descendants method"""
             with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
-                UIAElementInfo.use_property_conditions = True
+                UIAElementInfo.use_raw_view_walker = False
                 self.ctrl.descendants(depth=1)
                 self.assertEqual(mock_findall.call_count, 1)
 
-                UIAElementInfo.use_property_conditions = False
+                UIAElementInfo.use_raw_view_walker = True
                 self.ctrl.descendants(depth=1)
                 self.assertEqual(mock_findall.call_count, 1)
 
-        def test_use_property_conditions_iter_children(self):
-            """Test use CreateTreeWalker option for iter_children method"""
-            with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_walker:
-                UIAElementInfo.use_property_conditions = True
+        def test_use_create_tree_walker_iter_children(self):
+            """Test use CreateTreeWalker inside iter_children method"""
+            with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_create:
+                UIAElementInfo.use_raw_view_walker = False
                 next(self.ctrl.iter_children())
-                self.assertEqual(mock_walker.call_count, 1)
+                self.assertEqual(mock_create.call_count, 1)
 
-                UIAElementInfo.use_property_conditions = False
+                UIAElementInfo.use_raw_view_walker = True
                 next(self.ctrl.iter_children())
-                self.assertEqual(mock_walker.call_count, 1)
+                self.assertEqual(mock_create.call_count, 1)
 
-        def test_use_property_conditions_iter_descendants(self):
-            """Test use CreateTreeWalker option for iter_descendants method"""
-            with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_walker:
-                UIAElementInfo.use_property_conditions = True
+        def test_use_create_tree_walker_iter_descendants(self):
+            """Test use CreateTreeWalker inside iter_descendants method"""
+            with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_create:
+                UIAElementInfo.use_raw_view_walker = False
                 next(self.ctrl.iter_descendants(depth=3))
-                self.assertEqual(mock_walker.call_count, 1)
+                self.assertEqual(mock_create.call_count, 1)
 
-                UIAElementInfo.use_property_conditions = False
+                UIAElementInfo.use_raw_view_walker = True
                 next(self.ctrl.iter_descendants(depth=3))
-                self.assertEqual(mock_walker.call_count, 1)
+                self.assertEqual(mock_create.call_count, 1)
 
 if __name__ == "__main__":
     if UIA_support:

--- a/pywinauto/unittests/test_uia_element_info.py
+++ b/pywinauto/unittests/test_uia_element_info.py
@@ -107,56 +107,59 @@ if UIA_support:
             descendants = [desc for desc in self.ctrl.iter_descendants(depth=3)]
             self.assertSequenceEqual(self.ctrl.descendants(depth=3), descendants)
 
-        def test_use_property_conditions_children(self):
-            """Test use CondTreeWalker option for children method"""
-            with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
-                self.assertEqual(UIAElementInfo.use_property_conditions, False)
 
+    class UIAElementInfoUsePropertyConditionsTests(UIAElementInfoTests):
+        def setUp(self):
+            self.assertEqual(UIAElementInfo.use_property_conditions, False)
+            UIAElementInfo.use_property_conditions = True
+            super(UIAElementInfoUsePropertyConditionsTests, self).setUp()
+
+        def tearDown(self):
+            UIAElementInfo.use_property_conditions = False
+            super(UIAElementInfoUsePropertyConditionsTests, self).tearDown()
+
+        def test_use_property_conditions_children(self):
+            """Test use FindAll option for children method"""
+            with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
                 UIAElementInfo.use_property_conditions = True
-                self.assertEqual(len(self.ctrl.children()), 5)
+                self.ctrl.children()
                 self.assertEqual(mock_findall.call_count, 1)
 
                 UIAElementInfo.use_property_conditions = False
-                self.assertEqual(len(self.ctrl.children()), 5)
+                self.ctrl.children()
                 self.assertEqual(mock_findall.call_count, 1)
 
         def test_use_property_conditions_descendants(self):
-            """Test use CondTreeWalker option for descendants method"""
+            """Test use FindAll option for descendants method"""
             with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
-                self.assertEqual(UIAElementInfo.use_property_conditions, False)
-
                 UIAElementInfo.use_property_conditions = True
-                self.assertEqual(len(self.ctrl.descendants(depth=1)), 5)
+                self.ctrl.descendants(depth=1)
                 self.assertEqual(mock_findall.call_count, 1)
 
                 UIAElementInfo.use_property_conditions = False
-                self.assertEqual(len(self.ctrl.descendants(depth=1)), 5)
+                self.ctrl.descendants(depth=1)
                 self.assertEqual(mock_findall.call_count, 1)
 
         def test_use_property_conditions_iter_children(self):
-            """Test use CondTreeWalker option for iter_children method"""
+            """Test use CreateTreeWalker option for iter_children method"""
             with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_walker:
-                self.assertEqual(UIAElementInfo.use_property_conditions, False)
-
                 UIAElementInfo.use_property_conditions = True
-                self.assertSequenceEqual(self.ctrl.children(), list(self.ctrl.iter_children()))
+                next(self.ctrl.iter_children())
                 self.assertEqual(mock_walker.call_count, 1)
 
                 UIAElementInfo.use_property_conditions = False
-                self.assertSequenceEqual(self.ctrl.children(), list(self.ctrl.iter_children()))
+                next(self.ctrl.iter_children())
                 self.assertEqual(mock_walker.call_count, 1)
 
         def test_use_property_conditions_iter_descendants(self):
-            """Test use CondTreeWalker option for descendants method"""
+            """Test use CreateTreeWalker option for iter_descendants method"""
             with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_walker:
-                self.assertEqual(UIAElementInfo.use_property_conditions, False)
-
                 UIAElementInfo.use_property_conditions = True
-                self.assertSequenceEqual(self.ctrl.descendants(), list(self.ctrl.iter_descendants()))
+                next(self.ctrl.iter_descendants(depth=3))
                 self.assertEqual(mock_walker.call_count, 1)
 
                 UIAElementInfo.use_property_conditions = False
-                self.assertSequenceEqual(self.ctrl.descendants(), list(self.ctrl.iter_descendants()))
+                next(self.ctrl.iter_descendants(depth=3))
                 self.assertEqual(mock_walker.call_count, 1)
 
 if __name__ == "__main__":

--- a/pywinauto/unittests/test_uia_element_info.py
+++ b/pywinauto/unittests/test_uia_element_info.py
@@ -12,6 +12,7 @@ from pywinauto.timings import Timings  # noqa: E402
 
 if UIA_support:
     from pywinauto.windows.uia_element_info import UIAElementInfo
+    from pywinauto.windows.uia_defines import IUIA
 
 mfc_samples_folder = os.path.join(
     os.path.dirname(__file__), r"..\..\apps\WPF_samples")
@@ -106,31 +107,57 @@ if UIA_support:
             descendants = [desc for desc in self.ctrl.iter_descendants(depth=3)]
             self.assertSequenceEqual(self.ctrl.descendants(depth=3), descendants)
 
-        def test_use_findall_children(self):
-            """Test use FindAll option for children method"""
+        def test_use_property_conditions_children(self):
+            """Test use CondTreeWalker option for children method"""
             with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
-                self.assertEqual(UIAElementInfo.use_findall, False)
+                self.assertEqual(UIAElementInfo.use_property_conditions, False)
 
-                UIAElementInfo.use_findall = True
+                UIAElementInfo.use_property_conditions = True
                 self.assertEqual(len(self.ctrl.children()), 5)
                 self.assertEqual(mock_findall.call_count, 1)
 
-                UIAElementInfo.use_findall = False
+                UIAElementInfo.use_property_conditions = False
                 self.assertEqual(len(self.ctrl.children()), 5)
                 self.assertEqual(mock_findall.call_count, 1)
 
-        def test_use_findall_descendants(self):
-            """Test use FindAll option for descendants method"""
+        def test_use_property_conditions_descendants(self):
+            """Test use CondTreeWalker option for descendants method"""
             with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
-                self.assertEqual(UIAElementInfo.use_findall, False)
+                self.assertEqual(UIAElementInfo.use_property_conditions, False)
 
-                UIAElementInfo.use_findall = True
+                UIAElementInfo.use_property_conditions = True
                 self.assertEqual(len(self.ctrl.descendants(depth=1)), 5)
                 self.assertEqual(mock_findall.call_count, 1)
 
-                UIAElementInfo.use_findall = False
+                UIAElementInfo.use_property_conditions = False
                 self.assertEqual(len(self.ctrl.descendants(depth=1)), 5)
                 self.assertEqual(mock_findall.call_count, 1)
+
+        def test_use_property_conditions_iter_children(self):
+            """Test use CondTreeWalker option for iter_children method"""
+            with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_walker:
+                self.assertEqual(UIAElementInfo.use_property_conditions, False)
+
+                UIAElementInfo.use_property_conditions = True
+                self.assertSequenceEqual(self.ctrl.children(), list(self.ctrl.iter_children()))
+                self.assertEqual(mock_walker.call_count, 1)
+
+                UIAElementInfo.use_property_conditions = False
+                self.assertSequenceEqual(self.ctrl.children(), list(self.ctrl.iter_children()))
+                self.assertEqual(mock_walker.call_count, 1)
+
+        def test_use_property_conditions_iter_descendants(self):
+            """Test use CondTreeWalker option for descendants method"""
+            with mock.patch.object(IUIA().iuia, 'CreateTreeWalker', wraps=IUIA().iuia.CreateTreeWalker) as mock_walker:
+                self.assertEqual(UIAElementInfo.use_property_conditions, False)
+
+                UIAElementInfo.use_property_conditions = True
+                self.assertSequenceEqual(self.ctrl.descendants(), list(self.ctrl.iter_descendants()))
+                self.assertEqual(mock_walker.call_count, 1)
+
+                UIAElementInfo.use_property_conditions = False
+                self.assertSequenceEqual(self.ctrl.descendants(), list(self.ctrl.iter_descendants()))
+                self.assertEqual(mock_walker.call_count, 1)
 
 if __name__ == "__main__":
     if UIA_support:

--- a/pywinauto/unittests/test_uia_element_info.py
+++ b/pywinauto/unittests/test_uia_element_info.py
@@ -1,6 +1,7 @@
 import unittest
 import os
 import sys
+import mock
 
 sys.path.append(".")
 from pywinauto.windows.application import Application  # noqa: E402
@@ -104,6 +105,32 @@ if UIA_support:
             """Test whether descendant generator iterates over correct elements"""
             descendants = [desc for desc in self.ctrl.iter_descendants(depth=3)]
             self.assertSequenceEqual(self.ctrl.descendants(depth=3), descendants)
+
+        def test_use_findall_children(self):
+            """Test use FindAll option for children method"""
+            with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
+                self.assertEqual(UIAElementInfo.use_findall, False)
+
+                UIAElementInfo.use_findall = True
+                self.assertEqual(len(self.ctrl.children()), 5)
+                self.assertEqual(mock_findall.call_count, 1)
+
+                UIAElementInfo.use_findall = False
+                self.assertEqual(len(self.ctrl.children()), 5)
+                self.assertEqual(mock_findall.call_count, 1)
+
+        def test_use_findall_descendants(self):
+            """Test use FindAll option for descendants method"""
+            with mock.patch.object(self.ctrl._element, 'FindAll', wraps=self.ctrl._element.FindAll) as mock_findall:
+                self.assertEqual(UIAElementInfo.use_findall, False)
+
+                UIAElementInfo.use_findall = True
+                self.assertEqual(len(self.ctrl.descendants(depth=1)), 5)
+                self.assertEqual(mock_findall.call_count, 1)
+
+                UIAElementInfo.use_findall = False
+                self.assertEqual(len(self.ctrl.descendants(depth=1)), 5)
+                self.assertEqual(mock_findall.call_count, 1)
 
 if __name__ == "__main__":
     if UIA_support:

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -72,7 +72,7 @@ if UIA_support:
             self.app.kill()
 
         def test_issue_296(self):
-            """Test handling of disappered descendants"""
+            """Test handling of disappeared descendants"""
             wrp = self.dlg.wrapper_object()
             with mock.patch.object(wrp.element_info._element, 'FindAll') as mock_findall:
                 mock_findall.side_effect = ValueError("Mocked value error")
@@ -459,16 +459,16 @@ if UIA_support:
         """Unit tests for the UIAWrapper class with enabled RawViewWalker"""
 
         def setUp(self):
-            self.assertEqual(UIAElementInfo.use_raw_view_walker, False)
+            self.default_use_raw_view_walker = UIAElementInfo.use_raw_view_walker
             UIAElementInfo.use_raw_view_walker = True
             super(UIAWrapperRawViewWalkerTests, self).setUp()
 
         def tearDown(self):
-            UIAElementInfo.use_raw_view_walker = False
+            UIAElementInfo.use_raw_view_walker = self.default_use_raw_view_walker
             super(UIAWrapperRawViewWalkerTests, self).tearDown()
 
         def test_issue_296(self):
-            """Test handling of disappered descendants"""
+            """Test handling of disappeared descendants"""
             wrp = self.dlg.wrapper_object()
             with mock.patch.object(uia_defs.IUIA().raw_tree_walker, 'GetFirstChildElement') as mock_get_first_child:
                 mock_get_first_child.side_effect = ValueError("Mocked value error")

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -24,6 +24,7 @@ if UIA_support:
     import pywinauto.windows.uia_defines as uia_defs
     import pywinauto.controls.uia_controls as uia_ctls
     from pywinauto.controls.uiawrapper import UIAWrapper
+    from pywinauto.windows.uia_element_info import UIAElementInfo
 
 wpf_samples_folder = os.path.join(
     os.path.dirname(__file__), r"..\..\apps\WPF_samples")
@@ -73,10 +74,10 @@ if UIA_support:
         def test_issue_296(self):
             """Test handling of disappered descendants"""
             wrp = self.dlg.wrapper_object()
-            with mock.patch.object(uia_defs.IUIA().raw_tree_walker, 'GetFirstChildElement') as mock_get_first_child:
-                mock_get_first_child.side_effect = ValueError("Mocked value error")
+            with mock.patch.object(wrp.element_info._element, 'FindAll') as mock_findall:
+                mock_findall.side_effect = ValueError("Mocked value error")
                 self.assertEqual([], wrp.descendants())
-                mock_get_first_child.side_effect = comtypes.COMError(-2147220991, "Mocked COM error", ())
+                mock_findall.side_effect = comtypes.COMError(-2147220991, "Mocked COM error", ())
                 self.assertEqual([], wrp.descendants())
 
         def test_issue_278(self):
@@ -451,6 +452,29 @@ if UIA_support:
                 expected = (rect.width(), rect.height())
                 result = self.dlg.capture_as_image().size
                 self.assertEqual(expected, result)
+
+
+    class UIAWrapperRawViewWalkerTests(UIAWrapperTests):
+
+        """Unit tests for the UIAWrapper class with enabled RawViewWalker"""
+
+        def setUp(self):
+            self.assertEqual(UIAElementInfo.use_raw_view_walker, False)
+            UIAElementInfo.use_raw_view_walker = True
+            super(UIAWrapperRawViewWalkerTests, self).setUp()
+
+        def tearDown(self):
+            UIAElementInfo.use_raw_view_walker = False
+            super(UIAWrapperRawViewWalkerTests, self).tearDown()
+
+        def test_issue_296(self):
+            """Test handling of disappered descendants"""
+            wrp = self.dlg.wrapper_object()
+            with mock.patch.object(uia_defs.IUIA().raw_tree_walker, 'GetFirstChildElement') as mock_get_first_child:
+                mock_get_first_child.side_effect = ValueError("Mocked value error")
+                self.assertEqual([], wrp.descendants())
+                mock_get_first_child.side_effect = comtypes.COMError(-2147220991, "Mocked COM error", ())
+                self.assertEqual([], wrp.descendants())
 
 
     class UIAWrapperMouseTests(unittest.TestCase):

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -80,39 +80,39 @@ class IUIA(object):
             self.known_control_types[ctrl_type] = type_id
             self.known_control_type_ids[type_id] = ctrl_type
 
-    # TODO add parameter to use FindAll instead of RawTreeWalker and uncomment
-    # def build_condition(self, process=None, class_name=None, name=None, control_type=None,
-    #                     content_only=None):
-    #     """Build UIA filtering conditions"""
-    #     conditions = []
-    #     if process:
-    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ProcessIdPropertyId, process))
-    #
-    #     if class_name:
-    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ClassNamePropertyId, class_name))
-    #
-    #     if control_type:
-    #         if isinstance(control_type, six.string_types):
-    #             control_type = self.known_control_types[control_type]
-    #         elif not isinstance(control_type, int):
-    #             raise TypeError('control_type must be string or integer')
-    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ControlTypePropertyId, control_type))
-    #
-    #     if name:
-    #         # TODO: CreatePropertyConditionEx with PropertyConditionFlags_IgnoreCase
-    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_NamePropertyId, name))
-    #
-    #     if isinstance(content_only, bool):
-    #         conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_IsContentElementPropertyId,
-    #                                                             content_only))
-    #
-    #     if len(conditions) > 1:
-    #         return self.iuia.CreateAndConditionFromArray(conditions)
-    #
-    #     if len(conditions) == 1:
-    #         return conditions[0]
-    #
-    #     return self.true_condition
+    def build_condition(self, process=None, class_name=None, name=None, control_type=None,
+                        content_only=None):
+        """Build UIA filtering conditions"""
+        conditions = []
+        if process:
+            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ProcessIdPropertyId, process))
+
+        if class_name:
+            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ClassNamePropertyId, class_name))
+
+        if control_type:
+            if isinstance(control_type, six.string_types):
+                control_type = self.known_control_types[control_type]
+            elif not isinstance(control_type, int):
+                raise TypeError('control_type must be string or integer')
+            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ControlTypePropertyId, control_type))
+
+        if name:
+            # TODO: CreatePropertyConditionEx with PropertyConditionFlags_IgnoreCase
+            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_NamePropertyId, name))
+
+        if isinstance(content_only, bool):
+            conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_IsContentElementPropertyId,
+                                                                content_only))
+
+        if len(conditions) > 1:
+            return self.iuia.CreateAndConditionFromArray(conditions)
+
+        if len(conditions) == 1:
+            return conditions[0]
+
+        return self.true_condition
+
 
 # Build a list of named constants that identify Microsoft UI Automation
 # control patterns and their appropriate comtypes classes

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -96,7 +96,7 @@ class UIAElementInfo(ElementInfo):
         "top_level_only": ("depth", {True: 1, False: None}),
     }
 
-    use_findall = False
+    use_property_conditions = False
 
     def __init__(self, handle_or_elem=None, cache_enable=False):
         """
@@ -331,9 +331,17 @@ class UIAElementInfo(ElementInfo):
            class_name, control_type, content_only and/or title.
         """
         cache_enable = kwargs.pop('cache_enable', False)
-        for element in self._iter_children_raw():
-            if is_element_satisfying_criteria(element, **kwargs):
-                yield UIAElementInfo(element, cache_enable)
+        if UIAElementInfo.use_property_conditions:
+            cond = IUIA().build_condition(**kwargs)
+            tree_walker = IUIA().iuia.CreateTreeWalker(cond)
+            element = tree_walker.GetFirstChildElement(self._element)
+            while element:
+                yield UIAElementInfo(element)
+                element = tree_walker.GetNextSiblingElement(element)
+        else:
+            for element in self._iter_children_raw():
+                if is_element_satisfying_criteria(element, **kwargs):
+                    yield UIAElementInfo(element, cache_enable)
 
     def iter_descendants(self, **kwargs):
         """Iterate over descendants of the element"""
@@ -344,14 +352,22 @@ class UIAElementInfo(ElementInfo):
 
         if depth == 0:
             return
-        for child in self._iter_children_raw():
-            if is_element_satisfying_criteria(child, **kwargs):
-                yield UIAElementInfo(child, cache_enable)
-            if depth is not None:
-                kwargs["depth"] = depth - 1
-            for c in UIAElementInfo(child, cache_enable).iter_descendants(**kwargs):
-                if is_element_satisfying_criteria(c._element, **kwargs):
+        if UIAElementInfo.use_property_conditions:
+            for child in self.iter_children(**kwargs):
+                yield child
+                if depth is not None:
+                    kwargs["depth"] = depth - 1
+                for c in child.iter_descendants(**kwargs):
                     yield c
+        else:
+            for child in self._iter_children_raw():
+                if is_element_satisfying_criteria(child, **kwargs):
+                    yield UIAElementInfo(child, cache_enable)
+                if depth is not None:
+                    kwargs["depth"] = depth - 1
+                for c in UIAElementInfo(child, cache_enable).iter_descendants(**kwargs):
+                    if is_element_satisfying_criteria(c._element, **kwargs):
+                        yield c
 
     def children(self, **kwargs):
         """Return a list of only immediate children of the element
@@ -359,7 +375,7 @@ class UIAElementInfo(ElementInfo):
          * **kwargs** is a criteria to reduce a list by process,
            class_name, control_type, content_only and/or title.
         """
-        if UIAElementInfo.use_findall:
+        if UIAElementInfo.use_property_conditions:
             cache_enable = kwargs.pop('cache_enable', False)
             cond = IUIA().build_condition(**kwargs)
             return self._get_elements(IUIA().tree_scope["children"], cond, cache_enable)
@@ -372,7 +388,7 @@ class UIAElementInfo(ElementInfo):
          * **kwargs** is a criteria to reduce a list by process,
            class_name, control_type, content_only and/or title.
         """
-        if UIAElementInfo.use_findall:
+        if UIAElementInfo.use_property_conditions:
             cache_enable = kwargs.pop('cache_enable', False)
             depth = kwargs.pop('depth', None)
             cond = IUIA().build_condition(**kwargs)

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -96,6 +96,7 @@ class UIAElementInfo(ElementInfo):
     }
 
     use_raw_view_walker = False
+    """Enable/disable RawViewWalker-based implementation (can find more elements in some cases, but slow)"""
 
     def __init__(self, handle_or_elem=None, cache_enable=False):
         """

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -398,7 +398,7 @@ class UIAElementInfo(ElementInfo):
                 cond = IUIA().build_condition(**kwargs)
                 return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
             else:
-                return ElementInfo.get_descendants_with_depth(self, depth=depth, **kwargs)
+                return self.get_descendants_with_depth(self, depth=depth, **kwargs)
 
     @property
     def visible(self):

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -389,12 +389,13 @@ class UIAElementInfo(ElementInfo):
            class_name, control_type, content_only and/or title.
         """
         if UIAElementInfo.use_property_conditions:
-            cache_enable = kwargs.pop('cache_enable', False)
             depth = kwargs.pop('depth', None)
-            cond = IUIA().build_condition(**kwargs)
-            elements = self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
-            elements = ElementInfo.filter_with_depth(elements, self, depth)
-            return elements
+            if depth is None:
+                cache_enable = kwargs.pop('cache_enable', False)
+                cond = IUIA().build_condition(**kwargs)
+                return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
+            else:
+                return ElementInfo.get_descendants_with_depth(self, depth=depth, **kwargs)
         else:
             return list(self.iter_descendants(**kwargs))
 

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -42,7 +42,6 @@ from .uia_defines import get_elem_interface
 from pywinauto.handleprops import dumpwindow, controlid
 from pywinauto.element_info import ElementInfo
 from .win32structures import RECT
-from pywinauto.actionlogger import ActionLogger
 
 
 def elements_from_uia_array(ptrs, cache_enable=False):

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -397,7 +397,7 @@ class UIAElementInfo(ElementInfo):
                 cond = IUIA().build_condition(**kwargs)
                 return self._get_elements(IUIA().tree_scope["descendants"], cond, cache_enable)
             else:
-                return self.get_descendants_with_depth(self, depth=depth, **kwargs)
+                return self.get_descendants_with_depth(depth=depth, **kwargs)
 
     @property
     def visible(self):

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -310,8 +310,9 @@ class UIAElementInfo(ElementInfo):
         try:
             ptrs_array = self._element.FindAll(tree_scope, cond)
             return elements_from_uia_array(ptrs_array, cache_enable)
-        except(COMError, ValueError):
-            ActionLogger().log("COM error: can't get elements")
+        except(COMError, ValueError) as e:
+            warnings.warn("Can't get elements due to COM error: {}. "
+                          "Try to set pywinauto.windows.uia_element_info.UIAElementInfo.use_raw_view_walker = True".format(e), RuntimeWarning)
             return []
 
     def _iter_children_raw(self):


### PR DESCRIPTION
In addition to PR #1001 

Changes:
* Added static boolean variable `UIAElementInfo.use_raw_view_walker` to optionally use RawViewWalker based implementation (default value is `False`). 
* Improved performance of `children()` and `descendants()` called with non-empty `depth` parameter on UIA backend. 
Usage of slow `filter_with_depth` method replaced to multiple `children()` calls (I think it will be useful to make this change on other backends in the future).

Comparison of approaches:
||`UIAElementInfo.use_raw_view_walker=True`|`UIAElementInfo.use_raw_view_walker=False`|
|---|---|---|
|Pros|Can find more elements (for example, for `WpfApplication1.exe` shows 2 additional `Pane` elements)|Better performance in most cases|
|Cons|Slow with a large number of elements|Has occasional problems with some apps <br> (#644 #696)|

Performance comparison (Qt 5 app, window with 67 children elements, average tree depth 62):
|Code|FindAll/CreateTreeWalker <br> median time (seconds)| RawTreeWalker <br> median time (seconds)|
|---|---|---|
|children()|0.125|0.219|
|descendants()|3.549|59.453|
|descendants(depth=3)|0.521|0.937|
|descendants(depth=50)|4.874|43.048|
|list(dlg.iter_children())|0.165|0.241|
|list(dlg.iter_descendants())|6.913|59.817|
|list(dlg.iter_children(class_name="ToolBar"))|1.071|0.192|
|list(dlg.iter_descendants(class_name="ToolBar"))|1.059|6.098|


