### PR TITLE
More informative dump_tree(): always display class_name and control_type

### DIFF
--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -642,10 +642,6 @@ class WindowSpecification(object):
                     auto_id = ctrl.element_info.automation_id
                 if hasattr(ctrl.element_info, 'control_type'):
                     control_type = ctrl.element_info.control_type
-                    if control_type:
-                        class_name = None  # no need for class_name if control_type exists
-                    else:
-                        control_type = None  # if control_type is empty, still use class_name instead
                 criteria_texts = []
                 if ctrl_text:
                     criteria_texts.append(u'name="{}"'.format(ctrl_text))


### PR DESCRIPTION
**Summary:**

Enabling class_name and control_type always display in dump_tree() helps finding Qt5 application windows with UIA.

**Detailed description:**

Some elements named GroupBox, Custom, Thumb, ListBox may appear without `class_name` in dump_tree() when `control_type` is known.
Some such elements (depending on the Qt application itself) can be opened and defined as `WindowSpecification` using child_window() by specific class_name:

`child_window(class_name="prop::PropertyParamsWidget", control_type="Group")`

But when dumping the active window through dump_tree(), we will not see either the class_name or the control_type, although pywinauto can successfully interact with them.
child_window text will also not show up in the output from dump_tree():

```
Control Identifiers:

GroupBox - ''    (L1359, T257, R1664, B275)
['GroupBox']
```

This is not comfortable, and I would like dump_tree() to provide complete information with which we can use to interact with the application.
The `print_control_identifiers()` function explicitly states that `class_name = None` if control_type was found:

pywinauto\base_application.py:

```
if control_type:
    class_name = None  # no need for class_name if control_type exists
else:
    control_type = None  # if control_type is empty, still use class_name instead
```

Removing these rules from the source code makes it possible to see all the necessary parameters for our window:

```
Control Identifiers:

GroupBox - ''    (L1359, T257, R1664, B275)
['GroupBox']
child_window(class_name="prop::PropertyParamsWidget", control_type="Group")
```

The dump is more informative and we can use it to get information about the GroupBox, Custom, Thumb, ListBox elements as windows.


**Environment:**

OS: Windows 10
Python: 3.9.1
pywinauto: 0.6.8

pywinauto application settings :

```
backend='uia'
allow_magic_lookup=False
```

`allow_magic_lookup = False` helps to gain in performance and the examples provide code specifically for this case.