### PR TITLE
docs: fix simple typo, strucrures -> structures

### DIFF
--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -1616,7 +1616,7 @@ class TrackbarWrapperTestCases(unittest.TestCase):
         self.assert_channel_rect(self.ctrl.get_channel_rect(), system_rect)
 
     def assert_channel_rect(self, first_rect, second_rect):
-        """Compare two rect strucrures"""
+        """Compare two rect structures"""
         self.assertEqual(first_rect.height(), second_rect.height())
         self.assertEqual(first_rect.width(), second_rect.width())
 


### PR DESCRIPTION
There is a small typo in pywinauto/unittests/test_common_controls.py.

Should read `structures` rather than `strucrures`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md