### PR TITLE
update 'Manual Installation' in `Readme.txt`

### DIFF
--- a/Readme.txt
+++ b/Readme.txt
@@ -13,7 +13,7 @@ dialogs and controls.
 Manual Installation
 ------------
 Install the following Python packages
-(Required) pyWin32      http://sourceforge.net/projects/pywin32/files/pywin32/
+(Required) pyWin32      https://github.com/mhammond/pywin32
 (Required) comtypes     https://github.com/enthought/comtypes
 (Optional) PIL          http://www.pythonware.com/products/pil/index.htm
 Unzip the pywinauto zip file to a folder.


### PR DESCRIPTION
I noticed that the repository URL for `pyWin32` in the `Readme.txt` is the sourceforge-hosted one that hasn't been updated for years.

Therefore, I have updated it to the URL of an active GitHub repository.