### PR TITLE
Create WindowSpecification for child element of wrapper

### DIFF
--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -91,7 +91,7 @@ from . import controls
 from . import findbestmatch
 from . import findwindows
 
-from .backend import registry
+from . import backend
 
 from .actionlogger import ActionLogger
 from .timings import Timings, wait_until, TimeoutError, wait_until_passes
@@ -150,7 +150,7 @@ class WindowSpecification(object):
         """
         # kwargs will contain however to find this window
         if 'backend' not in search_criteria:
-            search_criteria['backend'] = registry.active_backend.name
+            search_criteria['backend'] = backend.registry.active_backend.name
         if 'pid' in search_criteria and 'app' in search_criteria:
             raise KeyError('Keywords "pid" and "app" cannot be combined (ambiguous). ' \
                 'Use one option at a time: Application object with keyword "app" or ' \
@@ -158,7 +158,7 @@ class WindowSpecification(object):
         self.app = search_criteria.get('app', None)
         self.criteria = [search_criteria, ]
         self.actions = ActionLogger()
-        self.backend = registry.backends[search_criteria['backend']]
+        self.backend = backend.registry.backends[search_criteria['backend']]
         self.allow_magic_lookup = allow_magic_lookup
 
         # Non PEP-8 aliases for partial backward compatibility
@@ -266,7 +266,7 @@ class WindowSpecification(object):
         When this window specification is resolved it will be used
         to match against a control.
         """
-        # default to non top level windows because we are usualy
+        # default to non top level windows because we are usually
         # looking for a control
         if 'top_level_only' not in criteria:
             criteria['top_level_only'] = False

--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -551,32 +551,6 @@ class WindowSpecification(object):
         # None return value, since we are waiting for a `negative` state of the control.
         # Expect that you will have nothing to do with the window closed, disabled, etc.
 
-    def _ctrl_identifiers(self):
-
-        ctrls = self.__resolve_control(self.criteria)
-
-        if ctrls[-1].is_dialog():
-            # dialog controls are all the control on the dialog
-            dialog_controls = ctrls[-1].children()
-
-            ctrls_to_print = dialog_controls[:]
-            # filter out hidden controls
-            ctrls_to_print = [
-                ctrl for ctrl in ctrls_to_print if ctrl.is_visible()]
-        else:
-            dialog_controls = ctrls[-1].top_level_parent().children()
-            ctrls_to_print = [ctrls[-1]]
-
-        # build the list of disambiguated list of control names
-        name_control_map = findbestmatch.build_unique_dict(dialog_controls)
-
-        # swap it around so that we are mapped off the controls
-        control_name_map = {}
-        for name, ctrl in name_control_map.items():
-            control_name_map.setdefault(ctrl, []).append(name)
-
-        return control_name_map
-
     def dump_tree(self, depth=10, max_width=10, filename=None):
         """
         Dump the 'identifiers' to console or a file

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -146,6 +146,24 @@ class BaseWrapper(object):
         else:
             raise RuntimeError('NULL pointer was used to initialize BaseWrapper')
 
+    def by(self, **criteria):
+        """
+        Create WindowSpecification for search in descendants by criteria
+
+        Current wrapper object is used as a parent while searching in the subtree.
+        """
+        from .base_application import WindowSpecification
+        # default to non top level windows because we are usually
+        # looking for a control
+        if 'top_level_only' not in criteria:
+            criteria['top_level_only'] = False
+
+        criteria['backend'] = self.backend.name
+        criteria['parent'] = self.element_info
+        child_specification = WindowSpecification(criteria)
+
+        return child_specification
+
     def __repr_texts(self):
         """Internal common method to be called from __str__ and __repr__"""
         module = self.__class__.__module__

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -176,7 +176,9 @@ def find_elements(**kwargs):
     elif isinstance(parent, six.integer_types):
         # check if parent is a handle of element (in case of searching native controls)
         parent = backend_obj.element_info_class(parent)
-
+    elif parent and not isinstance(parent, backend_obj.element_info_class):
+        raise TypeError('Parent must be {}, {}, integer or None'.format(backend_obj.generic_wrapper_class,
+                                                                        backend_obj.element_info_class))
 
     # create initial list of all elements
     if top_level_only:

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -798,7 +798,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
     def setUp(self):
         """Set some data and ensure the application is in the state we want"""
         Timings.defaults()
-        self.app = Application().start("Notepad")
+        self.app = Application(backend="win32").start(_notepad_exe())
         self.dlgspec = self.app.UntitledNotepad
         self.ctrlspec = self.app.UntitledNotepad.Edit
 
@@ -1208,7 +1208,7 @@ class ChildWindowSpecificationFromWrapperTests(unittest.TestCase):
     def setUp(self):
         """Set some data and ensure the application is in the state we want"""
         Timings.defaults()
-        self.app = Application().start("Notepad")
+        self.app = Application(backend="win32").start(_notepad_exe())
         self.ctrlspec = self.app.window(found_index=0).find().by(class_name='Edit')
 
     def tearDown(self):
@@ -1249,7 +1249,7 @@ class ChildWindowSpecificationFromWrapperTests(unittest.TestCase):
     def test_properties(self):
         """Check control properties"""
         self.assertEqual(self.ctrlspec.class_name(), "Edit")
-        self.assertEqual(True, self.ctrlspec.exists())
+        self.assertTrue(self.ctrlspec.exists())
 
 
 if UIA_support:


### PR DESCRIPTION
Add `BaseWrapper.by()` method to create WindowSpecification for search in descendants of specified element wrapper 

resolve #570