### PR TITLE
Handle 87 error from OpenProcess and CI changes

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,10 +11,6 @@ shallow_clone: true                 # default is "false"
 environment:
 
   matrix:
-    - PYTHON: "C:\\Python27"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "32"
-      UIA_SUPPORT: "YES"
 
     - PYTHON: "C:\\Python27"
       PYTHON_VERSION: "2.7"
@@ -25,26 +21,11 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
-
-    - PYTHON: "C:\\Python27-x64"
-      PYTHON_VERSION: "2.7"
-      PYTHON_ARCH: "64"
-      UIA_SUPPORT: "NO"
 
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
       UIA_SUPPORT: "YES"
-
-    - PYTHON: "C:\\Python35-x64"
-      PYTHON_VERSION: "3.5"
-      PYTHON_ARCH: "64"
-      UIA_SUPPORT: "NO"
-
-    - PYTHON: "C:\\Python36"
-      PYTHON_VERSION: "3.6"
-      PYTHON_ARCH: "32"
-      UIA_SUPPORT: "NO"
 
     - PYTHON: "C:\\Python36-x64"
       PYTHON_VERSION: "3.6"
@@ -58,6 +39,16 @@ environment:
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
+      PYTHON_ARCH: "64"
+      UIA_SUPPORT: "YES"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8"
+      PYTHON_ARCH: "64"
+      UIA_SUPPORT: "NO"
+
+    - PYTHON: "C:\\Python38-x64"
+      PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
 

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -42,7 +42,7 @@ function run {
     $output = "transformed.xml"
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
-    nosetests --nologcapture --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
+    nosetests --nologcapture --traverse-namespace --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
     $success = $?
     Write-Host "result code of nosetests:" $success
 

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -42,6 +42,7 @@ function run {
     $output = "transformed.xml"
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
+    # --traverse-namespace is required for python 3.8 https://stackoverflow.com/q/58556183
     nosetests --nologcapture --traverse-namespace --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
     $success = $?
     Write-Host "result code of nosetests:" $success

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
-pywin32
+pywin32==301 ; python_version == '3.6'
+pywin32 ; python_version != '3.6'
 six
 pillow>=6.2.0
 coverage

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -9,4 +9,4 @@ rst2pdf
 Sphinx
 mock==2.0.0
 codacy-coverage
-PyQt5 ; python_version >= '3.6'
+PyQt5==5.15.4 ; python_version >= '3.6'

--- a/pywinauto/windows/application.py
+++ b/pywinauto/windows/application.py
@@ -478,7 +478,14 @@ class Application(BaseApplication):
         if not self.process:
             raise AppNotConnected("Please use start or connect before trying "
                                   "anything else")
-        h_process = win32api.OpenProcess(win32con.MAXIMUM_ALLOWED, 0, self.process)
+
+        try:
+            h_process = win32api.OpenProcess(win32con.MAXIMUM_ALLOWED, 0, self.process)
+        except win32api.error as e:
+            if e.winerror == win32defines.ERROR_INVALID_PARAMETER:
+                raise ProcessNotFoundError('Process does not exist')
+            else:
+                raise e
 
         times_dict = win32process.GetProcessTimes(h_process)
         UserTime_start, KernelTime_start = times_dict['UserTime'], times_dict['KernelTime']

--- a/pywinauto/windows/application.py
+++ b/pywinauto/windows/application.py
@@ -483,9 +483,8 @@ class Application(BaseApplication):
             h_process = win32api.OpenProcess(win32con.MAXIMUM_ALLOWED, 0, self.process)
         except win32api.error as e:
             if e.winerror == win32defines.ERROR_INVALID_PARAMETER:
-                raise ProcessNotFoundError('Process does not exist')
-            else:
-                raise e
+                raise ProcessNotFoundError('Process with PID {} does not exist'.format(self.process))
+            raise e
 
         times_dict = win32process.GetProcessTimes(h_process)
         UserTime_start, KernelTime_start = times_dict['UserTime'], times_dict['KernelTime']


### PR DESCRIPTION
resolves #1127
I think another `OpenProcess` calls without winapi errors handling (inside `WaitGuiThreadIdle` and `RemoteMemoryBlock` used by `HwndElementInfo` and various control wrappers) do not require handling of this error.

CI changes:
* Change python version matrix (remove some jobs, add Python 3.8)
* Fix `pywin32 is in an unsupported or invalid wheel` on Python 3.6