### PR TITLE
Remove `six` from this project dependencies.

### DIFF
--- a/.checkignore
+++ b/.checkignore
@@ -2,5 +2,4 @@ apps/*
 ci/*
 doc_src/*
 sandbox/*
-pywinauto/six.py
 pywinauto/unittests/*

--- a/README.md
+++ b/README.md
@@ -87,10 +87,8 @@ Properties.wait_not('visible') # make sure the dialog is closed
 * Windows:
   - [pyWin32](https://github.com/mhammond/pywin32/)
   - [comtypes](https://github.com/enthought/comtypes)
-  - [six](https://pypi.python.org/pypi/six)
 * Linux:
   - [python-xlib](https://github.com/python-xlib/python-xlib)
-  - [six](https://pypi.python.org/pypi/six)
 * Optional packages:
   - Install [Pillow](https://pypi.python.org/pypi/Pillow) (by `pip install -U Pillow`) to be able to call `capture_as_image()` method for making a control's snapshot.
 

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,7 +1,6 @@
 docutils<0.18
 pywin32<=227; python_version <= '3.6' and platform_system == 'Windows'
 pywin32>=300; python_version > '3.6' and platform_system == 'Windows'
-six
 Pillow==6.2.0; python_version <= '3.7'
 Pillow==10.3.0; python_version == '3.8'
 Pillow==11.1.0; python_version > '3.8'

--- a/docs/index.txt
+++ b/docs/index.txt
@@ -26,7 +26,6 @@ Manual installation
 
   - pyWin32_
   - comtypes_
-  - six_
   - *(optional)* Pillow_ (to make screenshots)
 
 - Download latest pywinauto from https://github.com/pywinauto/pywinauto/releases
@@ -35,7 +34,6 @@ Manual installation
 
 .. _pyWin32: https://github.com/mhammond/pywin32/releases
 .. _comtypes: https://github.com/enthought/comtypes/releases
-.. _six: https://pypi.python.org/pypi/six
 .. _Pillow: https://pypi.python.org/pypi/Pillow/2.7.0
 
 To check you have it installed correctly

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,4 @@
 Babel==2.17.0
 mock==2.0.0
 rst2pdf
-six==1.17.0
 Sphinx==8.2.3

--- a/pywinauto/base_application.py
+++ b/pywinauto/base_application.py
@@ -85,8 +85,6 @@ import codecs
 import collections
 import warnings
 
-import six
-
 from . import timings
 from . import controls
 from . import findbestmatch
@@ -796,23 +794,17 @@ class WindowSpecification(object):
                                    u'to see all children.\n'.format(max_width)
                 output += indent + u'**********'
 
-            if six.PY3:
-                log_func(output)
-            else:
-                log_func(output.encode(locale.getpreferredencoding(), errors='backslashreplace'))
+            log_func(output)
 
             if current_depth <= depth:
                 for child_elem in element_node.children:
                     print_identifiers(child_elem, current_depth + 1, log_func)
 
         if filename is None:
-            if six.PY3:
-                try:
-                    encoding = sys.stdout.encoding
-                except AttributeError:
-                    encoding = sys.getdefaultencoding()
-            else:
-                encoding = locale.getpreferredencoding()
+            try:
+                encoding = sys.stdout.encoding
+            except AttributeError:
+                encoding = sys.getdefaultencoding()
             print(u'# -*- coding: {} -*-'.format(encoding))
             print_identifiers(elements_tree)
         else:

--- a/pywinauto/base_types.py
+++ b/pywinauto/base_types.py
@@ -31,7 +31,6 @@
 
 """Definition of cross-platform types and structures"""
 
-import six
 from ctypes import Structure as Struct
 from ctypes import memmove
 from ctypes import addressof
@@ -173,11 +172,10 @@ class RectExtMixin(object):
         else:
             #if not isinstance(other, (int, long)):
             #    print type(self), type(other), other
-            long_int = six.integer_types[-1]
-            self.left = long_int(other)
-            self.right = long_int(right)
-            self.top = long_int(top)
-            self.bottom = long_int(bottom)
+            self.left = int(other)
+            self.right = int(right)
+            self.top = int(top)
+            self.bottom = int(bottom)
 
     # ----------------------------------------------------------------
     def __str__(self):

--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -38,8 +38,6 @@ import locale
 import re
 import sys
 
-import six
-
 try:
     from PIL import ImageGrab
 except ImportError:
@@ -83,8 +81,7 @@ class ElementNotActive(RuntimeError):
     pass
 
 #=========================================================================
-@six.add_metaclass(abc.ABCMeta)
-class BaseMeta(abc.ABCMeta):
+class BaseMeta(abc.ABCMeta, metaclass=abc.ABCMeta):
 
     """Abstract metaclass for Wrapper objects"""
 
@@ -94,8 +91,7 @@ class BaseMeta(abc.ABCMeta):
         raise NotImplementedError()
 
 #=========================================================================
-@six.add_metaclass(BaseMeta)
-class BaseWrapper(object):
+class BaseWrapper(object, metaclass=BaseMeta):
     """
     Abstract wrapper for elements.
 
@@ -141,7 +137,7 @@ class BaseWrapper(object):
         """
         self.backend = active_backend
         if element_info:
-            #if isinstance(element_info, six.integer_types):
+            #if isinstance(element_info, int):
             #    element_info = self.backend.element_info_class(element_info)
 
             self._element_info = element_info
@@ -182,13 +178,6 @@ class BaseWrapper(object):
         type_name = module + "." + self.__class__.__name__
         title = self.window_text()
         class_name = self.friendly_class_name()
-        if six.PY2:
-            if hasattr(sys.stdout, 'encoding') and sys.stdout.encoding is not None:
-                # some frameworks override sys.stdout without encoding attribute (Tee Stream),
-                # some users replace sys.stdout with file descriptor which can have None encoding
-                title = title.encode(sys.stdout.encoding, errors='backslashreplace')
-            else:
-                title = title.encode(locale.getpreferredencoding(), errors='backslashreplace')
         return type_name, title, class_name
 
     def __repr__(self):
@@ -205,10 +194,7 @@ class BaseWrapper(object):
         debugging purposes helping to distinguish between the runtime objects.
         """
         type_name, title, class_name = self.__repr_texts()
-        if six.PY2:
-            return b"<{0} - '{1}', {2}, {3}>".format(type_name, title, class_name, self.__hash__())
-        else:
-            return "<{0} - '{1}', {2}, {3}>".format(type_name, title, class_name, self.__hash__())
+        return "<{0} - '{1}', {2}, {3}>".format(type_name, title, class_name, self.__hash__())
 
     def __str__(self):
         """Pretty print representation of the wrapper object
@@ -222,10 +208,7 @@ class BaseWrapper(object):
         to prepare a window specification to access the control
         """
         type_name, title, class_name = self.__repr_texts()
-        if six.PY2:
-            return b"{0} - '{1}', {2}".format(type_name, title, class_name)
-        else:
-            return "{0} - '{1}', {2}".format(type_name, title, class_name)
+        return "{0} - '{1}', {2}".format(type_name, title, class_name)
 
     #------------------------------------------------------------
     @property

--- a/pywinauto/controls/atspi_controls.py
+++ b/pywinauto/controls/atspi_controls.py
@@ -33,7 +33,6 @@
 """Wrap various Linux ATSPI windows controls. To be used with 'atspi' backend"""
 
 import locale
-import six
 
 from . import atspiwrapper
 from ..import findbestmatch
@@ -148,7 +147,7 @@ class ComboBoxWrapper(atspiwrapper.AtspiWrapper):
         self.expand()
         children_lst = self.children(control_type='Menu')
         if len(children_lst) > 0:
-            if isinstance(item, six.string_types):
+            if isinstance(item, str):
                 if self.selected_text() != item:
                     item = children_lst[0].children(name=item)[0]
                     item.click()
@@ -236,28 +235,19 @@ class EditWrapper(atspiwrapper.AtspiWrapper):
             start, end = self.selection_indices()
             if pos_start is None:
                 pos_start = start
-            if pos_end is None and not isinstance(start, six.string_types):
+            if pos_end is None and not isinstance(start, str):
                 pos_end = end
         else:
             pos_start = 0
             pos_end = len(self.window_text())
 
-        if isinstance(text, six.text_type):
-            if six.PY3:
-                aligned_text = text
-            else:
-                aligned_text = text.encode(locale.getpreferredencoding())
-        elif isinstance(text, six.binary_type):
-            if six.PY3:
-                aligned_text = text.decode(locale.getpreferredencoding())
-            else:
-                aligned_text = text
+        if isinstance(text, str):
+            aligned_text = text
+        elif isinstance(text, bytes):
+            aligned_text = text.decode(locale.getpreferredencoding())
         else:
             # convert a non-string input
-            if six.PY3:
-                aligned_text = six.text_type(text)
-            else:
-                aligned_text = six.binary_type(text)
+            aligned_text = str(text)
 
         # Calculate new text value
         current_text = self.window_text()
@@ -279,12 +269,12 @@ class EditWrapper(atspiwrapper.AtspiWrapper):
 
         # if we have been asked to select a string
         string_to_select = False
-        if isinstance(start, six.text_type):
+        if isinstance(start, str):
             string_to_select = start
-        elif isinstance(start, six.binary_type):
+        elif isinstance(start, bytes):
             string_to_select = start.decode(locale.getpreferredencoding())
-        elif isinstance(start, six.integer_types):
-            if isinstance(end, six.integer_types) and start > end:
+        elif isinstance(start, int):
+            if isinstance(end, int) and start > end:
                 start, end = end, start
 
         if string_to_select:
@@ -523,9 +513,9 @@ class ScrollBarWrapper(atspiwrapper.AtspiWrapper):
         """Set position of slider's thumb"""
         if isinstance(value, float):
             value_to_set = value
-        elif isinstance(value, six.integer_types):
+        elif isinstance(value, int):
             value_to_set = value
-        elif isinstance(value, six.text_type):
+        elif isinstance(value, str):
             value_to_set = float(value)
         else:
             raise ValueError("value should be either string or number")

--- a/pywinauto/controls/atspiwrapper.py
+++ b/pywinauto/controls/atspiwrapper.py
@@ -34,8 +34,6 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
-import six
-
 from .. import backend
 from ..base_wrapper import BaseWrapper
 from ..base_wrapper import BaseMeta
@@ -89,8 +87,7 @@ class AtspiMeta(BaseMeta):
 
 
 # =========================================================================
-@six.add_metaclass(AtspiMeta)
-class AtspiWrapper(BaseWrapper):
+class AtspiWrapper(BaseWrapper, metaclass=AtspiMeta):
 
     """
     Default wrapper for User Interface Automation (Atspi) controls.

--- a/pywinauto/controls/common_controls.py
+++ b/pywinauto/controls/common_controls.py
@@ -51,7 +51,6 @@ import ctypes
 from ctypes import wintypes
 import warnings
 import locale
-import six
 
 from pywinauto.windows import win32defines, win32functions, win32structures
 from .. import findbestmatch
@@ -93,7 +92,7 @@ class _listview_item(object):
         list of item titles.
         """
         index = item
-        if isinstance(item, six.string_types):
+        if isinstance(item, str):
             index = int((self.listview_ctrl.texts().index(item) - 1) / self.listview_ctrl.column_count())
 
         return index
@@ -1326,7 +1325,7 @@ class _treeview_element(object):
         """
         #print child_spec
 
-        if isinstance(child_spec, six.string_types):
+        if isinstance(child_spec, str):
 
             texts = [c.text() for c in self.children()]
             if exact:
@@ -1545,7 +1544,7 @@ class TreeViewWrapper(hwndwrapper.HwndWrapper):
             return None
 
         # Ensure the path is absolute
-        if isinstance(path, six.string_types):
+        if isinstance(path, str):
             if not path.startswith("\\"):
                 raise RuntimeError(
                     "Only absolute paths allowed - "
@@ -1599,7 +1598,7 @@ class TreeViewWrapper(hwndwrapper.HwndWrapper):
             try:
                 current_elem = current_elem.get_child(child_spec, exact)
             except IndexError:
-                if isinstance(child_spec, six.string_types):
+                if isinstance(child_spec, str):
                     raise IndexError("Item '%s' does not have a child '%s'" %
                                      (current_elem.text(), child_spec))
                 else:
@@ -2212,7 +2211,7 @@ class TabControlWrapper(hwndwrapper.HwndWrapper):
 
         # if it's a string then find the index of
         # the tab with that text
-        if isinstance(tab, six.string_types):
+        if isinstance(tab, str):
             # find the string in the tab control
             best_text = findbestmatch.find_best_match(
                 tab, self.texts(), self.texts())
@@ -2455,7 +2454,7 @@ class ToolbarWrapper(hwndwrapper.HwndWrapper):
     #----------------------------------------------------------------
     def button(self, button_identifier, exact=True, by_tooltip=False):
         """Return the button at index button_index"""
-        if isinstance(button_identifier, six.string_types):
+        if isinstance(button_identifier, str):
             texts = self.texts()[1:]
             self.actions.log('Toolbar buttons: ' + str(texts))
             # one of these will be returned for the matching text

--- a/pywinauto/controls/hwndwrapper.py
+++ b/pywinauto/controls/hwndwrapper.py
@@ -45,7 +45,6 @@ import win32gui
 import win32con
 import win32process
 import win32event
-import six
 import pywintypes
 import warnings
 
@@ -124,7 +123,7 @@ class HwndMeta(BaseMeta):
     @staticmethod
     def find_wrapper(element):
         """Find the correct wrapper for this native element"""
-        if isinstance(element, six.integer_types):
+        if isinstance(element, int):
             element = HwndElementInfo(element)
         class_name = element.class_name
 
@@ -150,8 +149,7 @@ class HwndMeta(BaseMeta):
         return wrapper_match
 
 #====================================================================
-@six.add_metaclass(HwndMeta)
-class HwndWrapper(WinBaseWrapper):
+class HwndWrapper(WinBaseWrapper, metaclass=HwndMeta):
 
     """
     Default wrapper for controls.
@@ -188,7 +186,7 @@ class HwndWrapper(WinBaseWrapper):
         If the handle is not valid then an InvalidWindowHandle error
         is raised.
         """
-        if isinstance(element_info, six.integer_types):
+        if isinstance(element_info, int):
             element_info = HwndElementInfo(element_info)
         if hasattr(element_info, "element_info"):
             element_info = element_info.element_info
@@ -888,7 +886,7 @@ class HwndWrapper(WinBaseWrapper):
         if append:
             text = self.window_text() + text
 
-        text = ctypes.c_wchar_p(six.text_type(text))
+        text = ctypes.c_wchar_p(str(text))
         self.post_message(win32defines.WM_SETTEXT, 0, text)
         win32functions.WaitGuiThreadIdle(self.handle)
 
@@ -910,10 +908,10 @@ class HwndWrapper(WinBaseWrapper):
         rect = self.rectangle()
 
         #ret = win32functions.TextOut(
-        #    dc, rect.left, rect.top, six.text_type(text), len(text))
+        #    dc, rect.left, rect.top, str(text), len(text))
         ret = win32functions.DrawText(
             dc,
-            six.text_type(text),
+            str(text),
             len(text),
             ctypes.byref(rect),
             win32defines.DT_SINGLELINE)
@@ -1634,7 +1632,7 @@ def _perform_click(
     ctrl.verify_actionable()
     ctrl_text = ctrl.window_text()
     if ctrl_text is None:
-        ctrl_text = six.text_type(ctrl_text)
+        ctrl_text = str(ctrl_text)
 
     ctrl_friendly_class_name = ctrl.friendly_class_name()
 

--- a/pywinauto/controls/menuwrapper.py
+++ b/pywinauto/controls/menuwrapper.py
@@ -43,7 +43,6 @@ import time
 import win32gui
 import win32gui_struct
 import locale
-import six
 
 from functools import wraps
 from ..windows import win32defines, win32functions, win32structures
@@ -149,7 +148,7 @@ class MenuItem(object):
     FriendlyClassName = deprecated(friendly_class_name)
 
     #def __print__(self, ctrl, menu, index):
-    #    print('Menu ' + six.text_type(ctrl) + '; ' + six.text_type(menu) + '; ' + six.text_type(index))
+    #    print('Menu ' + str(ctrl) + '; ' + str(menu) + '; ' + str(index))
 
     def rectangle(self):
         """Get the rectangle of the menu item"""
@@ -211,8 +210,6 @@ class MenuItem(object):
     def text(self):
         """Return the text of this menu item"""
         item_info = self._read_item()
-        if six.PY2:
-            item_info.text = item_info.text.decode(locale.getpreferredencoding())
 
         # OWNERDRAW case try to get string from BCMenu
         if item_info.fType & 256 and not item_info.text:
@@ -362,10 +359,7 @@ class MenuItem(object):
 
     def __repr__(self):
         """Return a representation of the object as a string"""
-        if six.PY3:
-            return "<MenuItem " + self.text() + ">"
-        else:
-            return b"<MenuItem {}>".format(self.text().encode(locale.getpreferredencoding(), errors='backslashreplace'))
+        return "<MenuItem " + self.text() + ">"
 
 #    def check(self):
 #        item = self._read_item()
@@ -471,7 +465,7 @@ class Menu(object):
         * **exact** is True means exact matching for item text,
                        False means best matching.
         """
-        if isinstance(index, six.string_types):
+        if isinstance(index, str):
             if self.ctrl.appdata is not None:
                 menu_appdata = self.ctrl.appdata['menu_items']
             else:

--- a/pywinauto/controls/uiawrapper.py
+++ b/pywinauto/controls/uiawrapper.py
@@ -34,7 +34,6 @@
 from __future__ import unicode_literals
 from __future__ import print_function
 
-import six
 import time
 import warnings
 import comtypes
@@ -167,8 +166,7 @@ class UiaMeta(BaseMeta):
 
 
 # =========================================================================
-@six.add_metaclass(UiaMeta)
-class UIAWrapper(WinBaseWrapper):
+class UIAWrapper(WinBaseWrapper, metaclass=UiaMeta):
 
     """
     Default wrapper for User Interface Automation (UIA) controls.
@@ -716,10 +714,10 @@ class UIAWrapper(WinBaseWrapper):
         The action can be applied for dirrent controls with items:
         ComboBox, TreeView, Tab control
         """
-        if isinstance(item, six.integer_types):
+        if isinstance(item, int):
             item_index = item
             title = None
-        elif isinstance(item, six.string_types):
+        elif isinstance(item, str):
             item_index = 0
             title = item
         else:

--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -41,7 +41,6 @@ import win32gui
 import win32ui
 import win32api
 import win32con
-import six
 
 from ..windows.win32structures import RECT
 
@@ -60,8 +59,7 @@ from ..base_wrapper import BaseMeta
 
 
 #=========================================================================
-@six.add_metaclass(BaseMeta)
-class WinBaseWrapper(BaseWrapper):
+class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
     """
     Abstract wrapper for elements.
 
@@ -202,7 +200,7 @@ class WinBaseWrapper(BaseWrapper):
         if use_log:
             ctrl_text = self.window_text()
             if ctrl_text is None:
-                ctrl_text = six.text_type(ctrl_text)
+                ctrl_text = str(ctrl_text)
             if button.lower() == 'move':
                 message = 'Moved mouse over ' + self.friendly_class_name() + \
                           ' "' + ctrl_text + '" to screen point ('
@@ -326,13 +324,13 @@ class WinBaseWrapper(BaseWrapper):
             # TODO: UIA stuff maybe
             pass
 
-        if isinstance(keys, six.text_type):
+        if isinstance(keys, str):
             aligned_keys = keys
-        elif isinstance(keys, six.binary_type):
+        elif isinstance(keys, bytes):
             aligned_keys = keys.decode(locale.getpreferredencoding())
         else:
             # convert a non-string input
-            aligned_keys = six.text_type(keys)
+            aligned_keys = str(keys)
 
         # Play the keys to the active window
         keyboard.send_keys(

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -31,7 +31,6 @@
 
 """Interface for classes which should deal with different backend elements"""
 
-from six import integer_types
 
 class ElementInfo(object):
 
@@ -159,7 +158,7 @@ class ElementInfo(object):
     def filter_with_depth(elements, root, depth):
         """Return filtered elements with particular depth level relative to the root"""
         if depth is not None:
-                if isinstance(depth, integer_types) and depth > 0:
+                if isinstance(depth, int) and depth > 0:
                     return [element for element in elements if element.has_depth(root, depth)]
                 else:
                     raise Exception("Depth must be natural number")

--- a/pywinauto/findbestmatch.py
+++ b/pywinauto/findbestmatch.py
@@ -34,7 +34,6 @@ from __future__ import unicode_literals
 
 import re
 import difflib
-import six
 #import ctypes
 #import ldistance
 #levenshtein_distance = ctypes.cdll.levenshtein.levenshtein_distance
@@ -89,7 +88,7 @@ def _get_match_ratios(texts, match_against):
             ratio_calc.set_seq2(text)
 
             # try using the levenshtein distance instead
-            #lev_dist = levenshtein_distance(six.text_type(match_against), six.text_type(text))
+            #lev_dist = levenshtein_distance(str(match_against), str(text))
             #ratio = 1 - lev_dist / 10.0
             #ratios[text] = ratio
 
@@ -434,7 +433,7 @@ class UniqueDict(dict):
                 _cache[(text, search_text)] = ratio
 
             # try using the levenshtein distance instead
-            #lev_dist = levenshtein_distance(six.text_type(search_text), six.text_type(text))
+            #lev_dist = levenshtein_distance(str(search_text), str(text))
             #ratio = 1 - lev_dist / 10.0
             #ratios[text_] = ratio
             #print "%5s" %("%0.2f"% ratio), search_text, `text`
@@ -504,7 +503,7 @@ def find_best_control_matches(search_text, controls):
 #        for name in ctrl_names:
 #            name_control_map[name] = ctrl
 
-    search_text = six.text_type(search_text)
+    search_text = str(search_text)
 
     best_ratio, best_texts = name_control_map.find_best_matches(search_text)
 

--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -34,7 +34,6 @@ from __future__ import unicode_literals
 
 import re
 import warnings
-import six
 
 from . import findbestmatch
 from . import WindowNotFoundError
@@ -90,7 +89,7 @@ def find_element(**kwargs):
         exception = ElementAmbiguousError(
             "There are {0} elements that match the criteria {1}".format(
                 len(elements),
-                six.text_type(kwargs),
+                str(kwargs),
             )
         )
 
@@ -181,7 +180,7 @@ def find_elements(**kwargs):
 
     if isinstance(parent, backend_obj.generic_wrapper_class):
         parent = parent.element_info
-    elif isinstance(parent, six.integer_types):
+    elif isinstance(parent, int):
         # check if parent is a handle of element (in case of searching native controls)
         parent = backend_obj.element_info_class(parent)
     elif parent and not isinstance(parent, backend_obj.element_info_class):

--- a/pywinauto/linux/atspi_objects.py
+++ b/pywinauto/linux/atspi_objects.py
@@ -33,7 +33,6 @@
 """Low-level interface to Linux ATSPI"""
 
 import subprocess
-import six
 
 from ctypes import c_int, c_bool, c_char_p, c_char, POINTER, c_uint, c_uint32, c_uint64, c_double, c_short, \
     create_string_buffer, cdll, pointer, c_void_p, CFUNCTYPE
@@ -433,8 +432,7 @@ def _find_library(libs_list):
         return libs_list[-1]
 
 
-@six.add_metaclass(Singleton)
-class IATSPI(object):
+class IATSPI(object, metaclass=Singleton):
 
     """Python wrapper around C functions from ATSPI library"""
 

--- a/pywinauto/linux/keyboard.py
+++ b/pywinauto/linux/keyboard.py
@@ -41,7 +41,6 @@ from Xlib import X
 from Xlib.ext.xtest import fake_input
 import Xlib.XK
 import time
-import six
 
 _display = Display()
 
@@ -311,7 +310,7 @@ class KeyAction(object):
 
     def run(self):
         """Do a single keyboard action using xlib"""
-        if isinstance(self.key, six.string_types):
+        if isinstance(self.key, str):
             key = self.key
             self.key = Xlib.XK.string_to_keysym(self.key)
             if self.key == 0:
@@ -320,7 +319,7 @@ class KeyAction(object):
             if self.key == 0:
                 raise RuntimeError('Key {} not found!'.format(self.key))
             self.is_shifted = key.isupper() or key in '~!@#$%^&*()_+{}|:"<>?'
-        elif not isinstance(self.key, six.integer_types):
+        elif not isinstance(self.key, int):
             raise TypeError('self.key = {} is not a string or integer'.format(self.key))
 
         self._key_modifiers(self.ctrl, (self.shift or self.is_shifted),

--- a/pywinauto/tests/__init__.py
+++ b/pywinauto/tests/__init__.py
@@ -32,8 +32,6 @@
 """Package of tests that can be run on controls or lists of controls"""
 from __future__ import print_function
 
-import six
-
 
 def run_tests(controls, tests_to_run = None, test_visible_only = True):
     """Run the tests"""
@@ -66,8 +64,8 @@ def get_bug_as_string(bug):
     header = ["BugType:", str(bug_type), str(is_in_ref)]
 
     for i in info:
-        header.append(six.text_type(i))
-        header.append(six.text_type(info[i]))
+        header.append(str(i))
+        header.append(str(info[i]))
 
     lines = []
     lines.append(" ".join(header))
@@ -97,7 +95,7 @@ def print_bugs(bugs):
         print("BugType:", bug_type, is_in_ref)
 
         for i in info:
-            print(six.text_type(i).encode('utf-8'), six.text_type(info[i]).encode('utf-8'))
+            print(str(i).encode('utf-8'), str(info[i]).encode('utf-8'))
         print()
 
         for i, ctrl in enumerate(ctrls):

--- a/pywinauto/tests/comparetoreffont.py
+++ b/pywinauto/tests/comparetoreffont.py
@@ -82,7 +82,6 @@ The identifier for this test/bug is "CompareToRefFont"
 
 testname = "CompareToRefFont"
 
-import six
 from pywinauto.windows import win32structures
 
 _font_attribs = [field[0] for field in win32structures.LOGFONTW._fields_]
@@ -110,8 +109,8 @@ def CompareToRefFontTest(windows):
                     [win, ],
                     {
                         "ValueType": font_attrib,
-                        "Ref": six.text_type(ref_value),
-                        "Loc": six.text_type(loc_value),
+                        "Ref": str(ref_value),
+                        "Loc": str(loc_value),
                     },
                     testname,
                     0,)

--- a/pywinauto/tests/miscvalues.py
+++ b/pywinauto/tests/miscvalues.py
@@ -70,7 +70,6 @@ The identifier for this test/bug is "MiscValues"
 
 testname = "MiscValues"
 
-import six
 
 def MiscValuesTest(windows):
     """Return the bugs from checking miscelaneous values of a control"""
@@ -107,8 +106,8 @@ def MiscValuesTest(windows):
                 [win, ],
                 {
                     "ValueType": diff,
-                    "Ref": six.text_type(vals[1]),
-                    "Loc": six.text_type(vals[0]),
+                    "Ref": str(vals[1]),
+                    "Loc": str(vals[0]),
                 },
                 testname,
                 0,)

--- a/pywinauto/tests/translation.py
+++ b/pywinauto/tests/translation.py
@@ -80,7 +80,7 @@ The identifier for this test/bug is "Translation" """
 testname = "Translation"
 
 import re
-import six
+
 
 #-----------------------------------------------------------------------------
 def TranslationTest(windows):
@@ -94,7 +94,7 @@ def TranslationTest(windows):
         untranTitles, untranIndices = _GetUntranslations(win)
 
         if untranTitles:
-            indicesAsString = ",".join([six.text_type(idx) for idx in untranIndices])
+            indicesAsString = ",".join([str(idx) for idx in untranIndices])
 
             bugs.append((
                 [win,],

--- a/pywinauto/tests/truncation.py
+++ b/pywinauto/tests/truncation.py
@@ -72,7 +72,6 @@ The identifier for this test/bug is "Truncation"
 testname = "Truncation"
 
 import ctypes
-import six
 
 from pywinauto.windows import win32defines, win32functions, win32structures
 
@@ -101,9 +100,9 @@ def TruncationTest(windows):
                 if refTruncIdxs:
                     isInRef = 1
 
-            truncIdxs = ",".join([six.text_type(index) for index in truncIdxs])
+            truncIdxs = ",".join([str(index) for index in truncIdxs])
             truncStrings = '"%s"' % ",".join(
-                [six.text_type(string) for string in truncStrings])
+                [str(string) for string in truncStrings])
             truncations.append((
                 [win,],
                 {
@@ -189,7 +188,7 @@ def _GetMinimumRect(text, font, usableRect, drawFlags):
     # Now write the text to our DC with our font to get the
     # rectangle that the text needs to fit in
     win32functions.DrawText (txtDC,  # The DC
-                             six.text_type(text),  # The Title of the control
+                             str(text),  # The Title of the control
                              -1,  # -1 because sTitle is NULL terminated
                              ctypes.byref(modifiedRect),  # The rectangle to be calculated to
                              #truncCtrlData.drawTextFormat |

--- a/pywinauto/timings.py
+++ b/pywinauto/timings.py
@@ -113,7 +113,6 @@ The Following are the individual timing settings that can be adjusted:
 
 """
 
-import six
 import time
 import operator
 from functools import wraps
@@ -298,10 +297,7 @@ class TimeoutError(RuntimeError):
 
 
 #=========================================================================
-if six.PY3:
-    _clock_func = time.perf_counter
-else:
-    _clock_func = time.clock
+_clock_func = time.perf_counter
 
 
 def timestamp():

--- a/pywinauto/unittests/test_actionlogger.py
+++ b/pywinauto/unittests/test_actionlogger.py
@@ -37,7 +37,7 @@ import os
 import sys
 import logging
 import mock
-from six.moves import reload_module
+import importlib
 sys.path.append(".")
 from pywinauto import actionlogger  # noqa: E402
 from pywinauto.windows.application import Application  # noqa: E402
@@ -118,7 +118,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
             self.logger_patcher.stop()
 
         self.module_patcher.stop()
-        reload_module(actionlogger)
+        importlib.reload(actionlogger)
 
     def test_import_clash(self):
         """Test a custom logger import clash: issue #315"""
@@ -131,7 +131,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
         self.module_patcher = mock.patch.dict('sys.modules', self.modules)
         self.module_patcher.start()
 
-        reload_module(actionlogger)
+        importlib.reload(actionlogger)
         self.assertEqual(False, actionlogger._found_logger)
 
         # Verify the fallback to the standard logger
@@ -140,7 +140,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
 
     def test_import_custom_logger(self):
         """Test if custom logger class can be imported"""
-        reload_module(actionlogger)
+        importlib.reload(actionlogger)
         self.assertEqual(True, actionlogger._found_logger)
 
         # Check there is no instance of logger created on import
@@ -151,7 +151,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
 
     def test_logger_disable_and_reset(self):
         """Test if the logger can be disabled and level reset"""
-        reload_module(actionlogger)
+        importlib.reload(actionlogger)
 
         # verify on mock
         self.logger_patcher = mock.patch('pywinauto.actionlogger.ActionLogger', spec=True)
@@ -165,7 +165,7 @@ class ActionLoggerOnCustomLoggerTestCases(unittest.TestCase):
 
     def test_logger_enable_mapped_to_reset_level(self):
         """Test if the logger enable is mapped to reset_level"""
-        reload_module(actionlogger)
+        importlib.reload(actionlogger)
 
         # verify on mock
         self.logger_patcher = mock.patch('pywinauto.actionlogger.ActionLogger', spec=True)

--- a/pywinauto/unittests/test_application.py
+++ b/pywinauto/unittests/test_application.py
@@ -45,7 +45,6 @@ import warnings
 from threading import Thread
 import ctypes
 import mock
-import six
 
 sys.path.append(".")
 from pywinauto import Desktop
@@ -1523,7 +1522,7 @@ class DesktopWin32WindowSpecificationTests(unittest.TestCase):
         self.assertIsInstance(dlg, TrackbarWrapper)
 
         pos = dlg.get_position()
-        self.assertIsInstance(pos, six.integer_types)
+        self.assertIsInstance(pos, int)
 
         with self.assertRaises(AttributeError):
             getattr(self.desktop_no_magic, self.window_title.replace(" ", "_"))

--- a/pywinauto/unittests/test_atspi_controls.py
+++ b/pywinauto/unittests/test_atspi_controls.py
@@ -36,7 +36,6 @@ import os
 import sys
 import time
 import unittest
-import six
 import mock
 import ctypes
 
@@ -300,10 +299,8 @@ if sys.platform.startswith("linux"):
 
             expected_err_msg = "GError with code: {0}, message: '{1}'".format(
                                gerror.code, gerror.message.decode(encoding='UTF-8'))
-            six.assertRaisesRegex(self,
-                                  GErrorException,
-                                  expected_err_msg,
-                                  self.wrp.locale)
+            with self.assertRaisesRegex(GErrorException, expected_err_msg):
+                self.wrp.locale()
 
         @mock.patch.object(AtspiDocument, '_get_attribute_value')
         def test_document_get_attribute_value_success(self, mock_get_attribute_value):

--- a/pywinauto/unittests/test_common_controls.py
+++ b/pywinauto/unittests/test_common_controls.py
@@ -41,7 +41,6 @@ from datetime import datetime
 import os
 import win32api
 import win32gui
-import six
 
 sys.path.append(".")
 from pywinauto.windows.application import Application  # noqa: E402
@@ -1154,7 +1153,7 @@ class ToolbarTestCases(unittest.TestCase):
     def testTexts(self):
         """Make sure the texts are set correctly"""
         for txt in self.ctrl.texts():
-            self.assertEqual(isinstance(txt, six.string_types), True)
+            self.assertIsInstance(txt, str)
 
     def testGetProperties(self):
         """Test getting the properties for the toolbar control"""
@@ -1284,7 +1283,7 @@ class RebarTestCases(unittest.TestCase):
     def testTexts(self):
         """Make sure the texts are set correctly"""
         for txt in self.ctrl.texts():
-            self.assertEqual(isinstance(txt, six.string_types), True)
+            self.assertIsInstance(txt, str)
 
     def testBandCount(self):
         """Make sure band_count() returns 2"""

--- a/pywinauto/unittests/test_handleprops.py
+++ b/pywinauto/unittests/test_handleprops.py
@@ -32,7 +32,6 @@
 """Tests for handleprops.py"""
 
 import unittest
-import six
 import os
 import platform
 import sys
@@ -221,10 +220,10 @@ class HandlepropsTestCases(unittest.TestCase):
     def test_font(self):
         """Make sure font() function works"""
         dlgfont = font(self.dlghandle)
-        self.assertEqual(True, isinstance(dlgfont.lfFaceName, six.string_types))
+        self.assertIsInstance(dlgfont.lfFaceName, str)
 
         editfont = font(self.edit_handle)
-        self.assertEqual(True, isinstance(editfont.lfFaceName, six.string_types))
+        self.assertIsInstance(editfont.lfFaceName, str)
 
         # handle.props font should return DEFAULT font for an invalid handle
         # Check only for a returned type as the default font can vary

--- a/pywinauto/unittests/test_hwndwrapper.py
+++ b/pywinauto/unittests/test_hwndwrapper.py
@@ -33,7 +33,6 @@
 from __future__ import print_function
 from __future__ import unicode_literals
 
-import six
 import time
 #import pprint
 #import pdb
@@ -548,10 +547,7 @@ class HwndWrapperTests(unittest.TestCase):
 
     def test_pretty_print(self):
         """Test __str__ method for HwndWrapper based controls"""
-        if six.PY3:
-            assert_regex = self.assertRegex
-        else:
-            assert_regex = self.assertRegexpMatches
+        assert_regex = self.assertRegex
 
         wrp = self.dlg.find()
         assert_regex(wrp.__str__(), "^hwndwrapper.DialogWrapper - 'Common Controls Sample', Dialog$")

--- a/pywinauto/unittests/test_keyboard.py
+++ b/pywinauto/unittests/test_keyboard.py
@@ -224,10 +224,7 @@ class SendKeysTests(unittest.TestCase):
     #    extended_chars = b"\x81\x82\x83\xa1\xe1\xff"
     #    for char in extended_chars:
 
-    #        if six.PY3:
-    #            c = str(char)
-    #        else:
-    #            c = char.decode(locale.getpreferredencoding()) #'cp850')
+    #        c = str(char)
     #        send_keys(c, pause = .01)
     #        received = self.receive_text()[-1]
 

--- a/pywinauto/unittests/test_uiawrapper.py
+++ b/pywinauto/unittests/test_uiawrapper.py
@@ -9,7 +9,6 @@ import collections
 import unittest
 
 import mock
-import six
 
 sys.path.append(".")
 from pywinauto.windows.application import Application  # noqa: E402
@@ -347,14 +346,14 @@ if UIA_support:
             # Check an exception on a non-scrollable control
             button = self.dlg.by(class_name="Button",
                                  name="OK").find()
-            six.assertRaisesRegex(self, AttributeError, "not scrollable",
-                                  button.scroll, "left", "page")
+            with self.assertRaisesRegex(AttributeError, "not scrollable"):
+                button.scroll("left", "page")
 
             # Check an exception on a control without horizontal scroll bar
             tab = self.dlg.Tree_and_List_Views.select()
             listview = self.dlg.child_window(auto_id="lvVegs", control_type="DataGrid").wait('ready')
-            six.assertRaisesRegex(self, AttributeError, "not horizontally scrollable",
-                                  listview.scroll, "right", "line")
+            with self.assertRaisesRegex(AttributeError, "not horizontally scrollable"):
+                listview.scroll("right", "line")
 
             # Check exceptions on wrong arguments
             self.assertRaises(ValueError, listview.scroll, "bbbb", "line")
@@ -376,8 +375,8 @@ if UIA_support:
             # Check an exception on a control without vertical scroll bar
             tab = self.dlg.ListBox_and_Grid.set_focus()
             datagrid = tab.children(class_name=u"DataGrid")[0]
-            six.assertRaisesRegex(self, AttributeError, "not vertically scrollable",
-                                  datagrid.scroll, "down", "page")
+            with self.assertRaisesRegex(AttributeError, "not vertically scrollable"):
+                datagrid.scroll("down", "page")
 
         # def testVerifyActionable(self):
         #    self.assertRaises()
@@ -611,10 +610,7 @@ if UIA_support:
 
         def test_pretty_print(self):
             """Test __str__ and __repr__ methods for UIA based controls"""
-            if six.PY3:
-                assert_regex = self.assertRegex
-            else:
-                assert_regex = self.assertRegexpMatches
+            assert_regex = self.assertRegex
 
             wrp = self.dlg.OK.find()
             assert_regex(wrp.__str__(), r"^uia_controls\.ButtonWrapper - 'OK', Button$")

--- a/pywinauto/unittests/test_xml_helpers.py
+++ b/pywinauto/unittests/test_xml_helpers.py
@@ -34,7 +34,6 @@
 import os
 import sys
 import unittest
-import six
 sys.path.append(".")
 
 from pywinauto.xml_helpers import WriteDialogToFile
@@ -76,7 +75,7 @@ class XMLHelperTestCases(unittest.TestCase):
         """Test writing/reading a dictionary with some escape sequences"""
         test_string = []
         for i in range(0, 50000):
-            test_string.append(six.unichr(i))
+            test_string.append(chr(i))
 
         test_string = "".join(test_string)
 

--- a/pywinauto/unittests/testall.py
+++ b/pywinauto/unittests/testall.py
@@ -87,8 +87,7 @@ def run_tests():
     print(cov.report())
     cov.html_report(
         directory = os.path.join(package_root, "Coverage_report"),
-        omit = [os.path.join(package_root, 'pywinauto', '*tests', '*.py'),
-                os.path.join(package_root, 'pywinauto', 'six.py'), ]
+        omit = [os.path.join(package_root, 'pywinauto', '*tests', '*.py')]
         )
 
 

--- a/pywinauto/windows/keyboard.py
+++ b/pywinauto/windows/keyboard.py
@@ -33,7 +33,6 @@
 """Windows branch of the keyboard module
 
 """
-import six
 
 from ctypes import wintypes
 from ctypes import windll
@@ -596,9 +595,9 @@ class KeyboardHook(object):
         key_code = kbd.vkCode
         if key_code == VK_PACKET:
             scan_code = kbd.scanCode
-            current_key = six.unichr(scan_code)
+            current_key = chr(scan_code)
         elif key_code in self.ID_TO_KEY:
-            current_key = six.u(self.ID_TO_KEY[key_code])
+            current_key = self.ID_TO_KEY[key_code]
         else:
             al = ActionLogger()
             al.log("_process_data, bad key_code: {0}".format(key_code))
@@ -717,8 +716,8 @@ class KeyAction(object):
 
     def __init__(self, key, down=True, up=True):
         self.key = key
-        if isinstance(self.key, six.string_types):
-            self.key = six.text_type(key)
+        if isinstance(self.key, str):
+            self.key = str(key)
         self.down = down
         self.up = up
 
@@ -994,7 +993,7 @@ def parse_keys(string,
                 should_escape_next_keys = True
             current_keys = handle_code(code, vk_packet)
             if current_key_event is not None:
-                if isinstance(current_keys[0].key, six.string_types):
+                if isinstance(current_keys[0].key, str):
                     current_keys[0] = EscapedKeyAction(current_keys[0].key)
 
                 if current_key_event.strip() == 'up':

--- a/pywinauto/windows/uia_defines.py
+++ b/pywinauto/windows/uia_defines.py
@@ -33,14 +33,11 @@
 
 import comtypes
 import comtypes.client
-import six
 
 from ..backend import Singleton
 
 
-
-@six.add_metaclass(Singleton)
-class IUIA(object):
+class IUIA(object, metaclass=Singleton):
 
     """Singleton class to store global COM objects from UIAutomationCore.dll"""
 
@@ -91,7 +88,7 @@ class IUIA(object):
             conditions.append(self.iuia.CreatePropertyCondition(self.UIA_dll.UIA_ClassNamePropertyId, class_name))
 
         if control_type:
-            if isinstance(control_type, six.string_types):
+            if isinstance(control_type, str):
                 control_type = self.known_control_types[control_type]
             elif not isinstance(control_type, int):
                 raise TypeError('control_type must be string or integer')

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -126,9 +126,9 @@ class UIAElementInfo(ElementInfo):
         """Return an actual class name of the element"""
         try:
             cn = self._element.CurrentClassName
-            return str('') if cn is None else cn
+            return "" if cn is None else cn
         except COMError:
-            return str('')  # probably element already doesn't exist
+            return ""  # probably element already doesn't exist
 
     def _get_cached_class_name(self):
         """Return a cached class name of the element"""
@@ -166,9 +166,9 @@ class UIAElementInfo(ElementInfo):
         """Return an actual name of the element"""
         try:
             n = self._element.CurrentName
-            return str('') if n is None else n
+            return "" if n is None else n
         except COMError:
-            return str('')  # probably element already doesn't exist
+            return ""  # probably element already doesn't exist
 
     def _get_cached_name(self):
         """Return a cached name of the element"""
@@ -304,84 +304,84 @@ class UIAElementInfo(ElementInfo):
         """Return access key for the element. Most preferred way to get keyboard shortcut"""
         try:
             val = self._element.CurrentAccessKey
-            return str('') if val is None else val
+            return "" if val is None else val
         except COMError:
             # probably element already doesn't exist
-            return str('')
+            return ""
 
     @property
     def accelerator(self):
         """Return accelerator key for the element (try to use access_key property in case of empty value) """
         try:
             val = self._element.CurrentAcceleratorKey
-            return str('') if val is None else val
+            return "" if val is None else val
         except COMError:
             # probably element already doesn't exist
-            return str('')
+            return ""
 
     @property
     def value(self):
         """Return value of the element from ValuePattern (in order to search elements by this property)"""
         try:
             val = get_elem_interface(self._element, "Value").CurrentValue
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
             # COMError also can be raised in case of attempt to get value of password EditBox
-            return str('')
+            return ""
 
     @property
     def legacy_action(self):
         """Return DefaultAction value of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentDefaultAction
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return str('')
+            return ""
 
     @property
     def legacy_descr(self):
         """Return description of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentDescription
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return str('')
+            return ""
 
     @property
     def legacy_help(self):
         """Return help string of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentHelp
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return str('')
+            return ""
 
     @property
     def legacy_name(self):
         """Return name of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentName
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return str('')
+            return ""
 
     @property
     def legacy_shortcut(self):
         """Return keyboard shortcut of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentKeyboardShortcut
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return str('')
+            return ""
 
     @property
     def legacy_value(self):
         """Return value of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentValue
-            return str('') if val is None else val
+            return "" if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return str('')
+            return ""
 
     @property
     def parent(self):

--- a/pywinauto/windows/uia_element_info.py
+++ b/pywinauto/windows/uia_element_info.py
@@ -32,7 +32,6 @@
 """Implementation of the class to deal with an UI element (based on UI Automation API)"""
 
 from comtypes import COMError
-from six import integer_types, text_type, string_types
 from ctypes.wintypes import tagPOINT
 import warnings
 
@@ -60,9 +59,9 @@ def is_element_satisfying_criteria(element, process=None, class_name=None, name=
     """Check if element satisfies filter criteria"""
     is_appropriate_control_type = True
     if control_type:
-        if isinstance(control_type, string_types):
+        if isinstance(control_type, str):
             is_appropriate_control_type = element.CurrentControlType == IUIA().known_control_types[control_type]
-        elif not isinstance(control_type, integer_types):
+        elif not isinstance(control_type, int):
             raise TypeError('control_type must be string or integer')
         else:
             is_appropriate_control_type = element.CurrentControlType == control_type
@@ -110,7 +109,7 @@ class UIAElementInfo(ElementInfo):
         If handle_or_elem is None create an instance for UI root element.
         """
         if handle_or_elem is not None:
-            if isinstance(handle_or_elem, integer_types):
+            if isinstance(handle_or_elem, int):
                 # Create instane of UIAElementInfo from a handle
                 self._element = IUIA().iuia.ElementFromHandle(handle_or_elem)
             elif isinstance(handle_or_elem, IUIA().ui_automation_client.IUIAutomationElement):
@@ -127,9 +126,9 @@ class UIAElementInfo(ElementInfo):
         """Return an actual class name of the element"""
         try:
             cn = self._element.CurrentClassName
-            return text_type('') if cn is None else cn
+            return str('') if cn is None else cn
         except COMError:
-            return text_type('')  # probably element already doesn't exist
+            return str('')  # probably element already doesn't exist
 
     def _get_cached_class_name(self):
         """Return a cached class name of the element"""
@@ -167,9 +166,9 @@ class UIAElementInfo(ElementInfo):
         """Return an actual name of the element"""
         try:
             n = self._element.CurrentName
-            return text_type('') if n is None else n
+            return str('') if n is None else n
         except COMError:
-            return text_type('')  # probably element already doesn't exist
+            return str('')  # probably element already doesn't exist
 
     def _get_cached_name(self):
         """Return a cached name of the element"""
@@ -305,84 +304,84 @@ class UIAElementInfo(ElementInfo):
         """Return access key for the element. Most preferred way to get keyboard shortcut"""
         try:
             val = self._element.CurrentAccessKey
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except COMError:
             # probably element already doesn't exist
-            return text_type('')
+            return str('')
 
     @property
     def accelerator(self):
         """Return accelerator key for the element (try to use access_key property in case of empty value) """
         try:
             val = self._element.CurrentAcceleratorKey
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except COMError:
             # probably element already doesn't exist
-            return text_type('')
+            return str('')
 
     @property
     def value(self):
         """Return value of the element from ValuePattern (in order to search elements by this property)"""
         try:
             val = get_elem_interface(self._element, "Value").CurrentValue
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
             # COMError also can be raised in case of attempt to get value of password EditBox
-            return text_type('')
+            return str('')
 
     @property
     def legacy_action(self):
         """Return DefaultAction value of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentDefaultAction
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return text_type('')
+            return str('')
 
     @property
     def legacy_descr(self):
         """Return description of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentDescription
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return text_type('')
+            return str('')
 
     @property
     def legacy_help(self):
         """Return help string of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentHelp
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return text_type('')
+            return str('')
 
     @property
     def legacy_name(self):
         """Return name of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentName
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return text_type('')
+            return str('')
 
     @property
     def legacy_shortcut(self):
         """Return keyboard shortcut of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentKeyboardShortcut
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return text_type('')
+            return str('')
 
     @property
     def legacy_value(self):
         """Return value of the element from LegacyIAccessible pattern"""
         try:
             val = get_elem_interface(self._element, "LegacyIAccessible").CurrentValue
-            return text_type('') if val is None else val
+            return str('') if val is None else val
         except (NoPatternInterfaceError, COMError):
-            return text_type('')
+            return str('')
 
     @property
     def parent(self):
@@ -436,7 +435,7 @@ class UIAElementInfo(ElementInfo):
         """Iterate over descendants of the element"""
         cache_enable = kwargs.pop('cache_enable', False)
         depth = kwargs.pop("depth", None)
-        if not isinstance(depth, (integer_types, type(None))) or isinstance(depth, integer_types) and depth < 0:
+        if not isinstance(depth, (int, type(None))) or isinstance(depth, int) and depth < 0:
             raise Exception("Depth must be an integer")
 
         if depth == 0:

--- a/pywinauto/windows/win32_element_info.py
+++ b/pywinauto/windows/win32_element_info.py
@@ -32,7 +32,6 @@
 """Implementation of the class to deal with a native element (window with a handle)"""
 
 import ctypes
-import six
 import win32gui
 
 from pywinauto.windows import win32functions
@@ -43,8 +42,8 @@ from pywinauto.windows.remote_memory_block import RemoteMemoryBlock
 
 
 def _register_win_msg(msg_name):
-    msg_id = win32functions.RegisterWindowMessage(six.text_type(msg_name))
-    if not isinstance(msg_id, six.integer_types):
+    msg_id = win32functions.RegisterWindowMessage(str(msg_name))
+    if not isinstance(msg_id, int):
         return -1 # return dummy value if win32functions is mocked (on ReadTheDocs)
     if msg_id > 0:
         return msg_id

--- a/pywinauto/windows/win32_hooks.py
+++ b/pywinauto/windows/win32_hooks.py
@@ -49,7 +49,6 @@ The fork of this code (at some moment) was used in
 standalone library pyhooked 0.8 maintained by Ethan Smith.
 """
 
-import six
 from ctypes import wintypes
 from ctypes import windll
 from ctypes import CFUNCTYPE
@@ -420,9 +419,9 @@ class Hook(object):
         key_code = kbd.vkCode
         if key_code == VK_PACKET:
             scan_code = kbd.scanCode
-            current_key = six.unichr(scan_code)
+            current_key = chr(scan_code)
         elif key_code in self.ID_TO_KEY:
-            current_key = six.u(self.ID_TO_KEY[key_code])
+            current_key = self.ID_TO_KEY[key_code]
         else:
             al = ActionLogger()
             al.log("_process_kbd_data, bad key_code: {0}".format(key_code))

--- a/pywinauto/xml_helpers.py
+++ b/pywinauto/xml_helpers.py
@@ -37,7 +37,6 @@ from xml.etree.cElementTree import Element
 from xml.etree.cElementTree import SubElement
 from xml.etree.cElementTree import ElementTree
 
-import six
 import ctypes
 import re
 import bz2
@@ -94,9 +93,9 @@ def _set_node_props(element, name, value):
             prop_name = prop_name[0]
             item_val = getattr(value, prop_name)
 
-            if isinstance(item_val, six.integer_types):
+            if isinstance(item_val, int):
                 prop_name += "_LONG"
-                item_val = six.text_type(item_val)
+                item_val = str(item_val)
 
             struct_elem.set(prop_name, _escape_specials(item_val))
 
@@ -142,9 +141,9 @@ def _set_node_props(element, name, value):
 
     else:
         if isinstance(value, bool):
-            value = six.integer_types[-1](value)
+            value = int(value)
 
-        if isinstance(value, six.integer_types):
+        if isinstance(value, int):
             name += "_LONG"
 
         element.set(name, _escape_specials(value))
@@ -181,14 +180,14 @@ def WriteDialogToFile(filename, props):
 def _escape_specials(string):
     """Ensure that some characters are escaped before writing to XML"""
     # ensure it is unicode
-    string = six.text_type(string)
+    string = str(string)
 
     # escape backslashs
     string = string.replace('\\', r'\\')
 
     # escape non printable characters (chars below 30)
     for i in range(0, 32):
-        string = string.replace(six.unichr(i), "\\%02d"%i)
+        string = string.replace(chr(i), "\\%02d"%i)
 
     return string
 
@@ -198,12 +197,12 @@ def _un_escape_specials(string):
     """Replace escaped characters with real character"""
     # Unescape all the escape characters
     for i in range(0, 32):
-        string = string.replace("\\%02d"%i, six.unichr(i))
+        string = string.replace("\\%02d"%i, chr(i))
 
     # convert doubled backslashes to a single backslash
     string = string.replace(r'\\', '\\')
 
-    return six.text_type(string)
+    return str(string)
 
 
 #-----------------------------------------------------------------------------
@@ -240,13 +239,13 @@ def _xml_to_struct(element, struct_type = None):
         # if the value ends with "_long"
         if prop_name.endswith("_LONG"):
             # get an long attribute out of the value
-            val = six.integer_types[-1](val)
+            val = int(val)
             prop_name = prop_name[:-5]
 
         # if the value is a string
-        elif isinstance(val, six.string_types):
+        elif isinstance(val, str):
             # make sure it if Unicode
-            val = six.text_type(val)
+            val = str(val)
 
         # now we can have all upper case attribute name
         # but structure name will not be upper case
@@ -277,7 +276,7 @@ def _old_xml_to_titles(element):
         val = val.replace('\\x12', '\x12')
         val = val.replace('\\\\', '\\')
 
-        titles.append(six.text_type(val))
+        titles.append(str(val))
 
     return titles
 
@@ -344,7 +343,7 @@ def _get_attributes(element):
 
         # if it is 'Long' element convert it to an long
         if attrib_name.endswith("_LONG"):
-            val = six.integer_types[-1](val)
+            val = int(val)
             attrib_name = attrib_name[:-5]
 
         else:

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ sys.path.append(setup_path())
 #    if not os.path.exists(setup_path("docs")):
 #        shutil.move(setup_path("website"), setup_path("docs"))
 
-install_requires = ['six']
+install_requires = []
 
 if sys.platform == 'win32':
     packages = ["pywinauto", "pywinauto.tests", "pywinauto.controls", "pywinauto.windows"]


### PR DESCRIPTION
The `master` branch of this project no longer supports Python 2, so `six` should no longer be necessary.

Removing unreachable code blocks as well might help improve test coverage.