### PR TITLE
Memory leak in capture_as_image() with multiple displays

### DIFF
--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -420,6 +420,9 @@ class WinBaseWrapper(BaseWrapper):
                                                'BGRX',
                                                0,
                                                1)
+                win32gui.DeleteObject(bmp.GetHandle())
+                memdc.DeleteDC()
+                win32gui.ReleaseDC(hwin, hwindc)
         else:
             # grab the image and get raw data as a string
             pil_img_obj = ImageGrab.grab(box)


### PR DESCRIPTION
When calling capture_as_image() rapidly with multiple displays on windows I get a win32ui.error: CreateCompatibleDC after about 4000 calls to CreateCompatibleDC(). This deletes these objects.