### PR TITLE
Fixes for some flaky tests

### DIFF
--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -142,6 +142,7 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
         BST_INDETERMINATE = 2
         """
         self._ensure_enough_privileges('BM_GETCHECK')
+        self.wait_for_idle()
         return self.send_message(win32defines.BM_GETCHECK)
     # Non PEP-8 alias
     GetCheckState = deprecated(get_check_state)

--- a/pywinauto/controls/win32_controls.py
+++ b/pywinauto/controls/win32_controls.py
@@ -160,10 +160,11 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     def check(self):
         """Check a checkbox"""
         self._ensure_enough_privileges('BM_SETCHECK')
+        self.wait_for_idle()
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_CHECKED)
 
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
         time.sleep(Timings.after_buttoncheck_wait)
 
         # return this control so that actions can be chained.
@@ -175,10 +176,11 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     def uncheck(self):
         """Uncheck a checkbox"""
         self._ensure_enough_privileges('BM_SETCHECK')
+        self.wait_for_idle()
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_UNCHECKED)
 
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
         time.sleep(Timings.after_buttoncheck_wait)
 
         # return this control so that actions can be chained.
@@ -190,10 +192,11 @@ class ButtonWrapper(hwndwrapper.HwndWrapper):
     def set_check_indeterminate(self):
         """Set the checkbox to indeterminate"""
         self._ensure_enough_privileges('BM_SETCHECK')
+        self.wait_for_idle()
         self.send_message_timeout(win32defines.BM_SETCHECK,
                                   win32defines.BST_INDETERMINATE)
 
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
         time.sleep(Timings.after_buttoncheck_wait)
 
         # return this control so that actions can be chained.
@@ -427,8 +430,7 @@ class ComboBoxWrapper(hwndwrapper.HwndWrapper):
             # Notify the parent that the drop down has closed
             self.notify_parent(win32defines.CBN_CLOSEUP)
 
-
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
         time.sleep(Timings.after_comboboxselect_wait)
 
         # return this control so that actions can be chained.
@@ -622,7 +624,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
         # Notify the parent that we have changed
         self.notify_parent(win32defines.LBN_SELCHANGE)
 
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
         time.sleep(Timings.after_listboxselect_wait)
 
         return self
@@ -634,6 +636,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
         """Set the ListBox focus to the item at index"""
         index = self._get_item_index(item)
 
+        self.wait_for_idle()
         # if it is a multiple selection dialog
         if self.has_style(win32defines.LBS_EXTENDEDSEL) or \
             self.has_style(win32defines.LBS_MULTIPLESEL):
@@ -641,7 +644,7 @@ class ListBoxWrapper(hwndwrapper.HwndWrapper):
         else:
             self.send_message_timeout(win32defines.LB_SETCURSEL, index)
 
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
         time.sleep(Timings.after_listboxfocuschange_wait)
 
         # return this control so that actions can be chained.
@@ -866,7 +869,7 @@ class EditWrapper(hwndwrapper.HwndWrapper):
         self.send_message(win32defines.EM_SETSEL, start, end)
 
         # give the control a chance to catch up before continuing
-        win32functions.WaitGuiThreadIdle(self.handle)
+        self.wait_for_idle()
 
         time.sleep(Timings.after_editselect_wait)
 

--- a/pywinauto/handleprops.py
+++ b/pywinauto/handleprops.py
@@ -179,13 +179,20 @@ def is64bitprocess(process_id):
     Return False if it is only a 32-bit process running under Wow64.
     Always return False for x86.
     """
+    from .base_application import ProcessNotFoundError
     from .sysinfo import is_x64_OS
     is32 = True
     if is_x64_OS():
-        phndl = win32api.OpenProcess(win32con.MAXIMUM_ALLOWED, 0, process_id)
-        if phndl:
-            is32 = win32process.IsWow64Process(phndl)
-            #print("is64bitprocess, is32: %d, procid: %d" % (is32, process_id))
+        try:
+            phndl = win32api.OpenProcess(win32con.MAXIMUM_ALLOWED, 0, process_id)
+            if phndl:
+                is32 = win32process.IsWow64Process(phndl)
+                #print("is64bitprocess, is32: %d, procid: %d" % (is32, process_id))
+        except win32gui.error as e:
+            if e.winerror == win32defines.ERROR_INVALID_PARAMETER:
+                raise ProcessNotFoundError
+            else:
+                raise e
 
     return (not is32)
 

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -765,6 +765,7 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
 
         birds.click_input(where='button')
         self.assertEqual(birds.is_expanded(), True)
