### PR TITLE
Fix crash on Python>=3.9 caused by removed Thread.isAlive method

### DIFF
--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -553,7 +553,7 @@ class UIAWrapper(WinBaseWrapper):
             thread.daemon = True
             thread.start()
             thread.join(2.)
-            if thread.isAlive():
+            if thread.is_alive():
                 warnings.warn('Timeout for InvokePattern.Invoke() call was exceeded', RuntimeWarning)
         watchdog_thread = threading.Thread(target=watchdog)
         watchdog_thread.start()


### PR DESCRIPTION
The deprecated method alias `Thread.isAlive()` was removed in Python 3.9. Method `is_alive()` works on 2.7.