### PR TITLE
Fix regression in calling `UIAElementInfo.descendants` with `depth` and criteria like `control_type` arguments

### DIFF
--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -166,21 +166,6 @@ class ElementInfo(object):
         else:
             return elements
 
-    def get_descendants_with_depth(self, depth=None, **kwargs):
-        """Return a list of all descendant children of the element with the specified depth"""
-        descendants = []
-
-        def walk_the_tree(root, depth, **kwargs):
-            if depth == 0:
-                return
-            for child in root.children(**kwargs):
-                descendants.append(child)
-                next_depth = None if depth is None else depth - 1
-                walk_the_tree(child, next_depth, **kwargs)
-
-        walk_the_tree(self, depth, **kwargs)
-        return descendants
-
     def descendants(self, **kwargs):
         """Return descendants of the element"""
         raise NotImplementedError()

--- a/pywinauto/unittests/test_uia_element_info.py
+++ b/pywinauto/unittests/test_uia_element_info.py
@@ -118,6 +118,35 @@ if UIA_support:
             """Test whether a list of descendants with invalid depth raises exception"""
             self.assertRaises(Exception, self.ctrl.descendants, depth='qwerty')
 
+        def test_default_depth_with_criteria_descendants(self):
+            """Test whether a list of descendants with default depth and same criteria of the element is equal"""
+            self.assertEqual(
+                len(self.ctrl.descendants(depth=None, control_type="RadioButton")),
+                len(self.ctrl.descendants(control_type="RadioButton")),
+            )
+
+        def test_default_and_specified_depth_level_with_criteria_descendants(self):
+            """Test whether specifying a depth level will find fewer elements than without specifying it"""
+            self.assertLess(
+                len(self.ctrl.descendants(control_type="Text", depth=2)),
+                len(self.ctrl.descendants(control_type="Text")),
+            )
+
+        def test_depth_level_one_with_criteria_descendants(self):
+            """Test whether a list of descendants with depth=1 and same criteria of the element is equal to children"""
+            self.assertEqual(
+                self.ctrl.children(control_type="ToolBar"), self.ctrl.descendants(control_type="ToolBar", depth=1)
+            )
+
+        def test_depth_level_more_than_one_with_criteria_descendants(self):
+            """Test whether an element not found with smaller depth levels is found with larger levels"""
+            # There is no element with `control_type='ScrollBar'` with depth level less than three
+            nothing = next(iter(self.ctrl.descendants(control_type="Slider", depth=2)), None)
+            self.assertIsNone(nothing)
+            slider = next(iter(self.ctrl.descendants(control_type="Slider", depth=3)), None)
+            self.assertIsNotNone(slider)
+            self.assertIn(slider, self.ctrl.descendants())
+
         def test_descendants_generator(self):
             """Test whether descendant generator iterates over correct elements"""
             descendants = [desc for desc in self.ctrl.iter_descendants(depth=3)]

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -462,7 +462,7 @@ class UIAElementInfo(ElementInfo):
         """Return a list of only immediate children of the element
 
          * **kwargs** is a criteria to reduce a list by process,
-           class_name, control_type, content_only and/or title.
+           class_name, control_type, content_only and/or name.
         """
         if UIAElementInfo.use_raw_view_walker:
             return list(self.iter_children(**kwargs))
@@ -475,7 +475,7 @@ class UIAElementInfo(ElementInfo):
         """Return a list of all descendant children of the element
 
          * **kwargs** is a criteria to reduce a list by process,
-           class_name, control_type, content_only and/or title.
+           class_name, control_type, content_only and/or name.
         """
         if UIAElementInfo.use_raw_view_walker:
             return list(self.iter_descendants(**kwargs))


### PR DESCRIPTION
fixes #1336 