### PR TITLE
Add and fix UIA pattern names.

### DIFF
--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -134,7 +134,7 @@ def _build_pattern_ids_dic():
         'Transform',
 
         # Windows 8 and later
-        'Annotation', 'Drag', 'Drop', 'ObjectModel', 'Spreadsheet',
+        'Annotation', 'Drag', 'DropTarget', 'ObjectModel', 'Spreadsheet',
         'SpreadsheetItem', 'Styles', 'TextChild', 'TextV2', 'TransformV2',
 
         # Windows 8.1 and later

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -141,7 +141,7 @@ def _build_pattern_ids_dic():
         'TextEdit',
 
         # Windows 10 and later
-        'CustomNavigation'
+        'CustomNavigation', 'SelectionV2',
     ]
 
     ptrn_ids_dic = {}


### PR DESCRIPTION
I noticed that in the UIA pattern names, `IUIAutomationDropPattern` is absent, and [`IUIAutomationDropTargetPattern`](https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationdroptargetpattern) exists instead. I also noticed that [`IUIAutomationSelectionPattern2`](https://learn.microsoft.com/en-us/windows/win32/api/uiautomationclient/nn-uiautomationclient-iuiautomationselectionpattern2) is not covered.

I vaguely remembered committing this fix and addition to my local branch a long time ago.

I've rebased those changes from that time onto the current `master`.