### PR TITLE
fix `ci/install.ps1` and other ci configs for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -86,7 +86,9 @@ install:
   # compiled extensions and are not provided as pre-built wheel packages,
   # pip will build them from source using the MSVC compiler matching the
   # target Python version and architecture
+  - "%PYTHON%\\python.exe -m pip install --upgrade pip"
   - "%CMD_IN_ENV% pip install -r dev-requirements.txt"
+  - "%CMD_IN_ENV% python -c \"import os,subprocess; os.environ.get('UIA_SUPPORT')=='YES' and subprocess.check_output(['pip','install','comtypes'])\""
 
   # Enable desktop (for correct screenshots).
   #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-desktop.ps1'))

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,46 +16,55 @@ environment:
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "32"
       UIA_SUPPORT: "NO"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - PYTHON: "C:\\Python27-x64"
       PYTHON_VERSION: "2.7"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - PYTHON: "C:\\Python35"
       PYTHON_VERSION: "3.5"
       PYTHON_ARCH: "32"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - PYTHON: "C:\\Python37"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "32"
       UIA_SUPPORT: "NO"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - PYTHON: "C:\\Python37-x64"
       PYTHON_VERSION: "3.7"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - PYTHON: "C:\\Python38-x64"
       PYTHON_VERSION: "3.8"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2015
 
     - PYTHON: "C:\\Python39"
       PYTHON_VERSION: "3.9"
       PYTHON_ARCH: "32"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
 
     - PYTHON: "C:\\Python310-x64"
       PYTHON_VERSION: "3.10"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
 
     - PYTHON: "C:\\Python311-x64"
       PYTHON_VERSION: "3.11"
       PYTHON_ARCH: "64"
       UIA_SUPPORT: "YES"
+      APPVEYOR_BUILD_WORKER_IMAGE: Visual Studio 2022
 
 #init:
   # Enable RDP.

--- a/ci/install.ps1
+++ b/ci/install.ps1
@@ -84,12 +84,6 @@ function UpdateConda ($python_home) {
     Start-Process -FilePath "$conda_path" -ArgumentList $args -Wait -Passthru
 }
 
