### PR TITLE
Add and fix abstract methods in `BaseWrapper` and `ElementInfo`.

### DIFF
--- a/pywinauto/base_wrapper.py
+++ b/pywinauto/base_wrapper.py
@@ -362,7 +362,7 @@ class BaseWrapper(object, metaclass=BaseMeta):
         If you want to raise an exception immediately if an element is
         not active then you can use the ``BaseWrapper.verify_active()``.
         """
-        return self.element_info.active
+        raise NotImplementedError
 
     # -----------------------------------------------------------
     def was_maximized(self):

--- a/pywinauto/element_info.py
+++ b/pywinauto/element_info.py
@@ -189,3 +189,18 @@ class ElementInfo(object):
     def dump_window(self):
         """Dump an element to a set of properties"""
         raise NotImplementedError()
+
+    @classmethod
+    def get_active(cls):
+        """Return current active element"""
+        raise NotImplementedError()
+
+    @classmethod
+    def from_point(cls, x, y):
+        """Return child element at specified point coordinates"""
+        raise NotImplementedError()
+
+    @classmethod
+    def top_from_point(cls, x, y):
+        """Return top level element at specified point coordinates"""
+        raise NotImplementedError()


### PR DESCRIPTION
`BaseWrapper` refers to `get_active`, `from_point`, and `top_from_point` of `self.backend.element_info_class`, but these are not defined as abstract methods in the base class `ElementInfo`.

Additionally, `BaseWrapper.is_active` returns `self.element_info.active`, but `ElementInfo` does not have an `active` property/attribute defined, and `AtspiWrapper`/`HwndWrapper`/`UIAWrapper` also override and define `is_active`.

I think these should be redefined as abstract methods.