### PR TITLE
small fix in `uia_defines`

### DIFF
--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -128,7 +128,7 @@ def _build_pattern_ids_dic():
     """
     base_names = [
         'Dock', 'ExpandCollapse', 'GridItem', 'Grid', 'Invoke', 'ItemContainer',
-        'LegacyIAccessible', 'MulipleView', 'RangeValue', 'ScrollItem', 'Scroll',
+        'LegacyIAccessible', 'MultipleView', 'RangeValue', 'ScrollItem', 'Scroll',
         'SelectionItem', 'Selection', 'SynchronizedInput', 'TableItem', 'Table',
         'Text', 'Toggle', 'VirtualizedItem', 'Value', 'Window',
         'Transform',

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -217,11 +217,11 @@ def get_elem_interface(element_info, pattern_name):
     TODO: handle a wrong pattern name
     """
     # Resolve the pattern id and the class to query
-    ptrn_id, cls_name = pattern_ids[pattern_name]
+    ptrn_id, ptrn_cls = pattern_ids[pattern_name]
     # Get the interface
     try:
         cur_ptrn = element_info.GetCurrentPattern(ptrn_id)
-        iface = cur_ptrn.QueryInterface(cls_name)
+        iface = cur_ptrn.QueryInterface(ptrn_cls)
     except (ValueError, comtypes.COMError):
         raise NoPatternInterfaceError()
     return iface


### PR DESCRIPTION
## delint and rename variables within `get_elem_interface`
In reality, what is passed to `QueryInterface` is not the "class name" but the "pattern class", so I changed the variable names to be appropriate.

## fix base name typo
Previously, it was 'MulipleView' instead of 'MultipleView', which is why `IUIAutomationMultipleViewPattern` or `UIA_MultipleViewPatternId` could not be found in `comtypes.gen.UIAutomationClient`.