### PR TITLE
encapsulate calling `FindItemByProperty`

### DIFF
--- a/pywinauto/controls/uia_controls.py
+++ b/pywinauto/controls/uia_controls.py
@@ -925,14 +925,14 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
             # Try to find item using FindItemByProperty
             # That way we can get access to virtualized (unloaded) items
             try:
-                com_elem = self.iface_item_container.FindItemByProperty(0, IUIA().UIA_dll.UIA_NamePropertyId, row)
+                elem = self.element_info.item_container.find(propid=IUIA().UIA_dll.UIA_NamePropertyId, value=row)
                 # Try to load element using VirtualizedItem pattern
                 try:
-                    get_elem_interface(com_elem, "VirtualizedItem").Realize()
-                    itm = uiawrapper.UIAWrapper(uia_element_info.UIAElementInfo(com_elem))
+                    get_elem_interface(elem.element, "VirtualizedItem").Realize()
+                    itm = uiawrapper.UIAWrapper(elem)
                 except NoPatternInterfaceError:
                     # Item doesn't support VirtualizedItem pattern - item is already on screen or com_elem is NULL
-                    itm = uiawrapper.UIAWrapper(uia_element_info.UIAElementInfo(com_elem))
+                    itm = uiawrapper.UIAWrapper(elem)
             except (NoPatternInterfaceError, ValueError):
                 # com_elem is NULL pointer or item doesn't support ItemContainer pattern
                 # Get DataGrid row
@@ -948,15 +948,15 @@ class ListViewWrapper(uiawrapper.UIAWrapper):
         elif isinstance(row, int):
             # Get the item by a row index
             try:
-                com_elem = 0
-                for _ in range(0, self.__resolve_row_index(row) + 1):
-                    com_elem = self.iface_item_container.FindItemByProperty(com_elem, 0, uia_defs.vt_empty)
+                elem = self.element_info.item_container.find()
+                for _ in range(0, self.__resolve_row_index(row)):
+                    elem = self.element_info.item_container.find(elem)
                 # Try to load element using VirtualizedItem pattern
                 try:
-                    get_elem_interface(com_elem, "VirtualizedItem").Realize()
+                    get_elem_interface(elem.element, "VirtualizedItem").Realize()
                 except NoPatternInterfaceError:
                     pass
-                itm = uiawrapper.UIAWrapper(uia_element_info.UIAElementInfo(com_elem))
+                itm = uiawrapper.UIAWrapper(elem)
             except (NoPatternInterfaceError, ValueError, AttributeError):
                 list_items = self.children(content_only=True)
                 itm = list_items[self.__resolve_row_index(row)]

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -862,12 +862,9 @@ class UIAWrapper(WinBaseWrapper, metaclass=UiaMeta):
         """Get texts through the ItemContainer interface"""
         texts = []
         try:
-            com_elem = self.iface_item_container.FindItemByProperty(0, 0, uia_defs.vt_empty)
-            while com_elem:
-                itm = UIAWrapper(UIAElementInfo(com_elem))
-                texts.append(itm.texts())
-                com_elem = self.iface_item_container.FindItemByProperty(com_elem, 0, uia_defs.vt_empty)
-        except (uia_defs.NoPatternInterfaceError):
+            for elem in self.element_info.item_container:
+                texts.append(UIAWrapper(elem).texts())
+        except uia_defs.NoPatternInterfaceError:
             pass
         return texts
 

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -782,18 +782,22 @@ if UIA_support:
             for t in combo_box.texts():
                 self.assertEqual((t in ref_texts), True)
 
-            # Mock a 0 pointer to COM element
-            combo_box.iface_item_container.FindItemByProperty = mock.Mock(return_value=0)
-            self.assertEqual(combo_box.texts(), ref_texts)
+            # Mock a empty container
+            patch_empty = mock.patch.object(UIAElementInfo, "item_container", [])
+            with patch_empty:
+                self.assertEqual(combo_box.texts(), ref_texts)
+
+            error_prop = mock.PropertyMock(side_effect=uia_defs.NoPatternInterfaceError())
 
             # Mock a combobox without "ItemContainer" pattern
