### PR TITLE
add "3.11" to `appveyor.yml`

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -52,6 +52,11 @@ environment:
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
 
+    - PYTHON: "C:\\Python311-x64"
+      PYTHON_VERSION: "3.11"
+      PYTHON_ARCH: "64"
+      UIA_SUPPORT: "YES"
+
 #init:
   # Enable RDP.
   #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))


### PR DESCRIPTION
Appveyor has been started supporting stable Python 3.11(appveyor/ci#3844, https://www.appveyor.com/updates/2022/11/07/).

Let's add it to ci's environment matrix.