### PR TITLE
Implement from_focused for uia/win32 backend

### DIFF
--- a/pywinauto/__init__.py
+++ b/pywinauto/__init__.py
@@ -163,3 +163,8 @@ class Desktop(object):
         """Get wrapper object for top level element at specified screen coordinates (x, y)"""
         top_element_info = self.backend.element_info_class.top_from_point(x, y)
         return self.backend.generic_wrapper_class(top_element_info)
+
+    def from_focused(self):
+        """Get wrapper object for element with focus"""
+        element_info = self.backend.element_info_class.from_focused()
+        return self.backend.generic_wrapper_class(element_info)

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -446,6 +446,11 @@ class UIAElementInfo(ElementInfo):
             current_parent = current_elem.parent
         return current_elem
 
+    @classmethod
+    def from_focused(cls):
+        """Return current active element"""
+        return cls(IUIA().iuia.GetFocusedElement())
+
     @property
     def rich_text(self):
         """Return rich_text of the element"""

--- a/pywinauto/windows/win32_element_info.py
+++ b/pywinauto/windows/win32_element_info.py
@@ -290,6 +290,22 @@ class HwndElementInfo(ElementInfo):
         return current_elem
 
     @classmethod
+    def from_focused(cls):
+        """Return current active element"""
+        gui_info = win32structures.GUITHREADINFO()
+        gui_info.cbSize = ctypes.sizeof(gui_info)
+
+        # get all the active elements (not just the specified process)
+        ret = win32functions.GetGUIThreadInfo(0, ctypes.byref(gui_info))
+
+        if not ret:
+            raise ctypes.WinError()
+
+        hwndFocus = gui_info.hwndFocus
+
+        return cls(hwndFocus) if hwndFocus is not None else None
+
+    @classmethod
     def get_active(cls):
         """Return current active element"""
         gui_info = win32structures.GUITHREADINFO()


### PR DESCRIPTION
This PR allows to connect to a focused element in an application via win32/uia backend.

`Desktop(backend="uia").from_focused()`