### PR TITLE
fix: accept WindowSpecification in find_elements parent

### DIFF
--- a/pywinauto/findwindows.py
+++ b/pywinauto/findwindows.py
@@ -140,6 +140,16 @@ def find_elements(**kwargs):
         backend = registry.active_backend.name
     backend_obj = registry.backends[backend]
 
+    # Allow passing WindowSpecification as a parent (issue #1313).
+    # Resolve it early to keep the rest of this function working with element_info.
+    if parent is not None:
+        try:
+            from .base_application import WindowSpecification
+        except Exception:  # pragma: no cover
+            WindowSpecification = ()
+        if isinstance(parent, WindowSpecification):
+            parent = parent.find().element_info
+
     if handle is not None:
         # TODO: uncomment later
         #if not kwargs:

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -36,7 +36,6 @@ import unittest
 
 import sys, os
 sys.path.append(".")
-from pywinauto.backend import registry
 from pywinauto.windows.application import Application
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.findwindows import find_window, find_windows
@@ -112,10 +111,14 @@ class FindWindowsTestCases(unittest.TestCase):
         self.assertEqual([e.handle for e in elems_via_windowspec],
                          [e.handle for e in elems_via_elem_info])
 
-    @unittest.skipUnless('uia' in registry.backends, "UIA backend is unavailable in this test environment")
     def test_find_elements_parent_windowspec_uia(self):
         """find_elements should accept WindowSpecification as parent (issue #1313) for UIA backend"""
