### PR TITLE
Add VK_MEDIA keys to the keyboard

### DIFF
--- a/pywinauto/keyboard.py
+++ b/pywinauto/keyboard.py
@@ -62,7 +62,8 @@ below. The module is also available on Linux.
     {F17}, {F14}, {F15}, {F24}, {RIGHT}, {VK_F24}, {VK_CAPITAL}, {VK_LBUTTON},
     {VK_OEM_CLEAR}, {VK_ESCAPE}, {UP}, {VK_DIVIDE}, {INS}, {VK_JUNJA},
     {VK_F19}, {VK_EXECUTE}, {VK_PLAY}, {VK_RMENU}, {VK_F13}, {VK_F12}, {LWIN},
-    {VK_DOWN}, {VK_F17}, {VK_F16}, {VK_F15}, {VK_F14}
+    {VK_DOWN}, {VK_F17}, {VK_F16}, {VK_F15}, {VK_F14}, {VK_MEDIA_NEXT_TRACK},
+    {VK_MEDIA_PREV_TRACK}, {VK_MEDIA_STOP}, {VK_MEDIA_PLAY_PAUSE}
 
     ~ is a shorter alias for {ENTER}
 

--- a/pywinauto/windows/keyboard.py
+++ b/pywinauto/windows/keyboard.py
@@ -250,6 +250,10 @@ CODES = {
     'VK_TAB': 9,
     'VK_UP': 38,
     'ZOOM': 251,
+    'VK_MEDIA_NEXT_TRACK': 176,
+    'VK_MEDIA_PREV_TRACK': 177,
+    'VK_MEDIA_STOP': 178,
+    'VK_MEDIA_PLAY_PAUSE': 179
 }
 # reverse the CODES dict to make it easy to look up a particular code name
 CODE_NAMES = dict((entry[1], entry[0]) for entry in CODES.items())


### PR DESCRIPTION
Adds the media keys ``VK_MEDIA_NEXT_TRACK`` ``VK_MEDIA_PLAY_PAUSE`` ``VK_MEDIA_PREV_TRACK`` ``VK_MEDIA_STOP`` to the keyboard. Needed some of these for my project and they weren't included. 