### PR TITLE
fix `is_checked` in `uia_controls`

### DIFF
--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -758,7 +758,7 @@ class ListItemWrapper(uiawrapper.UIAWrapper):
         Only items supporting Toggle pattern should answer.
         Raise NoPatternInterfaceError if the pattern is not supported
         """
-        return self.iface_toggle.ToggleState_On == toggle_state_on
+        return self.iface_toggle.CurrentToggleState == toggle_state_on
 
     def texts(self):
         """Return a list of item texts"""
@@ -1440,7 +1440,7 @@ class TreeItemWrapper(uiawrapper.UIAWrapper):
         Only items supporting Toggle pattern should answer.
         Raise NoPatternInterfaceError if the pattern is not supported
         """
-        return (self.iface_toggle.ToggleState_On == toggle_state_on)
+        return (self.iface_toggle.CurrentToggleState == toggle_state_on)
 
     # -----------------------------------------------------------
     def ensure_visible(self):

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -1708,6 +1708,19 @@ if UIA_support:
             self.listbox_datagrid_tab.select()
             listbox_item = self.listbox_datagrid_tab.children(class_name=u"ListBox")[0].get_item(u"CheckItem")
             self.assertRaises(uia_defs.NoPatternInterfaceError, listbox_item.is_checked)
+            # Creating an actual GUI that can be toggled by `ListItemWrapper`s is difficult,
+            # so the `iface_toggle` property was patched for testing purposes.
+            with mock.patch.object(
+                uia_ctls.ListItemWrapper,
+                "iface_toggle",
+                spec=uia_defs.IUIA().ui_automation_client.IUIAutomationTogglePattern,
+            ) as m_toggle:
+                m_toggle.CurrentToggleState = uia_defs.toggle_state_on
+                self.assertTrue(listbox_item.is_checked())
+                m_toggle.CurrentToggleState = uia_defs.toggle_state_off
+                self.assertFalse(listbox_item.is_checked())
+                m_toggle.CurrentToggleState = uia_defs.toggle_state_inderteminate
+                self.assertFalse(listbox_item.is_checked())
 
         def test_texts(self):
             """Test getting texts of ListItem"""
@@ -2143,6 +2156,19 @@ if UIA_support:
 
             # Verify errors handling
             self.assertRaises(uia_defs.NoPatternInterfaceError, itm.is_checked)
+            # Creating an actual GUI that can be toggled by `TreeItemWrapper`s is difficult,
+            # so the `iface_toggle` property was patched for testing purposes.
+            with mock.patch.object(
+                uia_ctls.TreeItemWrapper,
+                "iface_toggle",
+                spec=uia_defs.IUIA().ui_automation_client.IUIAutomationTogglePattern,
+            ) as m_toggle:
+                m_toggle.CurrentToggleState = uia_defs.toggle_state_on
+                self.assertTrue(itm.is_checked())
+                m_toggle.CurrentToggleState = uia_defs.toggle_state_off
+                self.assertFalse(itm.is_checked())
+                m_toggle.CurrentToggleState = uia_defs.toggle_state_inderteminate
+                self.assertFalse(itm.is_checked())
 
             self.assertRaises(RuntimeError,
                               self.ctrl.get_item,


### PR DESCRIPTION
I noticed that the `IUIAutomationTogglePattern` assigned to `iface_toggle` does not have an attribute named `ToggleState_On`.

https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationtogglepattern#methods

`uia_controls.FooWrapper.is_checked` have only been tested for cases where `NoPatternInterfaceError` raises, and there is no test that actually verifies if it is "toggled".

However, I believe it's not ideal to leave a situation where `AttributeError` is consistently occurring unaddressed, so I made the necessary corrections.