-        app_uia = Application(backend='uia').connect(process=self.app.process)
+        try:
+            app_uia = Application(backend='uia').connect(process=self.app.process)
+        except ValueError as exc:
+            if 'not registered' in str(exc):
+                self.skipTest("UIA backend is unavailable in this test environment")
+            raise
         dlg_uia = app_uia.CommonControlsSample
 
         elems_via_elem_info = find_elements(pid=self.app.process,

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -111,6 +111,21 @@ class FindWindowsTestCases(unittest.TestCase):
         self.assertEqual([e.handle for e in elems_via_windowspec],
                          [e.handle for e in elems_via_elem_info])
 
+    def test_find_elements_parent_windowspec_default_backend(self):
+        """find_elements should accept WindowSpecification as parent when using the active backend"""
+        elems_via_elem_info = find_elements(pid=self.app.process,
+                                            class_name='Edit',
+                                            top_level_only=False,
+                                            parent=self.dlg.find().element_info)
+
+        elems_via_windowspec = find_elements(pid=self.app.process,
+                                             class_name='Edit',
+                                             top_level_only=False,
+                                             parent=self.dlg)
+
+        self.assertEqual([e.handle for e in elems_via_windowspec],
+                         [e.handle for e in elems_via_elem_info])
+
     def test_find_elements_parent_windowspec_uia(self):
         """find_elements should accept WindowSpecification as parent (issue #1313) for UIA backend"""
         try:

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -39,6 +39,7 @@ sys.path.append(".")
 from pywinauto.windows.application import Application
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.findwindows import find_window, find_windows
+from pywinauto.findwindows import find_elements  # noqa: E402
 from pywinauto.findwindows import WindowNotFoundError
 from pywinauto.findwindows import WindowAmbiguousError
 from pywinauto.timings import Timings
@@ -93,7 +94,6 @@ class FindWindowsTestCases(unittest.TestCase):
 
     def test_find_elements_parent_windowspec_win32(self):
         """WindowSpecification parents should work for win32 searches."""
-        from pywinauto.findwindows import find_elements
 
         # Baseline: resolve parent to element_info explicitly
         parent_elem_info = self.dlg.find().element_info
@@ -115,7 +115,6 @@ class FindWindowsTestCases(unittest.TestCase):
 
     def test_find_elements_parent_windowspec_default_backend(self):
         """WindowSpecification parents should work on the active backend."""
-        from pywinauto.findwindows import find_elements
 
         parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = find_elements(pid=self.app.process,
@@ -133,7 +132,6 @@ class FindWindowsTestCases(unittest.TestCase):
 
     def test_find_elements_parent_windowspec_uia(self):
         """WindowSpecification parents should work for UIA searches."""
-        from pywinauto.findwindows import find_elements
 
         try:
             app_uia = Application(backend='uia').connect(

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -39,6 +39,7 @@ sys.path.append(".")
 from pywinauto.windows.application import Application
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.findwindows import find_window, find_windows
+from pywinauto.findwindows import find_elements
 from pywinauto.findwindows import WindowNotFoundError
 from pywinauto.findwindows import WindowAmbiguousError
 from pywinauto.timings import Timings
@@ -90,6 +91,46 @@ class FindWindowsTestCases(unittest.TestCase):
 
         self.assertRaises(WindowNotFoundError, find_windows,
                           pid=self.app.process, class_name='FakeClassName', found_index=1)
+
+    def test_find_elements_parent_windowspec_win32(self):
+        """find_elements should accept WindowSpecification as parent (issue #1313) for win32 backend"""
+        # Baseline: resolve parent to element_info explicitly
+        elems_via_elem_info = find_elements(pid=self.app.process,
+                                            backend='win32',
+                                            class_name='Edit',
+                                            top_level_only=False,
+                                            parent=self.dlg.find().element_info)
+
+        # Regression: WindowSpecification should be accepted directly
+        elems_via_windowspec = find_elements(pid=self.app.process,
+                                             backend='win32',
+                                             class_name='Edit',
+                                             top_level_only=False,
+                                             parent=self.dlg)
+
+        self.assertEqual([e.handle for e in elems_via_windowspec],
+                         [e.handle for e in elems_via_elem_info])
+
+    def test_find_elements_parent_windowspec_uia(self):
+        """find_elements should accept WindowSpecification as parent (issue #1313) for UIA backend"""
+        app_uia = Application(backend='uia').connect(process=self.app.process)
+        dlg_uia = app_uia.CommonControlsSample
+
+        elems_via_elem_info = find_elements(pid=self.app.process,
+                                            backend='uia',
+                                            control_type='Edit',
+                                            top_level_only=False,
+                                            parent=dlg_uia.find().element_info)
+
+        elems_via_windowspec = find_elements(pid=self.app.process,
+                                             backend='uia',
+                                             control_type='Edit',
+                                             top_level_only=False,
+                                             parent=dlg_uia)
+
+        # UIA element_info doesn't always expose a stable .handle, so compare by runtime_id
+        self.assertEqual([e.runtime_id for e in elems_via_windowspec],
+                         [e.runtime_id for e in elems_via_elem_info])
 
 
 if __name__ == "__main__":

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -39,7 +39,6 @@ sys.path.append(".")
 from pywinauto.windows.application import Application
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.findwindows import find_window, find_windows
-from pywinauto.findwindows import find_elements
 from pywinauto.findwindows import WindowNotFoundError
 from pywinauto.findwindows import WindowAmbiguousError
 from pywinauto.timings import Timings
@@ -94,6 +93,8 @@ class FindWindowsTestCases(unittest.TestCase):
 
     def test_find_elements_parent_windowspec_win32(self):
         """WindowSpecification parents should work for win32 searches."""
+        from pywinauto.findwindows import find_elements
+
         # Baseline: resolve parent to element_info explicitly
         parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = find_elements(pid=self.app.process,
@@ -114,6 +115,8 @@ class FindWindowsTestCases(unittest.TestCase):
 
     def test_find_elements_parent_windowspec_default_backend(self):
         """WindowSpecification parents should work on the active backend."""
+        from pywinauto.findwindows import find_elements
+
         parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = find_elements(pid=self.app.process,
                                             class_name='Edit',
@@ -130,6 +133,8 @@ class FindWindowsTestCases(unittest.TestCase):
 
     def test_find_elements_parent_windowspec_uia(self):
         """WindowSpecification parents should work for UIA searches."""
+        from pywinauto.findwindows import find_elements
+
         try:
             app_uia = Application(backend='uia').connect(
                 process=self.app.process

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -36,6 +36,7 @@ import unittest
 
 import sys, os
 sys.path.append(".")
+from pywinauto.backend import registry
 from pywinauto.windows.application import Application
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.findwindows import find_window, find_windows
@@ -111,6 +112,7 @@ class FindWindowsTestCases(unittest.TestCase):
         self.assertEqual([e.handle for e in elems_via_windowspec],
                          [e.handle for e in elems_via_elem_info])
 
+    @unittest.skipUnless('uia' in registry.backends, "UIA backend is unavailable in this test environment")
     def test_find_elements_parent_windowspec_uia(self):
         """find_elements should accept WindowSpecification as parent (issue #1313) for UIA backend"""
         app_uia = Application(backend='uia').connect(process=self.app.process)

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -93,13 +93,14 @@ class FindWindowsTestCases(unittest.TestCase):
                           pid=self.app.process, class_name='FakeClassName', found_index=1)
 
     def test_find_elements_parent_windowspec_win32(self):
-        """find_elements should accept WindowSpecification as parent (issue #1313) for win32 backend"""
+        """WindowSpecification parents should work for win32 searches."""
         # Baseline: resolve parent to element_info explicitly
+        parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = find_elements(pid=self.app.process,
                                             backend='win32',
                                             class_name='Edit',
                                             top_level_only=False,
-                                            parent=self.dlg.find().element_info)
+                                            parent=parent_elem_info)
 
         # Regression: WindowSpecification should be accepted directly
         elems_via_windowspec = find_elements(pid=self.app.process,
@@ -112,11 +113,12 @@ class FindWindowsTestCases(unittest.TestCase):
                          [e.handle for e in elems_via_elem_info])
 
     def test_find_elements_parent_windowspec_default_backend(self):
-        """find_elements should accept WindowSpecification as parent when using the active backend"""
+        """WindowSpecification parents should work on the active backend."""
+        parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = find_elements(pid=self.app.process,
                                             class_name='Edit',
                                             top_level_only=False,
-                                            parent=self.dlg.find().element_info)
+                                            parent=parent_elem_info)
 
         elems_via_windowspec = find_elements(pid=self.app.process,
                                              class_name='Edit',
@@ -127,12 +129,16 @@ class FindWindowsTestCases(unittest.TestCase):
                          [e.handle for e in elems_via_elem_info])
 
     def test_find_elements_parent_windowspec_uia(self):
-        """find_elements should accept WindowSpecification as parent (issue #1313) for UIA backend"""
+        """WindowSpecification parents should work for UIA searches."""
         try:
-            app_uia = Application(backend='uia').connect(process=self.app.process)
+            app_uia = Application(backend='uia').connect(
+                process=self.app.process
+            )
         except ValueError as exc:
             if 'not registered' in str(exc):
-                self.skipTest("UIA backend is unavailable in this test environment")
+                self.skipTest(
+                    "UIA backend is unavailable in this test environment"
+                )
             raise
         dlg_uia = app_uia.CommonControlsSample
 
@@ -148,7 +154,8 @@ class FindWindowsTestCases(unittest.TestCase):
                                              top_level_only=False,
                                              parent=dlg_uia)
 
-        # UIA element_info doesn't always expose a stable .handle, so compare by runtime_id
+        # UIA element_info doesn't always expose a stable .handle.
+        # Compare the resolved runtime_id values instead.
         self.assertEqual([e.runtime_id for e in elems_via_windowspec],
                          [e.runtime_id for e in elems_via_elem_info])
 

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -98,8 +98,7 @@ class FindWindowsTestCases(unittest.TestCase):
                           pid=self.app.process, class_name='FakeClassName', found_index=1)
 
     def test_find_elements_parent_windowspec_win32(self):
-        """WindowSpecification parents should work for win32 searches."""
-
+        """Ensure WindowSpecification parents work for win32 searches."""
         # Baseline: resolve parent to element_info explicitly
         parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = self._find_elements(pid=self.app.process,
@@ -119,8 +118,7 @@ class FindWindowsTestCases(unittest.TestCase):
                          [e.handle for e in elems_via_elem_info])
 
     def test_find_elements_parent_windowspec_default_backend(self):
-        """WindowSpecification parents should work on the active backend."""
-
+        """Ensure WindowSpecification parents work on the active backend."""
         parent_elem_info = self.dlg.find().element_info
         elems_via_elem_info = self._find_elements(pid=self.app.process,
                                                   class_name='Edit',
@@ -136,8 +134,7 @@ class FindWindowsTestCases(unittest.TestCase):
                          [e.handle for e in elems_via_elem_info])
 
     def test_find_elements_parent_windowspec_uia(self):
-        """WindowSpecification parents should work for UIA searches."""
-
+        """Ensure WindowSpecification parents work for UIA searches."""
         try:
             app_uia = Application(backend='uia').connect(
                 process=self.app.process

--- a/pywinauto/unittests/test_findwindows.py
+++ b/pywinauto/unittests/test_findwindows.py
@@ -39,7 +39,6 @@ sys.path.append(".")
 from pywinauto.windows.application import Application
 from pywinauto.sysinfo import is_x64_Python
 from pywinauto.findwindows import find_window, find_windows
-from pywinauto.findwindows import find_elements  # noqa: E402
 from pywinauto.findwindows import WindowNotFoundError
 from pywinauto.findwindows import WindowAmbiguousError
 from pywinauto.timings import Timings
@@ -70,6 +69,12 @@ class FindWindowsTestCases(unittest.TestCase):
         """Close the application after tests"""
         self.app.kill()
 
+    @staticmethod
+    def _find_elements(*args, **kwargs):
+        # pylint: disable-msg=C0415
+        from pywinauto.findwindows import find_elements
+        return find_elements(*args, **kwargs)
+
     def test_find_window(self):
         """Test if function find_window() works as expected including raising the exceptions"""
         ctrl = self.dlg.OK.find()
@@ -97,18 +102,18 @@ class FindWindowsTestCases(unittest.TestCase):
 
         # Baseline: resolve parent to element_info explicitly
         parent_elem_info = self.dlg.find().element_info
-        elems_via_elem_info = find_elements(pid=self.app.process,
-                                            backend='win32',
-                                            class_name='Edit',
-                                            top_level_only=False,
-                                            parent=parent_elem_info)
+        elems_via_elem_info = self._find_elements(pid=self.app.process,
+                                                  backend='win32',
+                                                  class_name='Edit',
+                                                  top_level_only=False,
+                                                  parent=parent_elem_info)
 
         # Regression: WindowSpecification should be accepted directly
-        elems_via_windowspec = find_elements(pid=self.app.process,
-                                             backend='win32',
-                                             class_name='Edit',
-                                             top_level_only=False,
-                                             parent=self.dlg)
+        elems_via_windowspec = self._find_elements(pid=self.app.process,
+                                                   backend='win32',
+                                                   class_name='Edit',
+                                                   top_level_only=False,
+                                                   parent=self.dlg)
 
         self.assertEqual([e.handle for e in elems_via_windowspec],
                          [e.handle for e in elems_via_elem_info])
@@ -117,15 +122,15 @@ class FindWindowsTestCases(unittest.TestCase):
         """WindowSpecification parents should work on the active backend."""
 
         parent_elem_info = self.dlg.find().element_info
-        elems_via_elem_info = find_elements(pid=self.app.process,
-                                            class_name='Edit',
-                                            top_level_only=False,
-                                            parent=parent_elem_info)
+        elems_via_elem_info = self._find_elements(pid=self.app.process,
+                                                  class_name='Edit',
+                                                  top_level_only=False,
+                                                  parent=parent_elem_info)
 
-        elems_via_windowspec = find_elements(pid=self.app.process,
-                                             class_name='Edit',
-                                             top_level_only=False,
-                                             parent=self.dlg)
+        elems_via_windowspec = self._find_elements(pid=self.app.process,
+                                                   class_name='Edit',
+                                                   top_level_only=False,
+                                                   parent=self.dlg)
 
         self.assertEqual([e.handle for e in elems_via_windowspec],
                          [e.handle for e in elems_via_elem_info])
@@ -144,18 +149,19 @@ class FindWindowsTestCases(unittest.TestCase):
                 )
             raise
         dlg_uia = app_uia.CommonControlsSample
+        dlg_uia_elem_info = dlg_uia.find().element_info
 
-        elems_via_elem_info = find_elements(pid=self.app.process,
-                                            backend='uia',
-                                            control_type='Edit',
-                                            top_level_only=False,
-                                            parent=dlg_uia.find().element_info)
+        elems_via_elem_info = self._find_elements(pid=self.app.process,
+                                                  backend='uia',
+                                                  control_type='Edit',
+                                                  top_level_only=False,
+                                                  parent=dlg_uia_elem_info)
 
-        elems_via_windowspec = find_elements(pid=self.app.process,
-                                             backend='uia',
-                                             control_type='Edit',
-                                             top_level_only=False,
-                                             parent=dlg_uia)
+        elems_via_windowspec = self._find_elements(pid=self.app.process,
+                                                   backend='uia',
+                                                   control_type='Edit',
+                                                   top_level_only=False,
+                                                   parent=dlg_uia)
 
         # UIA element_info doesn't always expose a stable .handle.
         # Compare the resolved runtime_id values instead.


### PR DESCRIPTION
## Summary
- accept `WindowSpecification` instances for `find_elements(parent=...)`
- resolve the parent through `parent.find().element_info` before the existing parent type gate
- add regression coverage showing `parent=<WindowSpecification>` matches the established `parent=<element_info>` behavior for both `win32` and `uia`

## Why
Fixes #1313. Higher-level search paths already understand `WindowSpecification`, so rejecting it in `find_elements(parent=...)` is inconsistent and forces callers onto a lower-level workaround.

## Validation
- `python -m unittest pywinauto.unittests.test_findwindows`

## Risk Notes
- narrow parent-resolution change only
- no touch to `base_application.py`
- no broader search-behavior refactor
