### PR TITLE
Improved capture_as_image with DWM bounds and cropping

### DIFF
--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -407,12 +407,12 @@ class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
             control_rectangle = RECT(dwmwa_rect.left, dwmwa_rect.top, dwmwa_rect.right, dwmwa_rect.bottom)
 
         # get the control rectangle in a way that PIL likes it
-        left = control_rectangle.left + 1
-        right = control_rectangle.right - 1
-        top = control_rectangle.top + 1
-        bottom = control_rectangle.bottom - 1
-        width = right - left
-        height = bottom - top
+        left = control_rectangle.left
+        right = control_rectangle.right
+        top = control_rectangle.top
+        bottom = control_rectangle.bottom
+        width = control_rectangle.width()
+        height = control_rectangle.height()
         box = (left, top, right, bottom)
 
         # check the number of monitors connected

--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -408,7 +408,7 @@ class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
 
         # get the control rectangle in a way that PIL likes it
         left = control_rectangle.left + 1
-        right = control_rectangle.right - 1d
+        right = control_rectangle.right - 1
         top = control_rectangle.top + 1
         bottom = control_rectangle.bottom - 1
         width = right - left

--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -394,14 +394,25 @@ class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
                 raise TypeError("capture_as_image() takes rect of type {} while incorrect type {} is given"
                                 .format(RECT, type(rect)))
             control_rectangle = rect
+        else:
+            hwnd = self.handle
+            dwmwa_rect = ctypes.wintypes.RECT()
+            DWMWA_EXTENDED_FRAME_BOUNDS = 9
+            ctypes.windll.dwmapi.DwmGetWindowAttribute(
+                ctypes.wintypes.HWND(hwnd),
+                ctypes.wintypes.DWORD(DWMWA_EXTENDED_FRAME_BOUNDS),
+                ctypes.byref(dwmwa_rect),
+                ctypes.sizeof(dwmwa_rect)
+            )
+            control_rectangle = RECT(dwmwa_rect.left, dwmwa_rect.top, dwmwa_rect.right, dwmwa_rect.bottom)   
 
         # get the control rectangle in a way that PIL likes it
-        width = control_rectangle.width()
-        height = control_rectangle.height()
-        left = control_rectangle.left
-        right = control_rectangle.right
-        top = control_rectangle.top
-        bottom = control_rectangle.bottom
+        left = control_rectangle.left + 1
+        right = control_rectangle.right - 1
+        top = control_rectangle.top + 1
+        bottom = control_rectangle.bottom - 1 
+        width = right - left
+        height = bottom - top
         box = (left, top, right, bottom)
 
         # check the number of monitors connected
@@ -432,5 +443,6 @@ class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
             pil_img_obj = ImageGrab.grab(box)
 
         return pil_img_obj
+
 
 #====================================================================

--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -408,7 +408,7 @@ class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
 
         # get the control rectangle in a way that PIL likes it
         left = control_rectangle.left + 1
-        right = control_rectangle.right - 1
+        right = control_rectangle.right - 1d
         top = control_rectangle.top + 1
         bottom = control_rectangle.bottom - 1
         width = right - left

--- a/pywinauto/controls/win_base_wrapper.py
+++ b/pywinauto/controls/win_base_wrapper.py
@@ -404,13 +404,13 @@ class WinBaseWrapper(BaseWrapper, metaclass=BaseMeta):
                 ctypes.byref(dwmwa_rect),
                 ctypes.sizeof(dwmwa_rect)
             )
-            control_rectangle = RECT(dwmwa_rect.left, dwmwa_rect.top, dwmwa_rect.right, dwmwa_rect.bottom)   
+            control_rectangle = RECT(dwmwa_rect.left, dwmwa_rect.top, dwmwa_rect.right, dwmwa_rect.bottom)
 
         # get the control rectangle in a way that PIL likes it
         left = control_rectangle.left + 1
         right = control_rectangle.right - 1
         top = control_rectangle.top + 1
-        bottom = control_rectangle.bottom - 1 
+        bottom = control_rectangle.bottom - 1
         width = right - left
         height = bottom - top
         box = (left, top, right, bottom)


### PR DESCRIPTION
In this PR, I refined the capture_as_method function in win_base_wrapper.py to improve the screenshot accuracy for windowed applications. It uses DwmGetWindowAttribute with DWMWA_EXTENDED_FRAME_BOUNDS to cpature the full window, and has a manual pixel trimming to eliminate border artifacts. 
This is the before:
<img width="629" height="377" alt="notepad_screenshot" src="https://github.com/user-attachments/assets/866ea8cc-c49b-403e-aa82-586cd59dfa7e" />


This is the after:
<img width="617" height="370" alt="edge_dwm_bounds" src="https://github.com/user-attachments/assets/d5cde2a1-377e-408e-a883-35d4e3c8c1e5" />