+        time.sleep(1.0)
         birds.click_input(double=True, where='icon')
         self.assertEqual(birds.is_expanded(), False)
 

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -40,6 +40,7 @@ from datetime import datetime
 #import pdb
 import os
 import win32api
+import win32gui
 import six
 
 sys.path.append(".")
@@ -765,7 +766,7 @@ class TreeViewAdditionalTestCases(unittest.TestCase):
 
         birds.click_input(where='button')
         self.assertEqual(birds.is_expanded(), True)
-        time.sleep(1.0)
+        time.sleep(win32gui.GetDoubleClickTime() * 2.0 / 1000)
         birds.click_input(double=True, where='icon')
         self.assertEqual(birds.is_expanded(), False)
 

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -2115,6 +2115,7 @@ if UIA_support:
         def test_issue_443(self):
             """Test .set_focus() for window that is not keyboard focusable"""
             self.dlg.minimize()
+            time.sleep(0.2)
             self.assertEqual(self.dlg.is_minimized(), True)
             self.dlg.set_focus()
             self.assertEqual(self.dlg.is_minimized(), False)

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -14,7 +14,7 @@ sys.path.append(".")
 from pywinauto.windows.application import Application  # noqa: E402
 from pywinauto.base_application import WindowSpecification  # noqa: E402
 from pywinauto.sysinfo import is_x64_Python, UIA_support  # noqa: E402
-from pywinauto.timings import Timings  # noqa: E402
+from pywinauto.timings import Timings, wait_until  # noqa: E402
 from pywinauto.actionlogger import ActionLogger  # noqa: E402
 from pywinauto import Desktop
 from pywinauto import mouse  # noqa: E402
@@ -2115,10 +2115,9 @@ if UIA_support:
         def test_issue_443(self):
             """Test .set_focus() for window that is not keyboard focusable"""
             self.dlg.minimize()
-            time.sleep(0.2)
-            self.assertEqual(self.dlg.is_minimized(), True)
+            wait_until(1, 0.2, self.dlg.is_minimized)
             self.dlg.set_focus()
-            self.assertEqual(self.dlg.is_minimized(), False)
+            wait_until(1, 0.2, self.dlg.is_minimized, value=False)
             self.assertEqual(self.dlg.is_normal(), True)
 
             # run another app instance (in focus now)


### PR DESCRIPTION
Fixes for some flaky tests that cause periodic build failures on AppVeyor.
* `test_uiawrapper.WindowWrapperTests.test_issue_443`
* `test_common_controls.TreeViewAdditionalTestCases.test_expand_collapse_buttons`
* `test_taskbar.TaskbarTestCases.testClickHiddenIcon`
* `test_win32controls.CheckBoxTests.testSetCheckIndeterminate`
See the commit messages for tracebacks and more information for each of them.

#### Validation:
After making this changes, running `git commit -m "$i fake commit" && git push --force && git reset HEAD^1 --hard` 30 times caused 5 failures:
* `test_expand_collapse_buttons` -> I increased delay from `0.8` to `1.0` seconds
* [`test_top_from_point_win32`](https://ci.appveyor.com/project/eltimen/pywinauto/builds/36586543/job/l1qme4ec6qd4br5h/tests) and [`test_can_select_top_menu`](https://ci.appveyor.com/project/eltimen/pywinauto/builds/36586564/job/pim4qgoef8fnieb5/tests) -> confusing the test application window with `cmd.exe` 
-> possible AppVeyor-related issue?
* [`testPressMoveRelease`](https://ci.appveyor.com/project/eltimen/pywinauto/builds/36586545/job/5hu21fj91uybif9d/tests) -> selects extra characters
* [`test_both_non_admin_click`](https://ci.appveyor.com/project/eltimen/pywinauto/builds/36586568/job/35y590op0d7x956f/tests) ->  need to add one more `self.wait_for_idle()` to `win32_controls.py` inside `ButtonWrapper.get_check_state`?