-            combo_box.iface_item_container.FindItemByProperty = mock.Mock(side_effect=uia_defs.NoPatternInterfaceError())
-            self.assertEqual(combo_box.texts(), ref_texts)
-
+            patch_container_error = mock.patch.object(UIAElementInfo, "item_container", error_prop)
             # Mock a combobox without "ExpandCollapse" pattern
-            # Expect empty texts
-            combo_box.iface_expand_collapse.Expand = mock.Mock(side_effect=uia_defs.NoPatternInterfaceError())
-            self.assertEqual(combo_box.texts(), [])
+            patch_expand_collapse_error = mock.patch.object(UIAWrapper, "iface_expand_collapse", error_prop)
+
+            with patch_container_error:
+                self.assertEqual(combo_box.texts(), ref_texts)
+                with patch_expand_collapse_error:
+                    self.assertEqual(combo_box.texts(), [])
 
         def test_combobox_select(self):
             """Test select related methods for the combo box control"""

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -31,10 +31,11 @@
 
 """Implementation of the class to deal with an UI element (based on UI Automation API)"""
 
-from comtypes import COMError
+from comtypes import COMError, POINTER
 from ctypes.wintypes import tagPOINT
 import warnings
 
+from . import uia_defines as uia_defs
 from .uia_defines import IUIA
 from .uia_defines import get_elem_interface, NoPatternInterfaceError
 
@@ -506,6 +507,10 @@ class UIAElementInfo(ElementInfo):
                     return descendants
 
     @property
+    def item_container(self):
+        return _ItemContainer(get_elem_interface(self._element, "ItemContainer"))
+
+    @property
     def visible(self):
         """Check if the element is visible"""
         return self._get_visible()
@@ -576,3 +581,40 @@ class UIAElementInfo(ElementInfo):
         """Return current active element"""
         ae = IUIA().get_focused_element()
         return cls(ae)
+
+
+class _ItemContainer(object):
+    """UI item container wrapper"""
+    def __init__(self, iface):
+        self._iface = iface  # IUIAutomationItemContainerPattern
+
+    def __iter__(self):
+        elem = self.find()
+        while elem.element:
+            yield elem
+            elem = self.find(elem)
+
+    def find(self, start_after=None, propid=None, value=None):
+        """Return the matching element in the container
+
+        * **start_after** Specifies the element after which the search begins.
+                          Defaults to search all elements.
+        * **propid** Specifies the property identifier.
+                     Defaults to return the next item after **start_after** element.
+        * **value** Specifies the property value.
+                    Defaults to return the next item after **start_after** element.
+
+        if all parameters are not specified, returns the first item.
+        if the **propid** is specified, the **value** must be specified.
+        """
+        if start_after is None:
+            # create a null com pointer
+            com_elem = POINTER(IUIA().ui_automation_client.IUIAutomationElement)()
+        elif isinstance(start_after, UIAElementInfo):
+            com_elem = start_after.element
+        else:
+            raise TypeError("UIAElementInfo type or None is expected")
+        propid = propid if propid is not None else 0
+        value = value if value is not None else uia_defs.vt_empty
+        itm = self._iface.FindItemByProperty(com_elem, propid, value)
+        return UIAElementInfo(itm)


### PR DESCRIPTION
`IUIAutomationItemContainerPattern.FindItemByProperty` is useful for finding matching elements in containers, but is inconvenient to use because it requires a null pointer and complicated arguments.

In the `uiawrapper` and `uia_controls` modules, direct referencing of such complex COM object methods to retrieve `IUIAutomationElement` and then passing it to the constructor of `UIAElementInfo` is overly responsible.
It is more appropriate that those be in the `uia_element_info` module.
So I defined the wrapper of UI item container in `uia_element_info`.

And I changed arguments passed to `IUIAutomationItemContainerPattern.FindItemByProperty` to be an instance of a more proper type.
As mentioned in https://github.com/pywinauto/pywinauto/pull/733#discussion_r285304327 (317a7c94f7a1d0df06a0cc6699b074a36da4e12b), if we try to create a null com pointer by passing `0` or `None` to `uia_defs.IUIA().iuia.ElementFromHandle`, an error will be raised.
 I realized there is a simpler way to create a null com pointer. It is just doing `POINTER(SubclassOfIUnknown)()`.

- reference: https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nf-uiautomationclient-iuiautomationitemcontainerpattern-finditembyproperty

