### PR TITLE
ci: pin codeql workflow actions to immutable SHAs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,18 +24,18 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v2
+        uses: github/codeql-action/init@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
         with:
           languages: ${{ matrix.language }}
           queries: +security-and-quality
 
       - name: Autobuild
-        uses: github/codeql-action/autobuild@v2
+        uses: github/codeql-action/autobuild@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v2
+        uses: github/codeql-action/analyze@b8d3b6e8af63cde30bdc382c0bc28114f4346c88
         with:
           category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- pin the four floating actions in `.github/workflows/codeql.yml` to immutable SHAs
- preserve the existing CodeQL trigger matrix and job behavior
- keep this as a one-file workflow hardening change only

## Validation
- `git diff --check`
- `python -c "import pathlib, yaml; p=pathlib.Path(r'.github/workflows/codeql.yml'); yaml.safe_load(p.read_text(encoding='utf-8')); print('yaml_ok', p)"`
- final exact-file overlap recheck found no open PR already touching `.github/workflows/codeql.yml`

## Notes
- no repo-local CONTRIBUTING/SECURITY/CODEOWNERS guidance was present on the working branch, so this stayed strictly one-file and behavior-preserving
- this does not overlap the adjacent `security_audit.yml` / `SECURITY.md` work in #1482
- prepared with AI assistance and manually validated before submission