-function InstallComtypes ($python_home) {
-    $pip_path = $python_home + "\Scripts\pip.exe"
-    $args = "install comtypes"
-    Start-Process -FilePath "$pip_path" -ArgumentList $args -Wait -Passthru
-}
-
 function main () {
     try {
         $CurrentResolution = Get-DisplayResolution
@@ -104,9 +98,6 @@ function main () {
     Write-Host "PYTHON_ARCH=" $env:PYTHON_ARCH
     Write-Host "UIA_SUPPORT=" $env:UIA_SUPPORT
 
-    if ($env:UIA_SUPPORT -eq "YES") {
-        InstallComtypes $env:PYTHON
-    }
     #InstallMiniconda $env:PYTHON_VERSION $env:PYTHON_ARCH $env:PYTHON
     #UpdateConda $env:PYTHON
     #InstallCondaPackages $env:PYTHON "pywin32 Pillow coverage nose"

--- a/ci/install.ps1
+++ b/ci/install.ps1
@@ -99,16 +99,10 @@ function main () {
         Write-Host "Can't print current resolution. Get-DisplayResolution cmd is not available"
     }
 
-    # fallback for running the script locally
-    if ( !(Test-Path $env:PYTHON) ) {
-        Write-Host "No PYTHON vars, setup default values"
-        $env:PYTHON="C:\\Python34-x64"
-        $env:PYTHON_VERSION="3.4"
-        $env:PYTHON_ARCH="64"     
-    }
     Write-Host "PYTHON=" $env:PYTHON
     Write-Host "PYTHON_VERSION=" $env:PYTHON_VERSION
     Write-Host "PYTHON_ARCH=" $env:PYTHON_ARCH
+    Write-Host "UIA_SUPPORT=" $env:UIA_SUPPORT
 
     if ($env:UIA_SUPPORT -eq "YES") {
         InstallComtypes $env:PYTHON

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -43,7 +43,13 @@ function run {
     
     #nosetests  --all-modules --with-xunit pywinauto/unittests
     # --traverse-namespace is required for python 3.8 https://stackoverflow.com/q/58556183
-    nosetests --nologcapture --traverse-namespace --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
+    $pyver = [System.Version]::new($env:PYTHON_VERSION)
+    if ($pyver.Major -gt 3 -or ($pyver.Major -eq 3 -and $pyver.Minor -ge 9)) {
+        coverage run --source=pywinauto -m nose2 --exclude=testall -vvv pywinauto.unittests
+        coverage xml -o $input
+    } else {
+        nosetests --nologcapture --traverse-namespace --exclude=testall --with-xunit --with-coverage --cover-html --cover-html-dir=Coverage_report --cover-package=pywinauto --verbosity=3 pywinauto\unittests
+    }
     $success = $?
     Write-Host "result code of nosetests:" $success
 

--- a/ci/runTestsuite.ps1
+++ b/ci/runTestsuite.ps1
@@ -41,6 +41,11 @@ function run {
     $input = "nosetests.xml"
     $output = "transformed.xml"
     
+    # Show file extensions
+    Set-ItemProperty -LiteralPath "HKCU:Software\Microsoft\Windows\CurrentVersion\Explorer\Advanced" -Name "HideFileExt" -Value "0" -Force
+    Stop-Process -Name Explorer -Force
+    Start-Sleep -Seconds 10
+
     #nosetests  --all-modules --with-xunit pywinauto/unittests
     # --traverse-namespace is required for python 3.8 https://stackoverflow.com/q/58556183
     $pyver = [System.Version]::new($env:PYTHON_VERSION)

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,12 +1,15 @@
 pywin32==301 ; python_version == '3.6' and sys_platform == "win32"
 pywin32 ; python_version != '3.6' and sys_platform == "win32"
 six
-pillow>=6.2.0
+pillow>=6.2.0 ; python_version != '3.9'
+pillow==9.5.0 ; python_version == '3.9'
 coverage
-nose
+nose ; python_version <= '3.8'
+nose2 ; python_version >= '3.9'
 codecov
 rst2pdf
 Sphinx
 mock==2.0.0
 codacy-coverage
-PyQt5==5.15.4 ; python_version >= '3.6'
+PyQt5==5.15.4 ; python_version >= '3.6' and python_version <= '3.8'
+PyQt5 ; python_version >= '3.9'


### PR DESCRIPTION
From the AppVeyor CI results in a previous PR, I noticed that in environments with Python 3.9 and later, `Test-Path $env:PYTHON` in `ci/install.ps1` returns False, and it falls back to Python 3.4.

As a result, even in cases where `UIA_SUPPORT=YES`, `comtypes` is not actually installed, and the functionality of `backend='uia'` is not being tested.

I'm experimenting with various solutions to fix this.

<details>
<summary>trial and error commits</summary>

### make tests runnable for each Python versions

> I tried [removing the fallback conditional](https://github.com/pywinauto/pywinauto/pull/1345/commits/97bd990c1186e72c10d36fd6e0cc27a34fc6fdbb), and while [it worked on Python 3.8](https://ci.appveyor.com/project/pywinauto/pywinauto/builds/48154955/job/lvsv6vnq1uybxjdk?fullLog=true#L7) and earlier, but [it failed on Python 3.9](https://ci.appveyor.com/project/pywinauto/pywinauto/builds/48154955/job/e5e7v0owexy3yv9y?fullLog=true#L7) and later.
> - (Is `C:\\Python3x\Scripts\pip.exe` truly missing from the env?)
> 

68204d2ba5dcf63f0739955cb95bebba4ae92c53
77e9f3d4a20dac98f880b16b2c4f92b151475ba2
6ec3cc90d393d02b16f568d8c8c8be08804cd392
a493bec8edb78ba4235d0676c9db2fb81a659488
c99a2771069409740d9bf714d1f1172cd81716dc
c1dfaa5c3b016dc875f57ccc28b66be4c710a12a
0a1c669fd187dbc963dcb56ab11add817c755a55
1077bd92ed8fe6d63460acfc55cf46f93579fa54
2b2b7a875e1be51ab3347cea564bcdaed0c4704d
83a69a61692b9f8a7e1ab49446adc406342de55d
5f9e12394396c5d4ab02f3bbec5c5e1821ef1eb0
1af2a72aee0d5ac2b2f4e07bf967509305ff8547
663b23b4577202e6278211da985eb62a24a141fa
d529000ad40b117bfca49f6d7f4885a4f7f0092e
f37d82eef85f360b537f0c79b2a522ed8e119551
47d4f4babd3f44a9f5e66e06abf10ca3472d8fbd
115b38d90919445d9d7165300f9066af34d69d93
c13950f6f9772ba19a500f55b982b5bd14a25528
0a7b9acfa7bba934007313f1e10c701fd519cc0b
1e7383fd47a67b092a7cf3c3a83f7e7fc0bdc14d
5d4e4d8045454f640a2f0cdf9c5c5281ba15ccc0
30d3d68951178993b6fb5b0e1abe29543372971b
6572f11a9b5ede2e7477945948b4d92f35386c87
a2aef5219fd74fcc78677c5e102ffd90363ba3f3
91d32fc9703376d07dbf064790ab4002ede6dc46
03a404dc0c72810657ef92346ee38fdf69245690
66eda1996f1f690b6efd68c6663ad194b2368b52
97bd990c1186e72c10d36fd6e0cc27a34fc6fdbb
70e864a09f7dd175e0ad09a9395af98702549503


</details>





I welcome other maintainers to contribute to resolving this issue.

Thank you.