### PR TITLE
`Application.window` and `findwindows.find_elements` can accept keys specified in `*ElementInfo.renamed_props`

### DIFF
--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -152,7 +152,8 @@ def find_elements(**kwargs):
     # tell user about new property name for every renamed one
     if hasattr(backend_obj.element_info_class, 'renamed_props'):
         #renamed_erros = []
-        for key, value in list(kwargs.items()):
+        items = list(kwargs.items())
+        for key, value in items:
             renamed_prop = backend_obj.element_info_class.renamed_props.get(key, None)
             if renamed_prop is not None:
                 new_key, values_map = renamed_prop

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -647,21 +647,25 @@ class ApplicationTestCases(unittest.TestCase):
 
         self.assertRaises(ValueError, app.windows_, **{'backend' : 'uia'})
 
-        title = app.window(name="Untitled - Notepad")
-        title_re = app.window(name_re="Untitled[ -]+Notepad")
+        name = app.window(name="Untitled - Notepad")
+        name_re = app.window(name_re="Untitled[ -]+Notepad")
+        title = app.window(title="Untitled - Notepad")
+        title_re = app.window(title_re="Untitled[ -]+Notepad")
         classname = app.window(class_name="Notepad")
         classname_re = app.window(class_name_re="Not..ad")
-        handle = app.window(handle=title.handle)
+        handle = app.window(handle=name.handle)
         bestmatch = app.window(best_match="Untiotled Notepad")
 
-        self.assertNotEqual(title.handle, None)
-        self.assertNotEqual(title.handle, 0)
+        self.assertNotEqual(name.handle, None)
+        self.assertNotEqual(name.handle, 0)
 
-        self.assertEqual(title.handle, title_re.handle)
-        self.assertEqual(title.handle, classname.handle)
-        self.assertEqual(title.handle, classname_re.handle)
-        self.assertEqual(title.handle, handle.handle)
-        self.assertEqual(title.handle, bestmatch.handle)
+        self.assertEqual(name.handle, name_re.handle)
+        self.assertEqual(name.handle, title.handle)
+        self.assertEqual(name.handle, title_re.handle)
+        self.assertEqual(name.handle, classname.handle)
+        self.assertEqual(name.handle, classname_re.handle)
+        self.assertEqual(name.handle, handle.handle)
+        self.assertEqual(name.handle, bestmatch.handle)
 
         app.UntitledNotepad.menu_select("File->Exit")
 


### PR DESCRIPTION
fixes #1338

### Note:
I don't have a Windows environment with an English interface, so I actually verified it with the following test code on a Windows environment with a Japanese interface.

```py
    def test_window(self):
        """Test that window_() works correctly"""
        app = Application()

        self.assertRaises(AppNotConnected, app.window_, **{'title' : 'not connected'})

        app.start(_notepad_exe())

        self.assertRaises(ValueError, app.windows_, **{'backend' : 'uia'})

        name = app.window(name="無題 - メモ帳")
        name_re = app.window(name_re="無題[ -]+メモ帳")
        title = app.window(title="無題 - メモ帳")
        title_re = app.window(title_re="無題[ -]+メモ帳")
        classname = app.window(class_name="Notepad")
        classname_re = app.window(class_name_re="Not..ad")
        handle = app.window(handle=name.handle)
        bestmatch = app.window(best_match="メモ帳Notepad")

        self.assertNotEqual(name.handle, None)
        self.assertNotEqual(name.handle, 0)

        self.assertEqual(name.handle, name_re.handle)
        self.assertEqual(name.handle, title.handle)
        self.assertEqual(name.handle, title_re.handle)
        self.assertEqual(name.handle, classname.handle)
        self.assertEqual(name.handle, classname_re.handle)
        self.assertEqual(name.handle, handle.handle)
        self.assertEqual(name.handle, bestmatch.handle)

        app.UntitledNotepad.menu_select("ファイル->メモ帳の終了")
```

I changed the arguments to English to make it work in the CI environment with an English interface, and then I committed and pushed the changes.