### PR TITLE
Make linux tests stable.

### DIFF
--- a/.github/workflows/atspi_test.yml
+++ b/.github/workflows/atspi_test.yml
@@ -86,6 +86,6 @@ jobs:
         sleep 5
     - name: Run tests
       run: |
-        coverage run -m pytest pywinauto/unittests/test_atspi_element_info.py pywinauto/unittests/test_atspi_wrapper.py pywinauto/unittests/test_atspi_controls.py pywinauto/unittests/test_clipboard_linux.py pywinauto/unittests/test_keyboard.py pywinauto/unittests/test_application_linux.py
+        coverage run -m pytest pywinauto/unittests/test_atspi_element_info.py pywinauto/unittests/test_atspi_wrapper.py pywinauto/unittests/test_atspi_controls.py pywinauto/unittests/test_clipboard_linux.py pywinauto/unittests/test_keyboard.py pywinauto/unittests/test_application_linux.py -v
     - name: Upload Coverage to Codecov
       uses: codecov/codecov-action@v3

--- a/pywinauto/unittests/test_atspi_element_info.py
+++ b/pywinauto/unittests/test_atspi_element_info.py
@@ -145,7 +145,7 @@ if sys.platform.startswith("linux"):
             self.desktop_info = AtspiElementInfo()
             self.app = Application()
             self.app.start(_test_app())
-            time.sleep(1)
+            time.sleep(3)
             self.app_info = self.get_app(app_name)
             self.app2 = None
 


### PR DESCRIPTION
When I rebased my past PR, the CI pipeline that ran failed the tests on Linux, even though the changes did not modify the atspi functionality or cause any side effects.

After investigating the cause, it seems that an exception was likely being thrown in `AtspiElementInfoTests.setUp`.
To improve stability, I extended the sleep duration.

Once this is merged, I plan to rebase my past PR onto it as well.