### PR TITLE
Improvements for dump_tree

### DIFF
--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -654,8 +654,8 @@ class WindowSpecification(object):
                 ctrl_text = ctrl.window_text()
                 if ctrl_text:
                     # transform multi-line text to one liner
-                    ctrl_text = ctrl_text.replace('\n', r'\n').replace('\r', r'\r')
-                output += indent + u"{class_name} - '{text}'    {rect}" \
+                    ctrl_text = repr(ctrl_text)
+                output += indent + u"{class_name} - {text}    {rect}" \
                                    "".format(class_name=ctrl.friendly_class_name(),
                                              text=ctrl_text,
                                              rect=ctrl.rectangle())
@@ -672,15 +672,15 @@ class WindowSpecification(object):
                     control_type = ctrl.element_info.control_type
                 criteria_texts = []
                 if ctrl_text:
-                    criteria_texts.append(u'name="{}"'.format(ctrl_text))
+                    criteria_texts.append(u'name={}'.format(ctrl_text))
                 if class_name:
-                    criteria_texts.append(u'class_name="{}"'.format(class_name))
+                    criteria_texts.append(u"class_name='{}'".format(class_name))
                 if auto_id:
-                    criteria_texts.append(u'auto_id="{}"'.format(auto_id))
+                    criteria_texts.append(u"auto_id='{}'".format(auto_id))
                 if control_type:
-                    criteria_texts.append(u'control_type="{}"'.format(control_type))
+                    criteria_texts.append(u"control_type='{}'".format(control_type))
                 if ctrl_text or class_name or auto_id:
-                    output += u'\n' + indent + u'child_window(' + u', '.join(criteria_texts) + u')'
+                    output += u'\n' + indent + u'.by(' + u', '.join(criteria_texts) + u')'
             else:
                 output += indent + u'**********\n'
                 output += indent + u'Max children output limit ({}) has been reached. ' \

--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -698,11 +698,20 @@ class WindowSpecification(object):
                     print_identifiers(child_elem, current_depth + 1, log_func)
 
         if filename is None:
+            if six.PY3:
+                try:
+                    encoding = sys.stdout.encoding
+                except AttributeError:
+                    encoding = sys.getdefaultencoding()
+            else:
+                encoding = locale.getpreferredencoding()
+            print(u'# -*- coding: {} -*-'.format(encoding))
             print_identifiers(elements_tree)
         else:
-            with codecs.open(filename, "w", locale.getpreferredencoding()) as log_file:
+            with codecs.open(filename, "w", locale.getpreferredencoding(), errors="backslashreplace") as log_file:
                 def log_func(msg):
                     log_file.write(str(msg) + os.linesep)
+                log_func(u'# -*- coding: {} -*-'.format(locale.getpreferredencoding()))
                 print_identifiers(elements_tree, log_func=log_func)
 
     print_control_identifiers = deprecated(dump_tree, deprecated_name='print_control_identifiers')

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -1183,7 +1183,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
                 content = str(test_log_file.readlines())
                 self.assertTrue("'Untitled - NotepadEdit'" in content
                     and "'Edit'" in content)
-                self.assertTrue("child_window(class_name=\"msctls_statusbar32\"" in content)
+                self.assertTrue(".by(class_name='msctls_statusbar32'" in content)
             os.remove(output_filename)
         else:
             self.fail("dump_tree can't create a file")
@@ -1192,7 +1192,7 @@ class WindowSpecificationTestCases(unittest.TestCase):
         if os.path.isfile(output_filename):
             with open(output_filename, "r") as test_log_file:
                 content = str(test_log_file.readlines())
-                self.assertTrue("child_window(class_name=\"Edit\")" in content)
+                self.assertTrue(".by(class_name='Edit')" in content)
             os.remove(output_filename)
         else:
             self.fail("dump_tree can't create a file")
@@ -1241,7 +1241,7 @@ class ChildWindowSpecificationFromWrapperTests(unittest.TestCase):
         if os.path.isfile(output_filename):
             with open(output_filename, "r") as test_log_file:
                 content = str(test_log_file.readlines())
-                self.assertTrue("child_window(class_name=\"Edit\")" in content)
+                self.assertTrue(".by(class_name='Edit')" in content)
             os.remove(output_filename)
         else:
             self.fail("dump_tree can't create a file")


### PR DESCRIPTION
fixes #1133 #1045
Changes:
* Fix partial unescaping
* Add encoding shebang
* Use new name of `.by()` method
* Fix UnicodeEncodeError when writing to file in some cases

PyQt-based test application: https://gist.github.com/eltimen/72cfccaf0b48ffc3e649d1cc506c5db5 